### PR TITLE
feat: post Teams webhook payloads

### DIFF
--- a/packages/webhooks/teams/src/index.test.ts
+++ b/packages/webhooks/teams/src/index.test.ts
@@ -1,4 +1,66 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { contractTestWebhook, fakeConnectContext } from '@profullstack/sh1pt-core/testing';
 import adapter from './index.js';
 
-smokeTest(adapter, { idPrefix: 'webhook' });
+contractTestWebhook(adapter, {
+  sampleConfig: {},
+  requiredSecrets: ['TEAMS_WEBHOOK_URL'],
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('webhook-teams HTTP delivery', () => {
+  const payload = {
+    event: 'ship.published',
+    timestamp: '2026-05-11T20:00:00.000Z',
+    data: { target: 'pkg-npm' },
+  };
+
+  it('posts the formatted Adaptive Card payload to Teams', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => '1',
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ TEAMS_WEBHOOK_URL: 'https://example.com/teams' }),
+      dryRun: false,
+    };
+
+    const result = await adapter.send(ctx as any, payload, {});
+
+    expect(result).toEqual({ ok: true, status: 200, url: 'https://example.com/teams' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://example.com/teams');
+    expect((init as RequestInit).method).toBe('POST');
+    expect(JSON.parse(String((init as RequestInit).body))).toMatchObject({
+      type: 'message',
+      attachments: [{ contentType: 'application/vnd.microsoft.card.adaptive' }],
+    });
+  });
+
+  it('returns non-2xx status and response body on delivery failure', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 410,
+      statusText: 'Gone',
+      text: async () => 'webhook has been removed',
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ TEAMS_WEBHOOK_URL: 'https://example.com/teams' }),
+      dryRun: false,
+    };
+
+    await expect(adapter.send(ctx as any, payload, {})).resolves.toEqual({
+      ok: false,
+      status: 410,
+      error: 'webhook has been removed',
+      url: 'https://example.com/teams',
+    });
+  });
+});

--- a/packages/webhooks/teams/src/index.ts
+++ b/packages/webhooks/teams/src/index.ts
@@ -13,39 +13,28 @@ export default defineWebhookTarget<Config>({
   label: 'Microsoft Teams (incoming webhook)',
 
   format(payload, config) {
-    if (config.useAdaptiveCards !== false) {
-      return {
-        type: 'message',
-        attachments: [{
-          contentType: 'application/vnd.microsoft.card.adaptive',
-          content: {
-            type: 'AdaptiveCard',
-            version: '1.5',
-            body: [
-              { type: 'TextBlock', text: payload.event, weight: 'Bolder', size: 'Large' },
-              { type: 'TextBlock', text: '```\n' + JSON.stringify(payload.data, null, 2).slice(0, 3500) + '\n```', wrap: true },
-              { type: 'TextBlock', text: payload.timestamp, isSubtle: true, spacing: 'None' },
-            ],
-          },
-        }],
-      };
-    }
-    return {
-      '@type': 'MessageCard',
-      '@context': 'https://schema.org/extensions',
-      summary: payload.event,
-      title: payload.event,
-      text: '```' + JSON.stringify(payload.data, null, 2).slice(0, 3500) + '```',
-    };
+    return formatTeamsPayload(payload, config);
   },
 
   async send(ctx, payload, config): Promise<WebhookResult> {
     const urlKey = config.urlKey ?? 'TEAMS_WEBHOOK_URL';
     const url = ctx.secret(urlKey);
-    if (!url) throw new Error(`${urlKey} not in vault`);
+    if (!url) throw new Error(`${urlKey} not in vault — run: sh1pt secret set ${urlKey} <webhook-url>`);
     ctx.log(`teams webhook · ${payload.event}`);
     if (ctx.dryRun) return { ok: true, url };
-    return { ok: true, url };
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(formatTeamsPayload(payload, config)),
+    });
+
+    if (!res.ok) {
+      const error = await res.text().catch(() => res.statusText);
+      return { ok: false, status: res.status, error, url };
+    }
+
+    return { ok: true, status: res.status, url };
   },
 
   setup: webhookUrlSetup<Config>({
@@ -59,3 +48,33 @@ export default defineWebhookTarget<Config>({
     ],
   }),
 });
+
+function formatTeamsPayload(
+  payload: { event: string; timestamp: string; data: Record<string, unknown> },
+  config: Config,
+): unknown {
+  if (config.useAdaptiveCards !== false) {
+    return {
+      type: 'message',
+      attachments: [{
+        contentType: 'application/vnd.microsoft.card.adaptive',
+        content: {
+          type: 'AdaptiveCard',
+          version: '1.5',
+          body: [
+            { type: 'TextBlock', text: payload.event, weight: 'Bolder', size: 'Large' },
+            { type: 'TextBlock', text: '```\n' + JSON.stringify(payload.data, null, 2).slice(0, 3500) + '\n```', wrap: true },
+            { type: 'TextBlock', text: payload.timestamp, isSubtle: true, spacing: 'None' },
+          ],
+        },
+      }],
+    };
+  }
+  return {
+    '@type': 'MessageCard',
+    '@context': 'https://schema.org/extensions',
+    summary: payload.event,
+    title: payload.event,
+    text: '```' + JSON.stringify(payload.data, null, 2).slice(0, 3500) + '```',
+  };
+}


### PR DESCRIPTION
## Summary
- replace the Teams webhook stub success path with real HTTP POST delivery
- reuse the Teams payload formatter for Adaptive Cards and legacy MessageCard mode
- return HTTP status and response body on non-2xx delivery failures
- add webhook contract coverage plus mocked Teams success/failure delivery tests

Ref: #6

## Verification
- env COREPACK_HOME=/private/tmp/corepack PNPM_HOME=/private/tmp/pnpm pnpm --filter @profullstack/sh1pt-webhooks-teams typecheck
- env COREPACK_HOME=/private/tmp/corepack PNPM_HOME=/private/tmp/pnpm pnpm exec vitest run packages/webhooks/teams/src/index.test.ts