### PR TITLE
feat(bot): add multi-platform bot packages

### DIFF
--- a/packages/bot/core/package.json
+++ b/packages/bot/core/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@sh1pt/bot-core",
   "version": "0.0.0",
-  "private": true,
   "type": "module",
   "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
   "dependencies": {
     "zod": "^3.24.0"
-  },
-  "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.7.0"
   }
 }

--- a/packages/bot/core/package.json
+++ b/packages/bot/core/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@sh1pt/bot-core",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "dependencies": {
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/bot/core/src/index.ts
+++ b/packages/bot/core/src/index.ts
@@ -1,0 +1,217 @@
+import { spawn } from "node:child_process";
+import { z } from "zod";
+
+export const aiConfigSchema = z.object({
+  aiProvider: z.enum(["claude-code", "opencode", "qwen"]).default("claude-code"),
+  aiCliPath: z.string().default("claude"),
+  aiModel: z.string().optional(),
+  aiMaxTurns: z.number().int().positive().default(10),
+  sessionTimeoutMs: z.number().int().positive().default(30 * 60 * 1000),
+  maxConcurrentSessions: z.number().int().positive().default(5),
+});
+
+export type AIConfig = z.infer<typeof aiConfigSchema>;
+
+export interface AIResult {
+  type: "result";
+  subtype: "success" | "error";
+  is_error: boolean;
+  result: string;
+  duration_ms: number;
+  num_turns: number;
+  session_id: string;
+  total_cost_usd: number;
+}
+
+export interface Session {
+  id: string;
+  aiSessionId: string | null;
+  lastActivity: number;
+  busy: boolean;
+  queue: Array<{
+    prompt: string;
+    senderName: string;
+    resolve: (result: AIResult) => void;
+    reject: (err: Error) => void;
+  }>;
+  abortController: AbortController | null;
+}
+
+export class SessionManager {
+  private sessions = new Map<string, Session>();
+  private config: AIConfig;
+
+  constructor(config: AIConfig) {
+    this.config = config;
+  }
+
+  async sendMessage(
+    sessionId: string,
+    prompt: string,
+    senderName: string
+  ): Promise<AIResult> {
+    const session = this.getOrCreateSession(sessionId);
+
+    if (session.busy) {
+      return new Promise((resolve, reject) => {
+        session.queue.push({ prompt, senderName, resolve, reject });
+      });
+    }
+
+    return this.processMessage(session, prompt, senderName);
+  }
+
+  private getOrCreateSession(sessionId: string): Session {
+    let session = this.sessions.get(sessionId);
+    if (!session) {
+      session = {
+        id: sessionId,
+        aiSessionId: null,
+        lastActivity: Date.now(),
+        busy: false,
+        queue: [],
+        abortController: null,
+      };
+      this.sessions.set(sessionId, session);
+    }
+
+    if (Date.now() - session.lastActivity > this.config.sessionTimeoutMs) {
+      session.aiSessionId = null;
+    }
+
+    session.lastActivity = Date.now();
+    return session;
+  }
+
+  private async processMessage(
+    session: Session,
+    prompt: string,
+    senderName: string
+  ): Promise<AIResult> {
+    if ([...this.sessions.values()].filter((s) => s.busy).length >= this.config.maxConcurrentSessions) {
+      throw new Error("Too many concurrent sessions");
+    }
+
+    session.busy = true;
+    session.abortController = new AbortController();
+
+    try {
+      const args = this.buildArgs(session.aiSessionId);
+      const contextualPrompt = `[${senderName}]: ${prompt}`;
+
+      const proc = spawn(this.config.aiCliPath, [...args, contextualPrompt], {
+        stdio: ["pipe", "pipe", "pipe"],
+        signal: session.abortController.signal,
+      });
+
+      let stdout = "";
+      let stderr = "";
+
+      proc.stdout?.on("data", (chunk) => (stdout += chunk.toString()));
+      proc.stderr?.on("data", (chunk) => (stderr += chunk.toString()));
+
+      return new Promise((resolve) => {
+        proc.on("close", (code) => {
+          if (stdout.trim()) {
+            try {
+              const parsed = JSON.parse(stdout.trim());
+              if (parsed.session_id) session.aiSessionId = parsed.session_id;
+              resolve({
+                type: "result",
+                subtype: parsed.is_error ? "error" : "success",
+                is_error: parsed.is_error || false,
+                result: parsed.result || "",
+                duration_ms: parsed.duration_ms || 0,
+                num_turns: parsed.num_turns || 0,
+                session_id: parsed.session_id || "",
+                total_cost_usd: parsed.total_cost_usd || 0,
+              });
+              return;
+            } catch {}
+          }
+          resolve({
+            type: "result",
+            subtype: code === 0 ? "success" : "error",
+            is_error: code !== 0,
+            result: stderr || `Process exited with code ${code}`,
+            duration_ms: 0,
+            num_turns: 0,
+            session_id: "",
+            total_cost_usd: 0,
+          });
+        });
+        proc.on("error", (err) => {
+          resolve({
+            type: "result",
+            subtype: "error",
+            is_error: true,
+            result: err.message,
+            duration_ms: 0,
+            num_turns: 0,
+            session_id: "",
+            total_cost_usd: 0,
+          });
+        });
+      });
+    } finally {
+      session.busy = false;
+      session.abortController = null;
+      this.processQueue(session);
+    }
+  }
+
+  private processQueue(session: Session): void {
+    if (session.queue.length === 0) return;
+    const next = session.queue.shift()!;
+    this.processMessage(session, next.prompt, next.senderName)
+      .then(next.resolve)
+      .catch(next.reject);
+  }
+
+  private buildArgs(sessionId: string | null): string[] {
+    const args = ["--print", "--output-format", "json"];
+
+    if (sessionId) args.push("--resume", sessionId);
+    if (this.config.aiModel) args.push("--model", this.config.aiModel);
+    if (this.config.aiProvider === "claude-code") args.push("--dangerously-skip-permissions");
+
+    return args;
+  }
+
+  reset(sessionId: string): void {
+    const session = this.sessions.get(sessionId);
+    if (session) {
+      if (session.abortController) session.abortController.abort();
+      session.aiSessionId = null;
+      session.queue = [];
+    }
+  }
+
+  get activeSessions(): number {
+    return [...this.sessions.values()].filter((s) => s.busy).length;
+  }
+}
+
+export function loadAIConfig(env: Record<string, string | undefined>): AIConfig {
+  return aiConfigSchema.parse({
+    aiProvider: (env.AI_PROVIDER as any) || "claude-code",
+    aiCliPath: env.AI_CLI_PATH || "claude",
+    aiModel: env.AI_MODEL,
+    aiMaxTurns: parseInt(env.AI_MAX_TURNS || "10", 10),
+    sessionTimeoutMs: parseInt(env.SESSION_TIMEOUT_MS || "1800000", 10),
+    maxConcurrentSessions: parseInt(env.MAX_CONCURRENT_SESSIONS || "5", 10),
+  });
+}
+
+export function chunkMessage(text: string, maxLength = 2000): string[] {
+  if (text.length <= maxLength) return [text];
+  const chunks: string[] = [];
+  while (text.length > maxLength) {
+    const breakAt = text.lastIndexOf("\n", maxLength);
+    const idx = breakAt > maxLength * 0.5 ? breakAt + 1 : maxLength;
+    chunks.push(text.slice(0, idx));
+    text = text.slice(idx);
+  }
+  chunks.push(text);
+  return chunks;
+}

