### PR TITLE
feat: publish Discord social posts

### DIFF
--- a/packages/social/discord/src/index.test.ts
+++ b/packages/social/discord/src/index.test.ts
@@ -1,4 +1,66 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { contractTestSocial, fakeConnectContext } from '@profullstack/sh1pt-core/testing';
 import adapter from './index.js';
 
-smokeTest(adapter, { idPrefix: 'social' });
+contractTestSocial(adapter, {
+  sampleConfig: {},
+  samplePost: { body: 'hello from sh1pt contract tests' },
+  requiredSecrets: ['DISCORD_WEBHOOK_URL'],
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('social-discord posting', () => {
+  it('posts content through a Discord webhook and returns the message link', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: '123456789',
+        channel_id: '222',
+        guild_id: '111',
+        timestamp: '2026-05-11T20:00:00.000000+00:00',
+      }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ DISCORD_WEBHOOK_URL: 'https://discord.com/api/webhooks/1/token' }),
+      dryRun: false,
+    };
+
+    const result = await adapter.post(ctx as any, { body: 'Release shipped', link: 'https://sh1pt.com' }, {});
+
+    expect(result).toEqual({
+      id: '123456789',
+      url: 'https://discord.com/channels/111/222/123456789',
+      platform: 'discord',
+      publishedAt: '2026-05-11T20:00:00.000Z',
+    });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://discord.com/api/webhooks/1/token?wait=true');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).headers).toMatchObject({ 'content-type': 'application/json' });
+    expect(JSON.parse(String((init as RequestInit).body))).toMatchObject({
+      content: 'Release shipped\nhttps://sh1pt.com',
+    });
+  });
+
+  it('throws Discord error messages when webhook posting fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      text: async () => JSON.stringify({ message: 'Invalid Form Body' }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ DISCORD_WEBHOOK_URL: 'https://discord.com/api/webhooks/1/token' }),
+      dryRun: false,
+    };
+
+    await expect(adapter.post(ctx as any, { body: 'Release shipped' }, {}))
+      .rejects.toThrow('Invalid Form Body');
+  });
+});

--- a/packages/social/discord/src/index.ts
+++ b/packages/social/discord/src/index.ts
@@ -1,10 +1,12 @@
-import { defineSocial, webhookUrlSetup } from '@profullstack/sh1pt-core';
+import { defineSocial, webhookUrlSetup, type SocialPost } from '@profullstack/sh1pt-core';
 
 // Discord — channel webhooks are the simplest publish path (one URL per
 // channel, no bot identity to manage). For richer automation (slash
 // commands, reactions, threads) wire up an OAuth bot separately.
 interface Config {
   channelLabel?: string;
+  username?: string;
+  avatarUrl?: string;
 }
 
 export default defineSocial<Config>({
@@ -13,15 +15,32 @@ export default defineSocial<Config>({
   requires: { maxBodyChars: 2000, maxHashtags: 0, hashtagsInBody: true },
 
   async connect(ctx) {
-    if (!ctx.secret('DISCORD_WEBHOOK_URL')) throw new Error('DISCORD_WEBHOOK_URL not in vault');
+    if (!ctx.secret('DISCORD_WEBHOOK_URL')) throw new Error('DISCORD_WEBHOOK_URL not in vault — run: sh1pt secret set DISCORD_WEBHOOK_URL <webhook-url>');
     return { accountId: 'webhook' };
   },
 
-  async post(ctx, post) {
+  async post(ctx, post, config) {
+    const webhookUrl = ctx.secret('DISCORD_WEBHOOK_URL');
+    if (!webhookUrl) throw new Error('DISCORD_WEBHOOK_URL not in vault — run: sh1pt secret set DISCORD_WEBHOOK_URL <webhook-url>');
     ctx.log(`discord message · ${post.body.length} chars · media=${post.media?.length ?? 0}`);
     if (ctx.dryRun) return { id: 'dry-run', url: 'https://discord.com/', platform: 'discord', publishedAt: new Date().toISOString() };
-    // TODO: POST {webhook_url} with { content, embeds, username, avatar_url }; multipart for files.
-    return { id: `dc_${Date.now()}`, url: 'https://discord.com/', platform: 'discord', publishedAt: new Date().toISOString() };
+
+    const res = await fetch(withWait(webhookUrl), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(formatDiscordPost(post, config)),
+    });
+    if (!res.ok) {
+      throw new Error(await readDiscordError(res));
+    }
+
+    const message = await res.json() as DiscordMessage;
+    return {
+      id: message.id,
+      url: messageUrl(message),
+      platform: 'discord',
+      publishedAt: new Date(message.timestamp).toISOString(),
+    };
   },
 
   setup: webhookUrlSetup({
@@ -36,3 +55,41 @@ export default defineSocial<Config>({
     ],
   }),
 });
+
+interface DiscordMessage {
+  id: string;
+  channel_id: string;
+  guild_id?: string;
+  timestamp: string;
+}
+
+function formatDiscordPost(post: SocialPost, config: Config): unknown {
+  const link = post.link ? `\n${post.link}` : '';
+  return {
+    content: `${post.body}${link}`.slice(0, 2000),
+    username: config.username,
+    avatar_url: config.avatarUrl,
+  };
+}
+
+function withWait(webhookUrl: string): string {
+  const separator = webhookUrl.includes('?') ? '&' : '?';
+  return `${webhookUrl}${separator}wait=true`;
+}
+
+async function readDiscordError(res: Response): Promise<string> {
+  const text = await res.text().catch(() => '');
+  if (!text) return res.statusText;
+  try {
+    const data = JSON.parse(text) as { message?: string };
+    return data.message ?? text;
+  } catch {
+    return text;
+  }
+}
+
+function messageUrl(message: DiscordMessage): string {
+  if (!message.channel_id) return 'https://discord.com/';
+  const guild = message.guild_id ?? '@me';
+  return `https://discord.com/channels/${guild}/${message.channel_id}/${message.id}`;
+}


### PR DESCRIPTION
## Summary
- implement Discord webhook posting for the social Discord adapter
- request webhook responses with wait=true to map native message ids, timestamps, and message links into PostResult
- replace smoke-only coverage with social contract and mocked Discord success/error tests

Ref: #6

## Verification
- env COREPACK_HOME=/private/tmp/corepack PNPM_HOME=/private/tmp/pnpm pnpm --filter @profullstack/sh1pt-social-discord typecheck
- env COREPACK_HOME=/private/tmp/corepack PNPM_HOME=/private/tmp/pnpm pnpm exec vitest run packages/social/discord/src/index.test.ts
- git diff --check