### PR TITLE
feat: add Square payment adapter

### DIFF
--- a/packages/targets/payment-square/package.json
+++ b/packages/targets/payment-square/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@profullstack/sh1pt-target-payment-square",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "pnpm build"
+  },
+  "dependencies": {
+    "@profullstack/sh1pt-core": "workspace:*"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/profullstack/sh1pt.git",
+    "directory": "packages/targets/payment-square"
+  },
+  "homepage": "https://sh1pt.com",
+  "bugs": "https://github.com/profullstack/sh1pt/issues",
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" } }
+  }
+}

--- a/packages/targets/payment-square/src/index.test.ts
+++ b/packages/targets/payment-square/src/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+
+describe('payment-square', () => {
+  it('should have correct metadata', () => {
+    const pkg = require('../package.json');
+    expect(pkg.name).toBe('@profullstack/sh1pt-target-payment-square');
+  });
+});

--- a/packages/targets/payment-square/src/index.ts
+++ b/packages/targets/payment-square/src/index.ts
@@ -1,4 +1,4 @@
-import { defineTarget, exec } from '@profullstack/sh1pt-core';
+import { defineTarget, setupGuide } from '@profullstack/sh1pt-core';
 
 interface Config {
   command?: 'create' | 'get' | 'cancel' | 'list' | 'refund';
@@ -6,84 +6,86 @@ interface Config {
   locationId?: string;
 }
 
+interface SquareError {
+  errors?: Array<{ code: string; detail: string }>;
+}
+
 export default defineTarget<Config>({
   id: 'payment-square',
   kind: 'payment',
-  label: 'Square (CLI wrapper)',
+  label: 'Square',
 
   async build(ctx, config) {
-    ctx.log('square: verifying CLI availability');
     const cmd = config.command || 'list';
-
     const key = ctx.secret('SQUARE_ACCESS_TOKEN');
     if (!key) throw new Error('SQUARE_ACCESS_TOKEN not set');
-
     const location = config.locationId || ctx.secret('SQUARE_LOCATION_ID') || 'main';
+    const base = 'https://connect.squareup.com/v2';
+
+    async function sq(path: string, init?: RequestInit) {
+      const res = await fetch(`${base}${path}`, {
+        ...init,
+        headers: {
+          'Authorization': `Bearer ${key}`,
+          'Content-Type': 'application/json',
+          ...init?.headers,
+        },
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        const err = data as SquareError;
+        throw new Error(err.errors?.[0]?.detail || `Square API error: ${res.status}`);
+      }
+      return data;
+    }
 
     switch (cmd) {
       case 'create': {
-        const amount = config.args?.amount || 0;
-        const currency = config.args?.currency || 'USD';
-        const sourceId = config.args?.sourceId || '';
+        const amount = config.args?.amount as number || 0;
+        const currency = config.args?.currency as string || 'USD';
+        const sourceId = config.args?.sourceId as string || '';
         ctx.log(`square: creating payment of ${amount} ${currency}`);
-        const r = await exec('curl', [
-          '-s', '-X', 'POST',
-          'https://connect.squareup.com/v2/payments',
-          '-H', `Authorization: Bearer ${key}`,
-          '-H', 'Content-Type: application/json',
-          '-d', JSON.stringify({
+        const data = await sq('/payments', {
+          method: 'POST',
+          body: JSON.stringify({
             source_id: sourceId,
             idempotency_key: `sh1pt-${Date.now()}`,
             amount_money: { amount, currency },
             location_id: location,
-          })
-        ], { log: ctx.log });
-        return { output: r.stdout };
+          }),
+        });
+        return { output: JSON.stringify(data) };
       }
       case 'get': {
         const id = config.args?.paymentId as string || '';
         ctx.log(`square: getting payment ${id}`);
-        const r = await exec('curl', [
-          '-s', `https://connect.squareup.com/v2/payments/${id}`,
-          '-H', `Authorization: Bearer ${key}`
-        ], { log: ctx.log });
-        return { output: r.stdout };
+        const data = await sq(`/payments/${id}`);
+        return { output: JSON.stringify(data) };
       }
       case 'cancel': {
         const id = config.args?.paymentId as string || '';
         ctx.log(`square: canceling payment ${id}`);
-        const r = await exec('curl', [
-          '-s', '-X', 'POST',
-          `https://connect.squareup.com/v2/payments/${id}/cancel`,
-          '-H', `Authorization: Bearer ${key}`,
-          '-H', 'Content-Type: application/json'
-        ], { log: ctx.log });
-        return { output: r.stdout };
+        const data = await sq(`/payments/${id}/cancel`, { method: 'POST' });
+        return { output: JSON.stringify(data) };
       }
       case 'list': {
         ctx.log('square: listing payments');
-        const r = await exec('curl', [
-          '-s', `https://connect.squareup.com/v2/payments`,
-          '-H', `Authorization: Bearer ${key}`
-        ], { log: ctx.log });
-        return { output: r.stdout };
+        const data = await sq('/payments');
+        return { output: JSON.stringify(data) };
       }
       case 'refund': {
         const id = config.args?.paymentId as string || '';
         ctx.log(`square: refunding payment ${id}`);
-        const r = await exec('curl', [
-          '-s', '-X', 'POST',
-          `https://connect.squareup.com/v2/refunds`,
-          '-H', `Authorization: Bearer ${key}`,
-          '-H', 'Content-Type: application/json',
-          '-d', JSON.stringify({
+        const data = await sq('/refunds', {
+          method: 'POST',
+          body: JSON.stringify({
             idempotency_key: `sh1pt-${Date.now()}`,
             payment_id: id,
             amount_money: config.args?.amount,
-            reason: config.args?.reason || 'requested_by_customer',
-          })
-        ], { log: ctx.log });
-        return { output: r.stdout };
+            reason: (config.args?.reason as string) || 'requested_by_customer',
+          }),
+        });
+        return { output: JSON.stringify(data) };
       }
       default:
         throw new Error(`Unknown command: ${cmd}`);
@@ -102,7 +104,6 @@ export default defineTarget<Config>({
           '3. Go to Credentials → Access Token',
           '4. Copy your Sandbox or Production token',
           '5. Run: sh1pt secret set SQUARE_ACCESS_TOKEN <token>',
-          'Optional: sh1pt secret set SQUARE_LOCATION_ID <id>',
         ],
       });
     }

--- a/packages/targets/payment-square/src/index.ts
+++ b/packages/targets/payment-square/src/index.ts
@@ -1,0 +1,111 @@
+import { defineTarget, exec } from '@profullstack/sh1pt-core';
+
+interface Config {
+  command?: 'create' | 'get' | 'cancel' | 'list' | 'refund';
+  args?: Record<string, unknown>;
+  locationId?: string;
+}
+
+export default defineTarget<Config>({
+  id: 'payment-square',
+  kind: 'payment',
+  label: 'Square (CLI wrapper)',
+
+  async build(ctx, config) {
+    ctx.log('square: verifying CLI availability');
+    const cmd = config.command || 'list';
+
+    const key = ctx.secret('SQUARE_ACCESS_TOKEN');
+    if (!key) throw new Error('SQUARE_ACCESS_TOKEN not set');
+
+    const location = config.locationId || ctx.secret('SQUARE_LOCATION_ID') || 'main';
+
+    switch (cmd) {
+      case 'create': {
+        const amount = config.args?.amount || 0;
+        const currency = config.args?.currency || 'USD';
+        const sourceId = config.args?.sourceId || '';
+        ctx.log(`square: creating payment of ${amount} ${currency}`);
+        const r = await exec('curl', [
+          '-s', '-X', 'POST',
+          'https://connect.squareup.com/v2/payments',
+          '-H', `Authorization: Bearer ${key}`,
+          '-H', 'Content-Type: application/json',
+          '-d', JSON.stringify({
+            source_id: sourceId,
+            idempotency_key: `sh1pt-${Date.now()}`,
+            amount_money: { amount, currency },
+            location_id: location,
+          })
+        ], { log: ctx.log });
+        return { output: r.stdout };
+      }
+      case 'get': {
+        const id = config.args?.paymentId as string || '';
+        ctx.log(`square: getting payment ${id}`);
+        const r = await exec('curl', [
+          '-s', `https://connect.squareup.com/v2/payments/${id}`,
+          '-H', `Authorization: Bearer ${key}`
+        ], { log: ctx.log });
+        return { output: r.stdout };
+      }
+      case 'cancel': {
+        const id = config.args?.paymentId as string || '';
+        ctx.log(`square: canceling payment ${id}`);
+        const r = await exec('curl', [
+          '-s', '-X', 'POST',
+          `https://connect.squareup.com/v2/payments/${id}/cancel`,
+          '-H', `Authorization: Bearer ${key}`,
+          '-H', 'Content-Type: application/json'
+        ], { log: ctx.log });
+        return { output: r.stdout };
+      }
+      case 'list': {
+        ctx.log('square: listing payments');
+        const r = await exec('curl', [
+          '-s', `https://connect.squareup.com/v2/payments`,
+          '-H', `Authorization: Bearer ${key}`
+        ], { log: ctx.log });
+        return { output: r.stdout };
+      }
+      case 'refund': {
+        const id = config.args?.paymentId as string || '';
+        ctx.log(`square: refunding payment ${id}`);
+        const r = await exec('curl', [
+          '-s', '-X', 'POST',
+          `https://connect.squareup.com/v2/refunds`,
+          '-H', `Authorization: Bearer ${key}`,
+          '-H', 'Content-Type: application/json',
+          '-d', JSON.stringify({
+            idempotency_key: `sh1pt-${Date.now()}`,
+            payment_id: id,
+            amount_money: config.args?.amount,
+            reason: config.args?.reason || 'requested_by_customer',
+          })
+        ], { log: ctx.log });
+        return { output: r.stdout };
+      }
+      default:
+        throw new Error(`Unknown command: ${cmd}`);
+    }
+  },
+
+  async ship(ctx, _config) {
+    ctx.log('square: verifying setup');
+    const key = ctx.secret('SQUARE_ACCESS_TOKEN');
+    if (!key) {
+      return setupGuide({
+        title: 'Square Access Token',
+        steps: [
+          '1. Go to https://developer.squareup.com/apps',
+          '2. Create or select your app',
+          '3. Go to Credentials → Access Token',
+          '4. Copy your Sandbox or Production token',
+          '5. Run: sh1pt secret set SQUARE_ACCESS_TOKEN <token>',
+          'Optional: sh1pt secret set SQUARE_LOCATION_ID <id>',
+        ],
+      });
+    }
+    return { status: 'ready' };
+  },
+});

--- a/packages/targets/payment-square/tsconfig.json
+++ b/packages/targets/payment-square/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
### Square Payment Adapter

Adds Square payment processing via Connect API v2.

**Commands:** create, get, cancel, list, refund

Clean PR — based off latest upstream master, only adapter files.