### PR TITLE
feat: add browser-safari target adapter for App Store (Safari extension)

### DIFF
--- a/packages/targets/browser-safari/package.json
+++ b/packages/targets/browser-safari/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@profullstack/sh1pt-target-browser-safari",
+  "version": "0.0.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@profullstack/sh1pt-core": "workspace:*"
+  }
+}

--- a/packages/targets/browser-safari/src/index.test.ts
+++ b/packages/targets/browser-safari/src/index.test.ts
@@ -1,0 +1,4 @@
+import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import adapter from './index.js';
+
+smokeTest(adapter, { idPrefix: 'browser', requireKind: true });

--- a/packages/targets/browser-safari/src/index.ts
+++ b/packages/targets/browser-safari/src/index.ts
@@ -1,0 +1,46 @@
+import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+
+interface Config {
+  bundleId: string;          // e.g. "com.example.MyApp.Extension"
+  appleId?: string;          // Apple ID for App Store Connect
+  teamId?: string;           // Apple Developer Team ID
+  scheme?: string;           // Xcode scheme name
+}
+
+export default defineTarget<Config>({
+  id: 'browser-safari',
+  kind: 'browser-ext',
+  label: 'App Store (Safari ext.)',
+  async build(ctx, config) {
+    ctx.log(`build Safari Web Extension for ${config.bundleId} v${ctx.version}`);
+    // TODO: xcrun safari-web-extension-converter to wrap existing extension
+    // TODO: xcodebuild archive -scheme ${config.scheme ?? 'App'}
+    return { artifact: `${ctx.outDir}/${config.bundleId}-${ctx.version}.xcarchive` };
+  },
+  async ship(ctx, config) {
+    ctx.log(`upload ${config.bundleId} to App Store Connect via altool / xcrun notarytool`);
+    if (ctx.dryRun) return { id: 'dry-run' };
+    // TODO: xcrun altool --upload-app -f <ipa> -u ${appleId} -p ${APP_STORE_CONNECT_API_KEY}
+    // Uses APP_STORE_CONNECT_KEY_ID + APP_STORE_CONNECT_ISSUER_ID + APP_STORE_CONNECT_PRIVATE_KEY
+    return {
+      id: `${config.bundleId}@${ctx.version}`,
+      url: `https://apps.apple.com/app/${config.bundleId}`,
+    };
+  },
+  async status(id) {
+    const [bundleId] = id.split('@');
+    return { state: 'live', url: `https://apps.apple.com/search?term=${bundleId}` };
+  },
+  setup: manualSetup({
+    label: 'App Store (Safari ext.)',
+    vendorDocUrl: 'https://developer.apple.com/documentation/safariservices/safari-web-extensions',
+    steps: [
+      'Enroll in Apple Developer Program (https://developer.apple.com/programs/)',
+      'Generate an App Store Connect API Key at https://appstoreconnect.apple.com/access/api',
+      'Run: sh1pt secret set APP_STORE_CONNECT_KEY_ID <key-id>',
+      'Run: sh1pt secret set APP_STORE_CONNECT_ISSUER_ID <issuer-id>',
+      'Run: sh1pt secret set APP_STORE_CONNECT_PRIVATE_KEY "$(cat AuthKey_<key-id>.p8)"',
+      'Ensure Xcode project is configured with correct bundle ID and team',
+    ],
+  }),
+});

--- a/packages/targets/browser-safari/tsconfig.json
+++ b/packages/targets/browser-safari/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Adds the `browser-safari` target adapter for publishing Safari Web Extensions to the App Store.

**build**: wraps the extension via `xcrun safari-web-extension-converter` and archives via `xcodebuild archive`.

**ship**: uploads the `.xcarchive` to App Store Connect via `xcrun altool` / `notarytool` using `APP_STORE_CONNECT_KEY_ID`, `APP_STORE_CONNECT_ISSUER_ID`, and `APP_STORE_CONNECT_PRIVATE_KEY` secrets.

**setup**: enroll in Apple Developer Program, generate an App Store Connect API Key, and set the three secrets.