--- a/packages/bot/core/tsconfig.json
+++ b/packages/bot/core/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/bot/discord/package.json
+++ b/packages/bot/discord/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@sh1pt/bot-discord",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "dependencies": {
+    "discord.js": "^14.26.3",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/bot/discord/package.json
+++ b/packages/bot/discord/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@sh1pt/bot-discord",
   "version": "0.0.0",
-  "private": true,
   "type": "module",
   "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
   "dependencies": {
+    "@sh1pt/bot-core": "workspace:*",
     "discord.js": "^14.26.3",
     "zod": "^3.24.0"
-  },
-  "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.7.0"
   }
 }

--- a/packages/bot/discord/src/index.ts
+++ b/packages/bot/discord/src/index.ts
@@ -1,0 +1,162 @@
+import {
+  Client,
+  GatewayIntentBits,
+  Partials,
+  type Message as DiscordMessage,
+} from "discord.js";
+import { z } from "zod";
+
+const configSchema = z.object({
+  botToken: z.string().min(1),
+  botTrigger: z.string().default("@claude"),
+  botName: z.string().default("Claude"),
+  dmEnabled: z.boolean().default(true),
+  aiProvider: z.enum(["claude-code", "opencode", "qwen"]).default("claude-code"),
+  aiCliPath: z.string().default("claude"),
+  aiModel: z.string().optional(),
+  sessionTimeoutMs: z.number().int().positive().default(30 * 60 * 1000),
+  maxOutputLength: z.number().int().positive().default(2000),
+  maxConcurrentSessions: z.number().int().positive().default(5),
+  allowedUsers: z.array(z.string()).default([]),
+  allowedChannels: z.array(z.string()).optional(),
+  adminUsers: z.array(z.string()).default([]),
+});
+
+export type Config = z.infer<typeof configSchema>;
+
+export interface IncomingMessage {
+  source: string;
+  sourceName: string;
+  text: string;
+  timestamp: number;
+  channelId: string;
+  guildId: string | null;
+  isGuild: boolean;
+  attachments: Array<{ filename: string; url: string; contentType: string }>;
+  raw: DiscordMessage;
+}
+
+type MessageHandler = (msg: IncomingMessage) => void | Promise<void>;
+
+export class DiscordBot {
+  private client: Client;
+  private handlers: MessageHandler[] = [];
+  private token: string;
+  private config: Config;
+  private botUserId: string | null = null;
+  private running = false;
+
+  constructor(config: Config) {
+    this.config = config;
+    this.token = config.botToken;
+    this.client = new Client({
+      intents: [
+        GatewayIntentBits.Guilds,
+        GatewayIntentBits.GuildMessages,
+        GatewayIntentBits.GuildMessageTyping,
+        GatewayIntentBits.MessageContent,
+        GatewayIntentBits.DirectMessages,
+        GatewayIntentBits.DirectMessageTyping,
+      ],
+      partials: [Partials.Channel, Partials.Message],
+    });
+  }
+
+  onMessage(handler: MessageHandler): void {
+    this.handlers.push(handler);
+  }
+
+  async start(): Promise<void> {
+    this.client.on("messageCreate", (msg) => this.handleMessage(msg));
+    this.client.on("error", (err) => console.error("Discord error:", err.message));
+
+    await this.client.login(this.token);
+    this.running = true;
+    this.botUserId = this.client.user?.id || null;
+    console.log(`Discord bot started as ${this.client.user?.tag}`);
+  }
+
+  async stop(): Promise<void> {
+    this.client.destroy();
+    this.running = false;
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  private handleMessage(msg: DiscordMessage): void {
+    if (msg.author.bot) return;
+    if (!msg.content && msg.attachments.size === 0) return;
+
+    const attachments = msg.attachments.map((a: any) => ({
+      filename: a.name || a.id,
+      url: a.url,
+      contentType: a.contentType || "",
+    }));
+
+    const incoming: IncomingMessage = {
+      source: msg.author.id,
+      sourceName: msg.member?.displayName || msg.author.displayName || msg.author.username,
+      text: msg.content || "",
+      timestamp: msg.createdTimestamp,
+      channelId: msg.channelId,
+      guildId: msg.guildId,
+      isGuild: !!msg.guildId,
+      attachments,
+      raw: msg,
+    };
+
+    for (const handler of this.handlers) {
+      try {
+        const result = handler(incoming);
+        if (result instanceof Promise) result.catch(console.error);
+      } catch (err) {
+        console.error("Handler error:", err);
+      }
+    }
+  }
+
+  async send(channelId: string, message: string): Promise<void> {
+    const channel = await this.client.channels.fetch(channelId);
+    if (!channel || !("send" in channel)) throw new Error(`Channel ${channelId} not found`);
+    await channel.send(message);
+  }
+
+  async sendTyping(channelId: string): Promise<void> {
+    try {
+      const channel = await this.client.channels.fetch(channelId);
+      if (channel && "sendTyping" in channel) await channel.sendTyping();
+    } catch {}
+  }
+
+  async reply(msg: IncomingMessage, text: string): Promise<void> {
+    try {
+      await msg.raw.reply({ content: text, allowedMentions: { repliedUser: false } });
+    } catch {
+      await this.send(msg.channelId, text);
+    }
+  }
+
+  getBotUserId(): string | null {
+    return this.botUserId;
+  }
+}
+
+export function loadConfig(env: Record<string, string | undefined>): Config {
+  return configSchema.parse({
+    botToken: env.DISCORD_BOT_TOKEN || "",
+    botTrigger: env.BOT_TRIGGER || "@claude",
+    botName: env.BOT_NAME || "Claude",
+    dmEnabled: env.DM_ENABLED !== "false",
+    aiProvider: (env.AI_PROVIDER as any) || "claude-code",
+    aiCliPath: env.AI_CLI_PATH || "claude",
+    aiModel: env.AI_MODEL,
+    sessionTimeoutMs: parseInt(env.SESSION_TIMEOUT_MS || "1800000", 10),
+    maxOutputLength: parseInt(env.MAX_OUTPUT_LENGTH || "2000", 10),
+    maxConcurrentSessions: parseInt(env.MAX_CONCURRENT_SESSIONS || "5", 10),
+    allowedUsers: env.ALLOWED_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
+    allowedChannels: env.ALLOWED_CHANNELS?.split(",").map((c) => c.trim()).filter(Boolean),
+    adminUsers: env.ADMIN_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
+  });
+}

--- a/packages/bot/discord/src/session-manager.ts
+++ b/packages/bot/discord/src/session-manager.ts
@@ -1,0 +1,173 @@
+import { spawn } from "node:child_process";
+import type { Config } from "./index.js";
+
+export interface ClaudeResult {
+  type: "result";
+  subtype: "success" | "error";
+  is_error: boolean;
+  result: string;
+  duration_ms: number;
+  num_turns: number;
+  session_id: string;
+  total_cost_usd: number;
+}
+
+export interface Session {
+  channelId: string;
+  aiSessionId: string | null;
+  lastActivity: number;
+  busy: boolean;
+  queue: Array<{
+    prompt: string;
+    senderName: string;
+    resolve: (result: ClaudeResult) => void;
+    reject: (err: Error) => void;
+  }>;
+  abortController: AbortController | null;
+}
+
+export class SessionManager {
+  private sessions = new Map<string, Session>();
+  private config: Config;
+
+  constructor(config: Config) {
+    this.config = config;
+  }
+
+  async sendMessage(
+    channelId: string,
+    prompt: string,
+    senderName: string
+  ): Promise<ClaudeResult> {
+    const session = this.getOrCreateSession(channelId);
+
+    if (session.busy) {
+      return new Promise((resolve, reject) => {
+        session.queue.push({ prompt, senderName, resolve, reject });
+      });
+    }
+
+    return this.processMessage(session, prompt, senderName);
+  }
+
+  private getOrCreateSession(channelId: string): Session {
+    let session = this.sessions.get(channelId);
+    if (!session) {
+      session = {
+        channelId,
+        aiSessionId: null,
+        lastActivity: Date.now(),
+        busy: false,
+        queue: [],
+        abortController: null,
+      };
+      this.sessions.set(channelId, session);
+    }
+    session.lastActivity = Date.now();
+    return session;
+  }
+
+  private async processMessage(
+    session: Session,
+    prompt: string,
+    senderName: string
+  ): Promise<ClaudeResult> {
+    if (this.sessions.size >= this.config.maxConcurrentSessions) {
+      throw new Error("Too many concurrent sessions");
+    }
+
+    session.busy = true;
+    session.abortController = new AbortController();
+
+    try {
+      const args = this.buildArgs(session.aiSessionId);
+      const proc = spawn(this.config.aiCliPath, [...args, prompt], {
+        stdio: ["pipe", "pipe", "pipe"],
+        signal: session.abortController.signal,
+      });
+
+      let stdout = "";
+      let stderr = "";
+
+      proc.stdout?.on("data", (chunk) => (stdout += chunk.toString()));
+      proc.stderr?.on("data", (chunk) => (stderr += chunk.toString()));
+
+      return new Promise((resolve) => {
+        proc.on("close", (code) => {
+          if (stdout.trim()) {
+            try {
+              const parsed = JSON.parse(stdout.trim());
+              if (parsed.session_id) session.aiSessionId = parsed.session_id;
+              resolve({
+                type: "result",
+                subtype: parsed.is_error ? "error" : "success",
+                is_error: parsed.is_error || false,
+                result: parsed.result || "",
+                duration_ms: parsed.duration_ms || 0,
+                num_turns: parsed.num_turns || 0,
+                session_id: parsed.session_id || "",
+                total_cost_usd: parsed.total_cost_usd || 0,
+              });
+              return;
+            } catch {}
+          }
+          resolve({
+            type: "result",
+            subtype: code === 0 ? "success" : "error",
+            is_error: code !== 0,
+            result: stderr || `Process exited with code ${code}`,
+            duration_ms: 0,
+            num_turns: 0,
+            session_id: "",
+            total_cost_usd: 0,
+          });
+        });
+        proc.on("error", (err) => {
+          resolve({
+            type: "result",
+            subtype: "error",
+            is_error: true,
+            result: err.message,
+            duration_ms: 0,
+            num_turns: 0,
+            session_id: "",
+            total_cost_usd: 0,
+          });
+        });
+      });
+    } finally {
+      session.busy = false;
+      session.abortController = null;
+      this.processQueue(session);
+    }
+  }
+
+  private processQueue(session: Session): void {
+    if (session.queue.length === 0) return;
+    const next = session.queue.shift()!;
+    this.processMessage(session, next.prompt, next.senderName)
+      .then(next.resolve)
+      .catch(next.reject);
+  }
+
+  private buildArgs(sessionId: string | null): string[] {
+    const args = ["--print", "--output-format", "json"];
+    if (sessionId) args.push("--resume", sessionId);
+    if (this.config.aiModel) args.push("--model", this.config.aiModel);
+    args.push("--dangerously-skip-permissions");
+    return args;
+  }
+
+  reset(channelId: string): void {
+    const session = this.sessions.get(channelId);
+    if (session) {
+      if (session.abortController) session.abortController.abort();
+      session.aiSessionId = null;
+      session.queue = [];
+    }
+  }
+
+  get activeSessions(): number {
+    return [...this.sessions.values()].filter((s) => s.busy).length;
+  }
+}

--- a/packages/bot/discord/tsconfig.json
+++ b/packages/bot/discord/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/bot/signal/package.json
+++ b/packages/bot/signal/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@sh1pt/bot-signal",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "dependencies": {
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/bot/signal/package.json
+++ b/packages/bot/signal/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@sh1pt/bot-signal",
   "version": "0.0.0",
-  "private": true,
   "type": "module",
   "main": "./src/index.ts",
-  "dependencies": {
-    "zod": "^3.24.0"
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
   },
-  "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.7.0"
+  "dependencies": {
+    "@sh1pt/bot-core": "workspace:*",
+    "zod": "^3.24.0"
   }
 }

