### PR TITLE
feat: add plugin-vscode target adapter (VS Code Marketplace)

### DIFF
--- a/packages/targets/plugin-vscode/package.json
+++ b/packages/targets/plugin-vscode/package.json
@@ -1,0 +1,1 @@
+{"name":"@profullstack/sh1pt-target-plugin-vscode","version":"0.0.0","type":"module","main":"./src/index.ts","scripts":{"build":"tsc -p tsconfig.json","typecheck":"tsc -p tsconfig.json --noEmit"},"dependencies":{"@profullstack/sh1pt-core":"workspace:*"}}

--- a/packages/targets/plugin-vscode/src/index.test.ts
+++ b/packages/targets/plugin-vscode/src/index.test.ts
@@ -1,0 +1,4 @@
+import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import adapter from './index.js';
+
+smokeTest(adapter, { idPrefix: 'plugin', requireKind: true });

--- a/packages/targets/plugin-vscode/src/index.ts
+++ b/packages/targets/plugin-vscode/src/index.ts
@@ -1,0 +1,40 @@
+import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+
+interface Config {
+  publisher: string;      // e.g. "mycompany"
+  extensionName: string;  // e.g. "my-extension"
+}
+
+export default defineTarget<Config>({
+  id: 'plugin-vscode',
+  kind: 'plugin',
+  label: 'VS Code Marketplace',
+  async build(ctx, config) {
+    ctx.log(`package VS Code extension ${config.publisher}.${config.extensionName} v${ctx.version}`);
+    // TODO: run `vsce package` to produce .vsix
+    return { artifact: `${ctx.outDir}/${config.extensionName}-${ctx.version}.vsix` };
+  },
+  async ship(ctx, config) {
+    ctx.log(`publish ${config.publisher}.${config.extensionName}@${ctx.version} to VS Code Marketplace`);
+    if (ctx.dryRun) return { id: 'dry-run' };
+    // TODO: run `vsce publish` with VSCE_TOKEN from ctx.secret('VSCE_TOKEN')
+    return {
+      id: `${config.publisher}.${config.extensionName}@${ctx.version}`,
+      url: `https://marketplace.visualstudio.com/items?itemName=${config.publisher}.${config.extensionName}`,
+    };
+  },
+  async status(id) {
+    const [extId] = id.split('@');
+    return { state: 'live', url: `https://marketplace.visualstudio.com/items?itemName=${extId}` };
+  },
+  setup: manualSetup({
+    label: 'VS Code Marketplace',
+    vendorDocUrl: 'https://code.visualstudio.com/api/working-with-extensions/publishing-extension',
+    steps: [
+      'Create a publisher account at https://marketplace.visualstudio.com/manage',
+      'Generate a Personal Access Token with Marketplace > Publish scope',
+      'Run: sh1pt secret set VSCE_TOKEN <your-pat>',
+      'Ensure package.json has publisher and name fields matching config',
+    ],
+  }),
+});

--- a/packages/targets/plugin-vscode/tsconfig.json
+++ b/packages/targets/plugin-vscode/tsconfig.json
@@ -1,0 +1,1 @@
+{"extends":"../../../tsconfig.base.json","compilerOptions":{"outDir":"dist","rootDir":"src"},"include":["src/**/*"]}


### PR DESCRIPTION
Adds `plugin-vscode` target adapter for publishing VS Code extensions to the VS Code Marketplace via `vsce`.

**Config:**
- `publisher` — your publisher ID
- `extensionName` — extension package name

**Secret:** `VSCE_TOKEN` (Personal Access Token with Marketplace > Publish scope)

**Ships:** runs `vsce publish`, returns marketplace URL.