### PR TITLE
feat: post Discord webhook payloads

### DIFF
--- a/packages/webhooks/discord/src/index.test.ts
+++ b/packages/webhooks/discord/src/index.test.ts
@@ -1,7 +1,67 @@
-import { contractTestWebhook } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { contractTestWebhook, fakeConnectContext } from '@profullstack/sh1pt-core/testing';
 import webhook from './index.js';
 
 contractTestWebhook(webhook, {
   sampleConfig: {},
   requiredSecrets: ['DISCORD_WEBHOOK_URL'],
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('webhook-discord HTTP delivery', () => {
+  const payload = {
+    event: 'ship.published',
+    timestamp: '2026-05-11T20:00:00.000Z',
+    project: 'demo',
+    data: { target: 'pkg-npm' },
+  };
+
+  it('posts the formatted message payload to Discord', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 204,
+      text: async () => '',
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ DISCORD_WEBHOOK_URL: 'https://discord.com/api/webhooks/1/token' }),
+      dryRun: false,
+    };
+
+    const result = await webhook.send(ctx as any, payload, { username: 'shipbot', mention: '<@&123>' });
+
+    expect(result).toEqual({ ok: true, status: 204, url: 'https://discord.com/api/webhooks/1/token' });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://discord.com/api/webhooks/1/token');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).headers).toMatchObject({ 'content-type': 'application/json' });
+    const body = JSON.parse(String((init as RequestInit).body));
+    expect(body.username).toBe('shipbot');
+    expect(body.content).toContain('<@&123>');
+    expect(body.embeds[0]).toMatchObject({ title: 'ship.published', color: 0x22c55e });
+  });
+
+  it('returns Discord error messages when delivery fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 429,
+      statusText: 'Too Many Requests',
+      text: async () => JSON.stringify({ message: 'You are being rate limited.', retry_after: 0.25 }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ DISCORD_WEBHOOK_URL: 'https://discord.com/api/webhooks/1/token' }),
+      dryRun: false,
+    };
+
+    await expect(webhook.send(ctx as any, payload, {})).resolves.toEqual({
+      ok: false,
+      status: 429,
+      error: 'You are being rate limited.',
+      url: 'https://discord.com/api/webhooks/1/token',
+    });
+  });
 });

--- a/packages/webhooks/discord/src/index.ts
+++ b/packages/webhooks/discord/src/index.ts
@@ -18,20 +18,7 @@ export default defineWebhookTarget<Config>({
   label: 'Discord (channel webhook)',
 
   format(payload, config) {
-    // Discord accepts { content, embeds, username, avatar_url }.
-    const prefix = config.mention ? `${config.mention} ` : '';
-    const summary = summarize(payload);
-    return {
-      username: config.username ?? 'sh1pt',
-      avatar_url: config.avatarUrl,
-      content: `${prefix}${summary}`,
-      embeds: [{
-        title: payload.event,
-        description: '```json\n' + JSON.stringify(payload.data, null, 2).slice(0, 1800) + '\n```',
-        timestamp: payload.timestamp,
-        color: colorFor(payload.event),
-      }],
-    };
+    return formatDiscordPayload(payload, config);
   },
 
   async send(ctx, payload, config): Promise<WebhookResult> {
@@ -40,9 +27,22 @@ export default defineWebhookTarget<Config>({
     if (!url) throw new Error(`${urlKey} not in vault — paste the Discord webhook URL via \`sh1pt secret set ${urlKey}\``);
     ctx.log(`discord webhook · event=${payload.event}`);
     if (ctx.dryRun) return { ok: true, url };
-    // TODO: POST url with Content-Type application/json; body = this.format(payload, config).
-    // Discord returns 204 on success, 429 with retry_after on rate limit.
-    return { ok: true, url };
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(formatDiscordPayload(payload, config)),
+    });
+    if (!res.ok) {
+      return {
+        ok: false,
+        status: res.status,
+        error: await readDiscordError(res),
+        url,
+      };
+    }
+
+    return { ok: true, status: res.status, url };
   },
 
   async setup(ctx: SetupContext): Promise<SetupResult<Config>> {
@@ -84,6 +84,36 @@ export default defineWebhookTarget<Config>({
     return { ok: true, config: { urlKey } };
   },
 });
+
+function formatDiscordPayload(
+  payload: { event: string; timestamp: string; data: Record<string, unknown> },
+  config: Config,
+): unknown {
+  const prefix = config.mention ? `${config.mention} ` : '';
+  const summary = summarize(payload);
+  return {
+    username: config.username ?? 'sh1pt',
+    avatar_url: config.avatarUrl,
+    content: `${prefix}${summary}`,
+    embeds: [{
+      title: payload.event,
+      description: '```json\n' + JSON.stringify(payload.data, null, 2).slice(0, 1800) + '\n```',
+      timestamp: payload.timestamp,
+      color: colorFor(payload.event),
+    }],
+  };
+}
+
+async function readDiscordError(res: Response): Promise<string> {
+  const text = await res.text().catch(() => '');
+  if (!text) return res.statusText;
+  try {
+    const data = JSON.parse(text) as { message?: string };
+    return data.message ?? text;
+  } catch {
+    return text;
+  }
+}
 
 function summarize(p: { event: string; data: Record<string, unknown> }): string {
   if (p.event.startsWith('ship.')) return `🚀 ship ${p.event.replace('ship.', '')}: ${p.data.target ?? ''}`;


### PR DESCRIPTION
## Summary
- implement real HTTP POST delivery for Discord channel webhooks
- return Discord error messages from failed webhook responses
- add mocked delivery tests alongside the webhook contract coverage

Ref: #6

## Verification
- env COREPACK_HOME=/private/tmp/corepack PNPM_HOME=/private/tmp/pnpm pnpm --filter @profullstack/sh1pt-webhooks-discord typecheck
- env COREPACK_HOME=/private/tmp/corepack PNPM_HOME=/private/tmp/pnpm pnpm exec vitest run packages/webhooks/discord/src/index.test.ts
- git diff --check