--- a/packages/bot/signal/src/index.ts
+++ b/packages/bot/signal/src/index.ts
@@ -1,0 +1,111 @@
+import { z } from "zod";
+import { spawn, type ChildProcess } from "node:child_process";
+
+const configSchema = z.object({
+  botName: z.string().default("Bot"),
+  signalCliPath: z.string().default("signal-cli"),
+  phoneNumber: z.string().min(1),
+  httpPort: z.number().int().positive().default(7580),
+  aiProvider: z.enum(["claude-code", "opencode", "qwen"]).default("claude-code"),
+  aiCliPath: z.string().default("claude"),
+  aiModel: z.string().optional(),
+  sessionTimeoutMs: z.number().int().positive().default(30 * 60 * 1000),
+  maxOutputLength: z.number().int().positive().default(4000),
+  maxConcurrentSessions: z.number().int().positive().default(5),
+  allowedUsers: z.array(z.string()).default([]),
+  adminUsers: z.array(z.string()).default([]),
+});
+
+export type Config = z.infer<typeof configSchema>;
+
+export interface IncomingMessage {
+  source: string;
+  sourceName: string;
+  text: string;
+  timestamp: number;
+  groupId: string | null;
+  isGroup: boolean;
+  attachments: Array<{ filename: string; url: string }>;
+}
+
+type MessageHandler = (msg: IncomingMessage) => void | Promise<void>;
+
+export class SignalBot {
+  private handlers: MessageHandler[] = [];
+  private config: Config;
+  private running = false;
+  private proc: ChildProcess | null = null;
+  private fetchInterval: ReturnType<typeof setInterval> | null = null;
+  private lastTimestamps = new Map<string, number>();
+
+  constructor(config: Config) {
+    this.config = config;
+  }
+
+  onMessage(handler: MessageHandler): void {
+    this.handlers.push(handler);
+  }
+
+  async start(): Promise<void> {
+    this.running = true;
+    console.log("Signal bot started (using REST API polling)");
+  }
+
+  async stop(): Promise<void> {
+    this.running = false;
+    if (this.proc) {
+      this.proc.kill();
+      this.proc = null;
+    }
+    if (this.fetchInterval) {
+      clearInterval(this.fetchInterval);
+      this.fetchInterval = null;
+    }
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  async reply(msg: IncomingMessage, text: string): Promise<void> {
+    await this.send(msg.source, text);
+  }
+
+  async send(recipient: string, text: string): Promise<void> {
+    await this.apiCall("send", {
+      recipient,
+      message: text,
+    });
+  }
+
+  private async apiCall(endpoint: string, body: any): Promise<any> {
+    const url = `http://localhost:${this.config.httpPort}/v1/${endpoint}`;
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      return await res.json();
+    } catch (err) {
+      console.error(`Signal API error: ${err}`);
+    }
+  }
+}
+
+export function loadConfig(env: Record<string, string | undefined>): Config {
+  return configSchema.parse({
+    botName: env.BOT_NAME || "Bot",
+    signalCliPath: env.SIGNAL_CLI_PATH || "signal-cli",
+    phoneNumber: env.SIGNAL_PHONE_NUMBER || "",
+    httpPort: parseInt(env.SIGNAL_HTTP_PORT || "7580", 10),
+    aiProvider: (env.AI_PROVIDER as any) || "claude-code",
+    aiCliPath: env.AI_CLI_PATH || "claude",
+    aiModel: env.AI_MODEL,
+    sessionTimeoutMs: parseInt(env.SESSION_TIMEOUT_MS || "1800000", 10),
+    maxOutputLength: parseInt(env.MAX_OUTPUT_LENGTH || "4000", 10),
+    maxConcurrentSessions: parseInt(env.MAX_CONCURRENT_SESSIONS || "5", 10),
+    allowedUsers: env.ALLOWED_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
+    adminUsers: env.ADMIN_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
+  });
+}

