### PR TITLE
feat: send Telegram webhook messages

### DIFF
--- a/packages/webhooks/telegram/src/index.test.ts
+++ b/packages/webhooks/telegram/src/index.test.ts
@@ -1,4 +1,67 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { contractTestWebhook, fakeConnectContext } from '@profullstack/sh1pt-core/testing';
 import adapter from './index.js';
 
-smokeTest(adapter, { idPrefix: 'webhook' });
+contractTestWebhook(adapter, {
+  sampleConfig: { chatId: -1001234567890 },
+  requiredSecrets: ['TELEGRAM_BOT_TOKEN'],
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('webhook-telegram HTTP delivery', () => {
+  const payload = {
+    event: 'ship.published',
+    timestamp: '2026-05-11T20:00:00.000Z',
+    project: 'demo',
+    data: { target: 'pkg-npm' },
+  };
+
+  it('posts the formatted sendMessage payload to Telegram', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, result: { message_id: 42 } }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ TELEGRAM_BOT_TOKEN: '123:abc' }),
+      dryRun: false,
+    };
+
+    const result = await adapter.send(ctx as any, payload, { chatId: -1001234567890, parseMode: 'HTML' });
+
+    expect(result).toEqual({ ok: true, status: 200, url: 'https://api.telegram.org/bot123:abc/sendMessage' });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.telegram.org/bot123:abc/sendMessage');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).headers).toMatchObject({ 'content-type': 'application/json' });
+    const body = JSON.parse(String((init as RequestInit).body));
+    expect(body.chat_id).toBe(-1001234567890);
+    expect(body.parse_mode).toBe('HTML');
+    expect(body.text).toContain('ship\\.published');
+  });
+
+  it('returns Telegram error descriptions when sendMessage is rejected', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      json: async () => ({ ok: false, description: 'Bad Request: chat not found' }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ TELEGRAM_BOT_TOKEN: '123:abc' }),
+      dryRun: false,
+    };
+
+    await expect(adapter.send(ctx as any, payload, { chatId: -1001234567890 })).resolves.toEqual({
+      ok: false,
+      status: 400,
+      error: 'Bad Request: chat not found',
+      url: 'https://api.telegram.org/bot123:abc/sendMessage',
+    });
+  });
+});

--- a/packages/webhooks/telegram/src/index.ts
+++ b/packages/webhooks/telegram/src/index.ts
@@ -1,4 +1,4 @@
-import { defineWebhookTarget, tokenSetup, type WebhookResult } from '@profullstack/sh1pt-core';
+import { defineWebhookTarget, tokenSetup, type WebhookPayload, type WebhookResult } from '@profullstack/sh1pt-core';
 
 // Telegram — not strictly "just a webhook URL," but close. Pipe through
 // a bot with sendMessage; setup is trivial (BotFather → /newbot → token +
@@ -15,24 +15,32 @@ export default defineWebhookTarget<Config>({
   label: 'Telegram (bot sendMessage)',
 
   format(payload, config) {
-    const summary = `*${escape(payload.event)}*`;
-    const body = '```\n' + JSON.stringify(payload.data, null, 2).slice(0, 3500) + '\n```';
-    return {
-      chat_id: config.chatId,
-      text: `${summary}\n${body}`,
-      parse_mode: config.parseMode ?? 'MarkdownV2',
-      disable_notification: config.disableNotification,
-    };
+    return formatTelegramPayload(payload, config);
   },
 
   async send(ctx, payload, config): Promise<WebhookResult> {
     const token = ctx.secret('TELEGRAM_BOT_TOKEN');
-    if (!token) throw new Error('TELEGRAM_BOT_TOKEN not in vault (BotFather → /newbot → copy the token)');
+    if (!token) throw new Error('TELEGRAM_BOT_TOKEN not in vault — run: sh1pt secret set TELEGRAM_BOT_TOKEN <bot-token>');
     const url = `https://api.telegram.org/bot${token}/sendMessage`;
     ctx.log(`telegram webhook · chat=${config.chatId}`);
     if (ctx.dryRun) return { ok: true, url };
-    // TODO: POST url with formatted body
-    return { ok: true, url };
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(formatTelegramPayload(payload, config)),
+    });
+    const data = await parseTelegramResponse(res);
+    if (!res.ok || !data.ok) {
+      return {
+        ok: false,
+        status: res.status,
+        error: data.description ?? res.statusText,
+        url,
+      };
+    }
+
+    return { ok: true, status: res.status, url };
   },
 
   setup: tokenSetup<Config>({
@@ -50,6 +58,30 @@ export default defineWebhookTarget<Config>({
     ],
   }),
 });
+
+interface TelegramResponse {
+  ok?: boolean;
+  description?: string;
+}
+
+function formatTelegramPayload(payload: WebhookPayload, config: Config): unknown {
+  const summary = `*${escape(payload.event)}*`;
+  const body = '```\n' + JSON.stringify(payload.data, null, 2).slice(0, 3500) + '\n```';
+  return {
+    chat_id: config.chatId,
+    text: `${summary}\n${body}`,
+    parse_mode: config.parseMode ?? 'MarkdownV2',
+    disable_notification: config.disableNotification,
+  };
+}
+
+async function parseTelegramResponse(res: Response): Promise<TelegramResponse> {
+  try {
+    return await res.json() as TelegramResponse;
+  } catch {
+    return { ok: res.ok, description: res.statusText };
+  }
+}
 
 function escape(s: string): string {
   return s.replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, (c) => '\\' + c);


### PR DESCRIPTION
## Summary
- implement real Telegram Bot API sendMessage delivery for the webhook adapter
- return Telegram error descriptions on failed delivery
- replace smoke-only coverage with webhook contract and mocked HTTP delivery tests

Ref: #6

## Verification
- env COREPACK_HOME=/private/tmp/corepack PNPM_HOME=/private/tmp/pnpm pnpm --filter @profullstack/sh1pt-webhooks-telegram typecheck
- env COREPACK_HOME=/private/tmp/corepack PNPM_HOME=/private/tmp/pnpm pnpm exec vitest run packages/webhooks/telegram/src/index.test.ts
- git diff --check