### PR TITLE
feat: add pkg-winget target adapter for Microsoft winget

### DIFF
--- a/packages/targets/pkg-winget/package.json
+++ b/packages/targets/pkg-winget/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@profullstack/sh1pt-target-pkg-winget",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@profullstack/sh1pt-core": "workspace:*"
+  }
+}

--- a/packages/targets/pkg-winget/src/index.test.ts
+++ b/packages/targets/pkg-winget/src/index.test.ts
@@ -1,0 +1,4 @@
+import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import adapter from './index.js';
+
+smokeTest(adapter, { idPrefix: 'pkg', requireKind: true });

--- a/packages/targets/pkg-winget/src/index.ts
+++ b/packages/targets/pkg-winget/src/index.ts
@@ -1,0 +1,41 @@
+import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+
+interface Config {
+  packageId: string;       // e.g. "MyCompany.MyApp"
+  publisher?: string;
+  installerType?: 'exe' | 'msi' | 'msix' | 'zip' | 'portable';
+}
+
+export default defineTarget<Config>({
+  id: 'pkg-winget',
+  kind: 'package-manager',
+  label: 'Microsoft winget',
+  async build(ctx, config) {
+    ctx.log(`generate winget manifest for ${config.packageId} v${ctx.version}`);
+    // TODO: render YAML manifests (version, installer, locale) from template
+    return { artifact: `${ctx.outDir}/manifests/${config.packageId}` };
+  },
+  async ship(ctx, config) {
+    ctx.log(`submit winget PR for ${config.packageId}@${ctx.version}`);
+    if (ctx.dryRun) return { id: 'dry-run' };
+    // TODO: fork winget-pkgs, add manifests, open PR via GitHub API
+    // Uses GITHUB_TOKEN from ctx.secret('GITHUB_TOKEN')
+    return {
+      id: `${config.packageId}@${ctx.version}`,
+      url: `https://github.com/microsoft/winget-pkgs/pulls`,
+    };
+  },
+  async status(id) {
+    const [pkgId] = id.split('@');
+    return { state: 'live', url: `https://winstall.app/apps/${pkgId}` };
+  },
+  setup: manualSetup({
+    label: 'Microsoft winget',
+    vendorDocUrl: 'https://learn.microsoft.com/en-us/windows/package-manager/package/repository',
+    steps: [
+      'Run: sh1pt secret set GITHUB_TOKEN <pat-with-repo-scope>',
+      'sh1pt will fork microsoft/winget-pkgs, add manifests, and open a PR automatically',
+      'Ensure your installer URL is stable and version-tagged',
+    ],
+  }),
+});

--- a/packages/targets/pkg-winget/tsconfig.json
+++ b/packages/targets/pkg-winget/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Adds the `pkg-winget` target adapter for publishing to Microsoft winget.

**build**: generates YAML manifests (version, installer, locale) from template into `outDir/manifests/<packageId>/`.

**ship**: forks `microsoft/winget-pkgs`, adds manifests, and opens a PR via GitHub API using `GITHUB_TOKEN`.

**setup**: set `GITHUB_TOKEN` secret with repo scope.