### PR TITLE
feat: publish DEV social articles

### DIFF
--- a/packages/social/devto/src/index.test.ts
+++ b/packages/social/devto/src/index.test.ts
@@ -1,4 +1,80 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { contractTestSocial, fakeConnectContext } from '@profullstack/sh1pt-core/testing';
 import adapter from './index.js';
 
-smokeTest(adapter, { idPrefix: 'social' });
+contractTestSocial(adapter, {
+  sampleConfig: { published: false },
+  samplePost: { title: 'Hello DEV', body: 'hello from sh1pt contract tests' },
+  requiredSecrets: ['DEVTO_API_KEY'],
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('social-devto posting', () => {
+  it('creates a DEV article with the API key header', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        id: 251,
+        url: 'https://dev.to/sh1pt/release-shipped',
+        published_at: '2026-05-11T20:00:00Z',
+      }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ DEVTO_API_KEY: 'dev-key' }),
+      dryRun: false,
+    };
+
+    const result = await adapter.post(ctx as any, {
+      title: 'Release shipped',
+      body: 'Article body',
+      hashtags: ['devto', 'api', 'typescript', 'automation', 'ignored'],
+      link: 'https://sh1pt.com',
+    }, { published: true, canonicalUrl: 'https://example.com/source', organizationId: 123 });
+
+    expect(result).toEqual({
+      id: '251',
+      url: 'https://dev.to/sh1pt/release-shipped',
+      platform: 'devto',
+      publishedAt: '2026-05-11T20:00:00.000Z',
+    });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://dev.to/api/articles');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).headers).toMatchObject({
+      'api-key': 'dev-key',
+      'content-type': 'application/json',
+    });
+    expect(JSON.parse(String((init as RequestInit).body))).toEqual({
+      article: {
+        title: 'Release shipped',
+        body_markdown: 'Article body\n\nhttps://sh1pt.com',
+        published: true,
+        tags: ['devto', 'api', 'typescript', 'automation'],
+        canonical_url: 'https://example.com/source',
+        organization_id: 123,
+      },
+    });
+  });
+
+  it('throws DEV API error messages when article creation fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 422,
+      statusText: 'Unprocessable Entity',
+      text: async () => JSON.stringify({ errors: ['Title has already been taken'] }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ DEVTO_API_KEY: 'dev-key' }),
+      dryRun: false,
+    };
+
+    await expect(adapter.post(ctx as any, { title: 'Release shipped', body: 'Article body' }, {}))
+      .rejects.toThrow('Title has already been taken');
+  });
+});

--- a/packages/social/devto/src/index.ts
+++ b/packages/social/devto/src/index.ts
@@ -1,4 +1,4 @@
-import { defineSocial, oauthSetup } from '@profullstack/sh1pt-core';
+import { defineSocial, oauthSetup, type SocialPost } from '@profullstack/sh1pt-core';
 
 // DEV Community (dev.to) — clean REST API at dev.to/api. Articles are
 // markdown; tags are native (not hashtags). Auth: API key from user
@@ -14,15 +14,35 @@ export default defineSocial<Config>({
   label: 'DEV Community (dev.to)',
   requires: { maxHashtags: 4, hashtagsInBody: false },    // DEV uses "tags", max 4
   async connect(ctx) {
-    if (!ctx.secret('DEVTO_API_KEY')) throw new Error('DEVTO_API_KEY not in vault (dev.to/settings/extensions → Generate API Key)');
+    if (!ctx.secret('DEVTO_API_KEY')) throw new Error('DEVTO_API_KEY not in vault — run: sh1pt secret set DEVTO_API_KEY <api-key>');
     return { accountId: 'devto' };
   },
   async post(ctx, post, config) {
     if (!post.title) throw new Error('dev.to requires a title');
+    const apiKey = ctx.secret('DEVTO_API_KEY');
+    if (!apiKey) throw new Error('DEVTO_API_KEY not in vault — run: sh1pt secret set DEVTO_API_KEY <api-key>');
     ctx.log(`dev.to article · "${post.title}"`);
     if (ctx.dryRun) return { id: 'dry-run', url: 'https://dev.to/', platform: 'devto', publishedAt: new Date().toISOString() };
-    // TODO: POST https://dev.to/api/articles { article: { title, body_markdown, published, tags, canonical_url, organization_id } }
-    return { id: `dev_${Date.now()}`, url: 'https://dev.to/', platform: 'devto', publishedAt: new Date().toISOString() };
+
+    const res = await fetch('https://dev.to/api/articles', {
+      method: 'POST',
+      headers: {
+        'api-key': apiKey,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ article: formatDevArticle(post, config) }),
+    });
+    if (!res.ok) {
+      throw new Error(await readDevtoError(res));
+    }
+
+    const article = await res.json() as DevtoArticle;
+    return {
+      id: String(article.id),
+      url: article.url ?? 'https://dev.to/',
+      platform: 'devto',
+      publishedAt: new Date(article.published_at ?? article.created_at ?? Date.now()).toISOString(),
+    };
   },
 
   setup: oauthSetup({
@@ -35,3 +55,34 @@ export default defineSocial<Config>({
     ],
   }),
 });
+
+interface DevtoArticle {
+  id: number;
+  url?: string;
+  created_at?: string;
+  published_at?: string | null;
+}
+
+function formatDevArticle(post: SocialPost, config: Config): Record<string, unknown> {
+  const link = post.link ? `\n\n${post.link}` : '';
+  return {
+    title: post.title,
+    body_markdown: `${post.body}${link}`,
+    published: config.published ?? false,
+    tags: (post.hashtags ?? []).slice(0, 4),
+    canonical_url: config.canonicalUrl,
+    organization_id: config.organizationId,
+  };
+}
+
+async function readDevtoError(res: Response): Promise<string> {
+  const text = await res.text().catch(() => '');
+  if (!text) return res.statusText;
+  try {
+    const data = JSON.parse(text) as { error?: string; errors?: string[] | string };
+    if (Array.isArray(data.errors)) return data.errors.join('; ');
+    return data.error ?? data.errors ?? text;
+  } catch {
+    return text;
+  }
+}


### PR DESCRIPTION
## Summary
- implement DEV Community article creation through the public REST API
- map DEV article ids, URLs, and timestamps into PostResult
- replace smoke-only coverage with social contract and mocked DEV success/error tests

Ref: #6

## Verification
- env COREPACK_HOME=/private/tmp/corepack PNPM_HOME=/private/tmp/pnpm pnpm --filter @profullstack/sh1pt-social-devto typecheck
- env COREPACK_HOME=/private/tmp/corepack PNPM_HOME=/private/tmp/pnpm pnpm exec vitest run packages/social/devto/src/index.test.ts
- git diff --check