### PR TITLE
feat: post Slack webhook payloads

### DIFF
--- a/packages/webhooks/slack/src/index.test.ts
+++ b/packages/webhooks/slack/src/index.test.ts
@@ -1,4 +1,65 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { contractTestWebhook, fakeConnectContext } from '@profullstack/sh1pt-core/testing';
 import adapter from './index.js';
 
-smokeTest(adapter, { idPrefix: 'webhook' });
+contractTestWebhook(adapter, {
+  sampleConfig: {},
+  requiredSecrets: ['SLACK_WEBHOOK_URL'],
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('webhook-slack HTTP delivery', () => {
+  const payload = {
+    event: 'ship.published',
+    timestamp: '2026-05-11T20:00:00.000Z',
+    project: 'demo',
+    data: { target: 'pkg-npm' },
+  };
+
+  it('posts the formatted Block Kit payload to Slack', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => 'ok',
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ SLACK_WEBHOOK_URL: 'https://hooks.slack.com/services/T/B/C' }),
+      dryRun: false,
+    };
+
+    const result = await adapter.send(ctx as any, payload, { username: 'shipbot' });
+
+    expect(result).toEqual({ ok: true, status: 200, url: 'https://hooks.slack.com/services/T/B/C' });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://hooks.slack.com/services/T/B/C');
+    expect((init as RequestInit).method).toBe('POST');
+    const body = JSON.parse(String((init as RequestInit).body));
+    expect(body.username).toBe('shipbot');
+    expect(body.text).toBe('*ship.published*');
+    expect(body.blocks[0]).toMatchObject({ type: 'section' });
+  });
+
+  it('returns Slack error text when the webhook rejects the payload', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => 'invalid_payload',
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ SLACK_WEBHOOK_URL: 'https://hooks.slack.com/services/T/B/C' }),
+      dryRun: false,
+    };
+
+    await expect(adapter.send(ctx as any, payload, {})).resolves.toEqual({
+      ok: false,
+      status: 200,
+      error: 'invalid_payload',
+      url: 'https://hooks.slack.com/services/T/B/C',
+    });
+  });
+});

--- a/packages/webhooks/slack/src/index.ts
+++ b/packages/webhooks/slack/src/index.ts
@@ -15,27 +15,27 @@ export default defineWebhookTarget<Config>({
   label: 'Slack (incoming webhook)',
 
   format(payload, config) {
-    return {
-      username: config.username ?? 'sh1pt',
-      icon_emoji: config.iconEmoji ?? ':ship:',
-      channel: config.channelOverride,
-      text: `*${payload.event}*`,
-      blocks: [
-        { type: 'section', text: { type: 'mrkdwn', text: `*${payload.event}* · _${payload.project ?? 'sh1pt'}_` } },
-        { type: 'section', text: { type: 'mrkdwn', text: '```' + JSON.stringify(payload.data, null, 2).slice(0, 2800) + '```' } },
-        { type: 'context', elements: [{ type: 'mrkdwn', text: payload.timestamp }] },
-      ],
-    };
+    return formatSlackPayload(payload, config);
   },
 
   async send(ctx, payload, config): Promise<WebhookResult> {
     const urlKey = config.urlKey ?? 'SLACK_WEBHOOK_URL';
     const url = ctx.secret(urlKey);
-    if (!url) throw new Error(`${urlKey} not in vault`);
+    if (!url) throw new Error(`${urlKey} not in vault — run: sh1pt secret set ${urlKey} <webhook-url>`);
     ctx.log(`slack webhook · ${payload.event}`);
     if (ctx.dryRun) return { ok: true, url };
-    // TODO: POST url with the formatted block payload; 200 "ok" on success
-    return { ok: true, url };
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(formatSlackPayload(payload, config)),
+    });
+    const text = await res.text().catch(() => res.statusText);
+    if (!res.ok || text.trim() !== 'ok') {
+      return { ok: false, status: res.status, error: text, url };
+    }
+
+    return { ok: true, status: res.status, url };
   },
 
   setup: webhookUrlSetup<Config>({
@@ -50,3 +50,20 @@ export default defineWebhookTarget<Config>({
     ],
   }),
 });
+
+function formatSlackPayload(
+  payload: { event: string; timestamp: string; project?: string; data: Record<string, unknown> },
+  config: Config,
+): unknown {
+  return {
+    username: config.username ?? 'sh1pt',
+    icon_emoji: config.iconEmoji ?? ':ship:',
+    channel: config.channelOverride,
+    text: `*${payload.event}*`,
+    blocks: [
+      { type: 'section', text: { type: 'mrkdwn', text: `*${payload.event}* · _${payload.project ?? 'sh1pt'}_` } },
+      { type: 'section', text: { type: 'mrkdwn', text: '```' + JSON.stringify(payload.data, null, 2).slice(0, 2800) + '```' } },
+      { type: 'context', elements: [{ type: 'mrkdwn', text: payload.timestamp }] },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- replace the Slack incoming webhook stub success path with real HTTP POST delivery
- reuse the Block Kit formatter for the delivered payload
- detect Slack text errors such as invalid_payload even when HTTP status is 200
- add webhook contract coverage plus mocked Slack success/error delivery tests

Ref: #6

## Verification
- env COREPACK_HOME=/private/tmp/corepack PNPM_HOME=/private/tmp/pnpm pnpm --filter @profullstack/sh1pt-webhooks-slack typecheck
- env COREPACK_HOME=/private/tmp/corepack PNPM_HOME=/private/tmp/pnpm pnpm exec vitest run packages/webhooks/slack/src/index.test.ts