### PR TITLE
feat: publish Telegram social posts

### DIFF
--- a/packages/social/telegram/src/index.test.ts
+++ b/packages/social/telegram/src/index.test.ts
@@ -1,4 +1,66 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { contractTestSocial, fakeConnectContext } from '@profullstack/sh1pt-core/testing';
 import adapter from './index.js';
 
-smokeTest(adapter, { idPrefix: 'social' });
+contractTestSocial(adapter, {
+  sampleConfig: { chatId: '@sh1pt' },
+  samplePost: { body: 'hello from sh1pt contract tests' },
+  requiredSecrets: ['TELEGRAM_BOT_TOKEN'],
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('social-telegram posting', () => {
+  it('posts text with sendMessage and returns the Telegram message link', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        result: { message_id: 42, chat: { username: 'sh1pt' }, date: 1_779_000_000 },
+      }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ TELEGRAM_BOT_TOKEN: '123:abc' }),
+      dryRun: false,
+    };
+
+    const result = await adapter.post(ctx as any, { body: 'Release shipped', link: 'https://sh1pt.com' }, { chatId: '@sh1pt' });
+
+    expect(result).toEqual({
+      id: '42',
+      url: 'https://t.me/sh1pt/42',
+      platform: 'telegram',
+      publishedAt: '2026-05-17T06:40:00.000Z',
+    });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.telegram.org/bot123:abc/sendMessage');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).headers).toMatchObject({ 'content-type': 'application/json' });
+    const body = JSON.parse(String((init as RequestInit).body));
+    expect(body).toMatchObject({
+      chat_id: '@sh1pt',
+      text: 'Release shipped\nhttps://sh1pt.com',
+    });
+  });
+
+  it('throws Telegram error descriptions when sendMessage is rejected', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      json: async () => ({ ok: false, description: 'Bad Request: chat not found' }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ TELEGRAM_BOT_TOKEN: '123:abc' }),
+      dryRun: false,
+    };
+
+    await expect(adapter.post(ctx as any, { body: 'Release shipped' }, { chatId: '@missing' }))
+      .rejects.toThrow('Bad Request: chat not found');
+  });
+});

--- a/packages/social/telegram/src/index.ts
+++ b/packages/social/telegram/src/index.ts
@@ -1,4 +1,4 @@
-import { defineSocial, tokenSetup } from '@profullstack/sh1pt-core';
+import { defineSocial, tokenSetup, type SocialPost } from '@profullstack/sh1pt-core';
 
 // Telegram Bot API. Bots auth with a bot token from @BotFather; channel /
 // group posting requires the bot to be added as admin to the target chat.
@@ -6,6 +6,8 @@ import { defineSocial, tokenSetup } from '@profullstack/sh1pt-core';
 // for sign-in only, not posting.
 interface Config {
   chatId: string;
+  parseMode?: 'MarkdownV2' | 'HTML';
+  disableNotification?: boolean;
 }
 
 export default defineSocial<Config>({
@@ -14,16 +16,32 @@ export default defineSocial<Config>({
   requires: { maxBodyChars: 4096, maxHashtags: 0, hashtagsInBody: true },
 
   async connect(ctx, config) {
-    if (!ctx.secret('TELEGRAM_BOT_TOKEN')) throw new Error('TELEGRAM_BOT_TOKEN not in vault');
+    if (!ctx.secret('TELEGRAM_BOT_TOKEN')) throw new Error('TELEGRAM_BOT_TOKEN not in vault — run: sh1pt secret set TELEGRAM_BOT_TOKEN <bot-token>');
     return { accountId: config.chatId };
   },
 
   async post(ctx, post, config) {
+    const token = ctx.secret('TELEGRAM_BOT_TOKEN');
+    if (!token) throw new Error('TELEGRAM_BOT_TOKEN not in vault — run: sh1pt secret set TELEGRAM_BOT_TOKEN <bot-token>');
     ctx.log(`telegram message · chat=${config.chatId} · ${post.body.length} chars`);
     if (ctx.dryRun) return { id: 'dry-run', url: 'https://t.me/', platform: 'telegram', publishedAt: new Date().toISOString() };
-    // TODO: POST https://api.telegram.org/bot{token}/sendMessage with { chat_id, text, parse_mode: 'MarkdownV2' }
-    // For media, use sendPhoto / sendVideo / sendMediaGroup.
-    return { id: `tg_${Date.now()}`, url: 'https://t.me/', platform: 'telegram', publishedAt: new Date().toISOString() };
+
+    const res = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(formatTelegramMessage(post, config)),
+    });
+    const data = await parseTelegramResponse(res);
+    if (!res.ok || !data.ok || !data.result) {
+      throw new Error(data.description ?? res.statusText);
+    }
+
+    return {
+      id: String(data.result.message_id),
+      url: messageUrl(data.result, config),
+      platform: 'telegram',
+      publishedAt: new Date(data.result.date * 1000).toISOString(),
+    };
   },
 
   setup: tokenSetup({
@@ -41,3 +59,38 @@ export default defineSocial<Config>({
     ],
   }),
 });
+
+interface TelegramResponse {
+  ok?: boolean;
+  description?: string;
+  result?: {
+    message_id: number;
+    date: number;
+    chat?: {
+      username?: string;
+    };
+  };
+}
+
+function formatTelegramMessage(post: SocialPost, config: Config): unknown {
+  const link = post.link ? `\n${post.link}` : '';
+  return {
+    chat_id: config.chatId,
+    text: `${post.body}${link}`.slice(0, 4096),
+    parse_mode: config.parseMode,
+    disable_notification: config.disableNotification,
+  };
+}
+
+async function parseTelegramResponse(res: Response): Promise<TelegramResponse> {
+  try {
+    return await res.json() as TelegramResponse;
+  } catch {
+    return { ok: res.ok, description: res.statusText };
+  }
+}
+
+function messageUrl(result: NonNullable<TelegramResponse['result']>, config: Config): string {
+  const username = result.chat?.username ?? (config.chatId.startsWith('@') ? config.chatId.slice(1) : undefined);
+  return username ? `https://t.me/${username}/${result.message_id}` : 'https://t.me/';
+}


### PR DESCRIPTION
## Summary
- implement Telegram Bot API sendMessage delivery for the social Telegram adapter
- map Telegram message ids, timestamps, and public channel links into PostResult
- replace smoke-only coverage with social contract and mocked Telegram success/error tests

Ref: #6

## Verification
- env COREPACK_HOME=/private/tmp/corepack PNPM_HOME=/private/tmp/pnpm pnpm --filter @profullstack/sh1pt-social-telegram typecheck
- env COREPACK_HOME=/private/tmp/corepack PNPM_HOME=/private/tmp/pnpm pnpm exec vitest run packages/social/telegram/src/index.test.ts
- git diff --check