### PR TITLE
feat: post generic webhook payloads

### DIFF
--- a/packages/webhooks/generic/src/index.test.ts
+++ b/packages/webhooks/generic/src/index.test.ts
@@ -1,4 +1,73 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { contractTestWebhook, fakeConnectContext } from '@profullstack/sh1pt-core/testing';
 import adapter from './index.js';
 
-smokeTest(adapter, { idPrefix: 'webhook' });
+contractTestWebhook(adapter, {
+  sampleConfig: {},
+  requiredSecrets: ['WEBHOOK_URL'],
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('webhook-generic HTTP delivery', () => {
+  const payload = {
+    event: 'ship.published',
+    timestamp: '2026-05-11T20:00:00.000Z',
+    data: { target: 'pkg-npm' },
+  };
+
+  it('posts JSON with event and HMAC signature headers', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 202,
+      text: async () => 'accepted',
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({
+        WEBHOOK_URL: 'https://example.com/hook',
+        WEBHOOK_SECRET: 'secret',
+      }),
+      dryRun: false,
+    };
+
+    const result = await adapter.send(ctx as any, payload, {
+      extraHeaders: { 'X-Custom': 'demo' },
+    });
+
+    expect(result).toEqual({ ok: true, status: 202, url: 'https://example.com/hook' });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://example.com/hook');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).body).toBe(JSON.stringify(payload));
+    expect((init as RequestInit).headers).toMatchObject({
+      'content-type': 'application/json',
+      'X-Sh1pt-Event': 'ship.published',
+      'X-Sh1pt-Signature': 'sha256=688ccc580a285a37b0bbd66d9b78c43fa13fd4a4cde5e72cff6b01cb92ef6a7d',
+      'X-Custom': 'demo',
+    });
+  });
+
+  it('returns non-2xx status and response body on delivery failure', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: async () => 'receiver failed',
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ WEBHOOK_URL: 'https://example.com/hook' }),
+      dryRun: false,
+    };
+
+    await expect(adapter.send(ctx as any, payload, {})).resolves.toEqual({
+      ok: false,
+      status: 500,
+      error: 'receiver failed',
+      url: 'https://example.com/hook',
+    });
+  });
+});

--- a/packages/webhooks/generic/src/index.ts
+++ b/packages/webhooks/generic/src/index.ts
@@ -1,3 +1,4 @@
+import { createHmac } from 'node:crypto';
 import { defineWebhookTarget, webhookUrlSetup, type WebhookResult } from '@profullstack/sh1pt-core';
 
 // Generic HTTP POST target. Use when the destination doesn't have its
@@ -24,11 +25,25 @@ export default defineWebhookTarget<Config>({
     ctx.log(`generic webhook · ${config.method ?? 'POST'} ${url}`);
     if (ctx.dryRun) return { ok: true, url };
 
-    // TODO:
-    //   const signature = hmacSha256(body, ctx.secret(config.secretKey ?? 'WEBHOOK_SECRET'))
-    //   headers: 'X-Sh1pt-Event': payload.event, 'X-Sh1pt-Signature': signature, ...extraHeaders
-    //   fetch(url, { method, body, headers })
-    return { ok: true, url };
+    const signingSecret = ctx.secret(config.secretKey ?? 'WEBHOOK_SECRET');
+    const signature = signingSecret ? hmacSha256(body, signingSecret) : undefined;
+    const res = await fetch(url, {
+      method: config.method ?? 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'X-Sh1pt-Event': payload.event,
+        ...(signature ? { 'X-Sh1pt-Signature': signature } : {}),
+        ...config.extraHeaders,
+      },
+      body,
+    });
+
+    if (!res.ok) {
+      const error = await res.text().catch(() => res.statusText);
+      return { ok: false, status: res.status, error, url };
+    }
+
+    return { ok: true, status: res.status, url };
   },
 
   setup: webhookUrlSetup<Config>({
@@ -42,3 +57,7 @@ export default defineWebhookTarget<Config>({
     ],
   }),
 });
+
+function hmacSha256(body: string, secret: string): string {
+  return `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`;
+}


### PR DESCRIPTION
## Summary
- replace the generic webhook stub success path with real HTTP POST/PUT delivery
- add HMAC-SHA256 signatures via X-Sh1pt-Signature when WEBHOOK_SECRET is configured
- include X-Sh1pt-Event plus user-provided extra headers
- return HTTP status and response body on non-2xx delivery failures
- add webhook contract coverage plus mocked success/failure delivery tests

Ref: #6

## Verification
- env COREPACK_HOME=/private/tmp/corepack PNPM_HOME=/private/tmp/pnpm pnpm --filter @profullstack/sh1pt-webhooks-generic typecheck
- env COREPACK_HOME=/private/tmp/corepack PNPM_HOME=/private/tmp/pnpm pnpm exec vitest run packages/webhooks/generic/src/index.test.ts