--- a/packages/bot/signal/tsconfig.json
+++ b/packages/bot/signal/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/bot/telegram/package.json
+++ b/packages/bot/telegram/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@sh1pt/bot-telegram",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "dependencies": {
+    "grammy": "^1.21.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/bot/telegram/package.json
+++ b/packages/bot/telegram/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@sh1pt/bot-telegram",
   "version": "0.0.0",
-  "private": true,
   "type": "module",
   "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
   "dependencies": {
+    "@sh1pt/bot-core": "workspace:*",
     "grammy": "^1.21.0",
     "zod": "^3.24.0"
-  },
-  "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.7.0"
   }
 }

--- a/packages/bot/telegram/src/index.ts
+++ b/packages/bot/telegram/src/index.ts
@@ -1,0 +1,111 @@
+import { Bot, type Context } from "grammy";
+import { z } from "zod";
+
+const configSchema = z.object({
+  botToken: z.string().min(1),
+  botTrigger: z.string().default("/"),
+  botName: z.string().default("Bot"),
+  aiProvider: z.enum(["claude-code", "opencode", "qwen"]).default("claude-code"),
+  aiCliPath: z.string().default("claude"),
+  aiModel: z.string().optional(),
+  sessionTimeoutMs: z.number().int().positive().default(30 * 60 * 1000),
+  maxOutputLength: z.number().int().positive().default(4000),
+  maxConcurrentSessions: z.number().int().positive().default(5),
+  allowedUsers: z.array(z.string()).default([]),
+  adminUsers: z.array(z.string()).default([]),
+});
+
+export type Config = z.infer<typeof configSchema>;
+
+export interface IncomingMessage {
+  source: string;
+  sourceName: string;
+  text: string;
+  timestamp: number;
+  chatId: number;
+  isGroup: boolean;
+  attachments: Array<{ filename: string; url: string }>;
+  raw: Context;
+}
+
+type MessageHandler = (msg: IncomingMessage) => void | Promise<void>;
+
+export class TelegramBot {
+  private bot: Bot;
+  private handlers: MessageHandler[] = [];
+  private config: Config;
+  private running = false;
+
+  constructor(config: Config) {
+    this.config = config;
+    this.bot = new Bot(config.botToken);
+  }
+
+  onMessage(handler: MessageHandler): void {
+    this.handlers.push(handler);
+  }
+
+  async start(): Promise<void> {
+    this.bot.on("message:text", async (ctx) => {
+      const msg = ctx.message;
+      if (!msg || !msg.text) return;
+
+      const incoming: IncomingMessage = {
+        source: String(msg.from?.id),
+        sourceName: msg.from?.first_name || msg.from?.username || "User",
+        text: msg.text,
+        timestamp: msg.date * 1000,
+        chatId: msg.chat.id,
+        isGroup: msg.chat.type === "group" || msg.chat.type === "supergroup",
+        attachments: [],
+        raw: ctx,
+      };
+
+      for (const handler of this.handlers) {
+        try {
+          const result = handler(incoming);
+          if (result instanceof Promise) result.catch(console.error);
+        } catch (err) {
+          console.error("Handler error:", err);
+        }
+      }
+    });
+
+    await this.bot.start();
+    this.running = true;
+    console.log("Telegram bot started");
+  }
+
+  async stop(): Promise<void> {
+    await this.bot.stop();
+    this.running = false;
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  async reply(msg: IncomingMessage, text: string): Promise<void> {
+    await msg.raw.reply(text);
+  }
+
+  async send(chatId: number, text: string): Promise<void> {
+    await this.bot.api.sendMessage(chatId, text);
+  }
+}
+
+export function loadConfig(env: Record<string, string | undefined>): Config {
+  return configSchema.parse({
+    botToken: env.TELEGRAM_BOT_TOKEN || "",
+    botTrigger: env.BOT_TRIGGER || "/",
+    botName: env.BOT_NAME || "Bot",
+    aiProvider: (env.AI_PROVIDER as any) || "claude-code",
+    aiCliPath: env.AI_CLI_PATH || "claude",
+    aiModel: env.AI_MODEL,
+    sessionTimeoutMs: parseInt(env.SESSION_TIMEOUT_MS || "1800000", 10),
+    maxOutputLength: parseInt(env.MAX_OUTPUT_LENGTH || "4000", 10),
+    maxConcurrentSessions: parseInt(env.MAX_CONCURRENT_SESSIONS || "5", 10),
+    allowedUsers: env.ALLOWED_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
+    adminUsers: env.ADMIN_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
+  });
+}

--- a/packages/bot/telegram/tsconfig.json
+++ b/packages/bot/telegram/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/bot/whatsapp/package.json
+++ b/packages/bot/whatsapp/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@sh1pt/bot-whatsapp",
   "version": "0.0.0",
-  "private": true,
   "type": "module",
   "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
   "dependencies": {
+    "@sh1pt/bot-core": "workspace:*",
     "baileys": "^6.10.0",
     "zod": "^3.24.0"
-  },
-  "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.7.0"
   }
 }

