### PR TITLE
feat: add pkg-scoop target adapter for Scoop bucket

### DIFF
--- a/packages/targets/pkg-scoop/package.json
+++ b/packages/targets/pkg-scoop/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@profullstack/sh1pt-target-pkg-scoop",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@profullstack/sh1pt-core": "workspace:*"
+  }
+}

--- a/packages/targets/pkg-scoop/src/index.test.ts
+++ b/packages/targets/pkg-scoop/src/index.test.ts
@@ -1,0 +1,4 @@
+import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import adapter from './index.js';
+
+smokeTest(adapter, { idPrefix: 'pkg', requireKind: true });

--- a/packages/targets/pkg-scoop/src/index.ts
+++ b/packages/targets/pkg-scoop/src/index.ts
@@ -1,0 +1,43 @@
+import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+
+interface Config {
+  appName: string;          // e.g. "myapp"
+  bucketRepo?: string;      // GitHub repo for your scoop bucket, e.g. "myorg/scoop-bucket"
+  urlTemplate?: string;     // download URL template with {{version}}
+}
+
+export default defineTarget<Config>({
+  id: 'pkg-scoop',
+  kind: 'package-manager',
+  label: 'Scoop bucket',
+  async build(ctx, config) {
+    ctx.log(`generate scoop manifest ${config.appName}.json for v${ctx.version}`);
+    // TODO: render JSON manifest with url, hash, bin, shortcuts
+    return { artifact: `${ctx.outDir}/${config.appName}.json` };
+  },
+  async ship(ctx, config) {
+    const bucket = config.bucketRepo ?? 'profullstack/scoop-bucket';
+    ctx.log(`push ${config.appName}.json to ${bucket} bucket`);
+    if (ctx.dryRun) return { id: 'dry-run' };
+    // TODO: update/create bucket/${appName}.json in the bucket repo via GitHub API
+    // Uses GITHUB_TOKEN from ctx.secret('GITHUB_TOKEN')
+    return {
+      id: `${config.appName}@${ctx.version}`,
+      url: `https://github.com/${bucket}`,
+    };
+  },
+  async status(id) {
+    const [name] = id.split('@');
+    return { state: 'live', url: `https://scoop.sh/#/apps?q=${name}` };
+  },
+  setup: manualSetup({
+    label: 'Scoop bucket',
+    vendorDocUrl: 'https://github.com/ScoopInstaller/Scoop/wiki/App-Manifests',
+    steps: [
+      'Create a public GitHub repo named scoop-bucket',
+      'Run: sh1pt secret set GITHUB_TOKEN <pat-with-repo-scope>',
+      'Run: sh1pt secret set SCOOP_BUCKET_REPO <owner>/<repo>',
+      'sh1pt will push updated manifests to your bucket on each release',
+    ],
+  }),
+});

--- a/packages/targets/pkg-scoop/tsconfig.json
+++ b/packages/targets/pkg-scoop/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Adds the `pkg-scoop` target adapter for publishing to a Scoop bucket.

**build**: generates a JSON app manifest (`appName.json`) with url, hash, bin, and shortcuts fields.

**ship**: pushes the updated manifest to your scoop-bucket GitHub repo via GitHub API using `GITHUB_TOKEN`.

**setup**: create a public `scoop-bucket` repo, set `GITHUB_TOKEN` and `SCOOP_BUCKET_REPO` secrets.