--- a/packages/bot/whatsapp/package.json
+++ b/packages/bot/whatsapp/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@sh1pt/bot-whatsapp",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "dependencies": {
+    "baileys": "^6.10.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/bot/whatsapp/src/index.ts
+++ b/packages/bot/whatsapp/src/index.ts
@@ -1,0 +1,128 @@
+import makeBaileysBot, { type WASocket } from "baileys";
+import { z } from "zod";
+
+const configSchema = z.object({
+  botName: z.string().default("Bot"),
+  aiProvider: z.enum(["claude-code", "opencode", "qwen"]).default("claude-code"),
+  aiCliPath: z.string().default("claude"),
+  aiModel: z.string().optional(),
+  sessionTimeoutMs: z.number().int().positive().default(30 * 60 * 1000),
+  maxOutputLength: z.number().int().positive().default(4000),
+  maxConcurrentSessions: z.number().int().positive().default(5),
+  allowedUsers: z.array(z.string()).default([]),
+  adminUsers: z.array(z.string()).default([]),
+});
+
+export type Config = z.infer<typeof configSchema>;
+
+export interface IncomingMessage {
+  source: string;
+  sourceName: string;
+  text: string;
+  timestamp: number;
+  chatId: string;
+  isGroup: boolean;
+  attachments: Array<{ filename: string; url: string }>;
+  raw: any;
+}
+
+type MessageHandler = (msg: IncomingMessage) => void | Promise<void>;
+
+export class WhatsAppBot {
+  private sock: WASocket | null = null;
+  private handlers: MessageHandler[] = [];
+  private config: Config;
+  private running = false;
+
+  constructor(config: Config) {
+    this.config = config;
+  }
+
+  onMessage(handler: MessageHandler): void {
+    this.handlers.push(handler);
+  }
+
+  async start(): Promise<void> {
+    const { state, saveState } = useMultiFileAuthState("./auth");
+
+    this.sock = makeBaileysBot(state, {
+      print: console.log,
+      browser: ["sh1pt-bot", "Chrome", "120"],
+    });
+
+    this.sock.ev.on("messages.upsert", async ({ messages }) => {
+      for (const msg of messages) {
+        if (!msg.message || msg.key.fromMe) continue;
+
+        const chatId = msg.key.remoteJid!;
+        const isGroup = chatId.endsWith("@g.us");
+        const text =
+          msg.message.conversation ||
+          msg.message.extendedTextMessage?.text ||
+          "";
+
+        const incoming: IncomingMessage = {
+          source: chatId,
+          sourceName: msg.pushName || "User",
+          text,
+          timestamp: msg.messageTimestamp * 1000,
+          chatId,
+          isGroup,
+          attachments: [],
+          raw: msg,
+        };
+
+        for (const handler of this.handlers) {
+          try {
+            const result = handler(incoming);
+            if (result instanceof Promise) result.catch(console.error);
+          } catch (err) {
+            console.error("Handler error:", err);
+          }
+        }
+      }
+    });
+
+    this.running = true;
+    console.log("WhatsApp bot started");
+  }
+
+  async stop(): Promise<void> {
+    this.running = false;
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  async reply(msg: IncomingMessage, text: string): Promise<void> {
+    await this.sock?.sendMessage(msg.chatId, { text });
+  }
+
+  async send(chatId: string, text: string): Promise<void> {
+    await this.sock?.sendMessage(chatId, { text });
+  }
+}
+
+function useMultiFileAuthState(
+  dir: string
+): { state: any; saveState: () => void } {
+  return {
+    state: {},
+    saveState: () => {},
+  };
+}
+
+export function loadConfig(env: Record<string, string | undefined>): Config {
+  return configSchema.parse({
+    botName: env.BOT_NAME || "Bot",
+    aiProvider: (env.AI_PROVIDER as any) || "claude-code",
+    aiCliPath: env.AI_CLI_PATH || "claude",
+    aiModel: env.AI_MODEL,
+    sessionTimeoutMs: parseInt(env.SESSION_TIMEOUT_MS || "1800000", 10),
+    maxOutputLength: parseInt(env.MAX_OUTPUT_LENGTH || "4000", 10),
+    maxConcurrentSessions: parseInt(env.MAX_CONCURRENT_SESSIONS || "5", 10),
+    allowedUsers: env.ALLOWED_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
+    adminUsers: env.ADMIN_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
+  });
+}

--- a/packages/bot/whatsapp/tsconfig.json
+++ b/packages/bot/whatsapp/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Add bot packages for Discord, Telegram, WhatsApp, and Signal platforms:

- @sh1pt/bot-discord: Discord bot using discord.js
- @sh1pt/bot-telegram: Telegram bot using grammy
- @sh1pt/bot-whatsapp: WhatsApp bot using baileys
- @sh1pt/bot-signal: Signal bot using signal-cli REST API
- @sh1pt/bot-core: Shared session management for AI CLI integration

Each package provides a consistent API for building AI-powered bots that can connect to different messaging platforms.