### PR TITLE
Implement Hashnode social publishing

### DIFF
--- a/packages/social/hashnode/src/index.test.ts
+++ b/packages/social/hashnode/src/index.test.ts
@@ -1,4 +1,89 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
-import adapter from './index.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { contractTestSocial } from '@profullstack/sh1pt-core/testing';
+import social from './index.js';
 
-smokeTest(adapter, { idPrefix: 'social' });
+contractTestSocial(social, {
+  sampleConfig: { publicationId: 'pub_123' },
+  samplePost: { title: 'Hello Hashnode', body: 'hello from sh1pt contract tests' },
+  requiredSecrets: ['HASHNODE_API_TOKEN'],
+});
+
+describe('Hashnode publishPost integration', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('publishes markdown through Hashnode GraphQL and returns the published post URL', async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    vi.stubGlobal('fetch', async (url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      return new Response(JSON.stringify({
+        data: {
+          publishPost: {
+            post: {
+              id: 'post_123',
+              url: 'https://hashnode.com/post/ship-it',
+            },
+          },
+        },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    });
+
+    const result = await social.post({
+      secret: (key) => key === 'HASHNODE_API_TOKEN' ? 'token_123' : undefined,
+      log: () => {},
+      dryRun: false,
+    }, {
+      title: 'Ship it',
+      body: 'Release notes go here.',
+      link: 'https://example.com/release',
+    }, {
+      publicationId: 'pub_123',
+      tags: ['tag_1'],
+      canonicalUrl: 'https://example.com/original',
+    });
+
+    expect(result).toEqual({
+      id: 'post_123',
+      url: 'https://hashnode.com/post/ship-it',
+      platform: 'hashnode',
+      publishedAt: expect.any(String),
+    });
+    expect(calls).toHaveLength(1);
+    const [request] = calls;
+    expect(request!.url).toBe('https://gql.hashnode.com');
+    expect(request!.init.method).toBe('POST');
+    expect(request!.init.headers).toMatchObject({
+      Authorization: 'Bearer token_123',
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    });
+
+    const payload = JSON.parse(request!.init.body as string);
+    expect(payload.query).toContain('mutation PublishPost');
+    expect(payload.variables.input).toEqual({
+      publicationId: 'pub_123',
+      title: 'Ship it',
+      contentMarkdown: 'Release notes go here.\n\nhttps://example.com/release',
+      tags: ['tag_1'],
+      canonicalUrl: 'https://example.com/original',
+    });
+  });
+
+  it('surfaces GraphQL errors with the Hashnode message', async () => {
+    vi.stubGlobal('fetch', async () => new Response(JSON.stringify({
+      errors: [{ message: 'Publication not found' }],
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+
+    await expect(social.post({
+      secret: (key) => key === 'HASHNODE_API_TOKEN' ? 'token_123' : undefined,
+      log: () => {},
+      dryRun: false,
+    }, {
+      title: 'Missing blog',
+      body: 'Body',
+    }, {
+      publicationId: 'missing',
+    })).rejects.toThrow('Publication not found');
+  });
+});

--- a/packages/social/hashnode/src/index.ts
+++ b/packages/social/hashnode/src/index.ts
@@ -1,12 +1,61 @@
 import { defineSocial, oauthSetup } from '@profullstack/sh1pt-core';
 
-// Hashnode — GraphQL API at gql.hashnode.com. Personal blogs live on
+const HASHNODE_API_URL = 'https://gql.hashnode.com';
+const HASHNODE_TOKEN_SECRET = 'HASHNODE_API_TOKEN';
+const PUBLISH_POST_MUTATION = `
+mutation PublishPost($input: PublishPostInput!) {
+  publishPost(input: $input) {
+    post {
+      id
+      slug
+      url
+    }
+  }
+}
+`;
+
+type HashnodeGraphQLError = {
+  message?: string;
+};
+
+type HashnodePublishResponse = {
+  data?: {
+    publishPost?: {
+      post?: {
+        id?: string;
+        slug?: string;
+        url?: string;
+      };
+    };
+  };
+  errors?: HashnodeGraphQLError[];
+};
+
+// Hashnode - GraphQL API at gql.hashnode.com. Personal blogs live on
 // hashnode.dev subdomains or custom domains; posts are markdown with
 // auto-SEO, RSS, newsletter. Auth: personal access token.
 interface Config {
   publicationId: string;
-  tags?: string[];              // max 5; each is an OBJECT id, not a string — resolve via /tags query
+  tags?: string[];              // max 5; each is an object id, not a label - resolve via tags query
   canonicalUrl?: string;
+}
+
+function buildContentMarkdown(post: { body: string; link?: string }): string {
+  return post.link ? `${post.body}\n\n${post.link}` : post.body;
+}
+
+function buildPublishInput(post: { body: string; title?: string; link?: string }, config: Config): Record<string, unknown> {
+  return {
+    publicationId: config.publicationId,
+    title: post.title,
+    contentMarkdown: buildContentMarkdown(post),
+    ...(config.tags?.length ? { tags: config.tags } : {}),
+    ...(config.canonicalUrl ? { canonicalUrl: config.canonicalUrl } : {}),
+  };
+}
+
+function authorizationHeader(token: string): string {
+  return token.toLowerCase().startsWith('bearer ') ? token : `Bearer ${token}`;
 }
 
 export default defineSocial<Config>({
@@ -14,24 +63,57 @@ export default defineSocial<Config>({
   label: 'Hashnode',
   requires: { maxHashtags: 5, hashtagsInBody: false },
   async connect(ctx) {
-    if (!ctx.secret('HASHNODE_TOKEN')) throw new Error('HASHNODE_TOKEN not in vault');
+    if (!ctx.secret(HASHNODE_TOKEN_SECRET)) throw new Error(`${HASHNODE_TOKEN_SECRET} not in vault`);
     return { accountId: 'hashnode' };
   },
   async post(ctx, post, config) {
     if (!post.title) throw new Error('Hashnode requires a title');
+    const token = ctx.secret(HASHNODE_TOKEN_SECRET);
+    if (!token) throw new Error(`${HASHNODE_TOKEN_SECRET} not in vault`);
     ctx.log(`hashnode post · ${config.publicationId} · "${post.title}"`);
-    if (ctx.dryRun) return { id: 'dry-run', url: 'https://hashnode.com/', platform: 'hashnode', publishedAt: new Date().toISOString() };
-    // TODO: GraphQL publishPost mutation with { input: { publicationId, title, contentMarkdown, tags, coverImageOptions } }
-    return { id: `hn_${Date.now()}`, url: 'https://hashnode.com/', platform: 'hashnode', publishedAt: new Date().toISOString() };
+    if (ctx.dryRun) {
+      return { id: 'dry-run', url: 'https://hashnode.com/', platform: 'hashnode', publishedAt: new Date().toISOString() };
+    }
+
+    const response = await fetch(HASHNODE_API_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: authorizationHeader(token),
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({
+        query: PUBLISH_POST_MUTATION,
+        variables: {
+          input: buildPublishInput(post, config),
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Hashnode publish failed (${response.status}): ${body.slice(0, 300)}`);
+    }
+
+    const payload = await response.json() as HashnodePublishResponse;
+    const graphQLError = payload.errors?.find((error) => error.message)?.message;
+    if (graphQLError) throw new Error(graphQLError);
+
+    const publishedPost = payload.data?.publishPost?.post;
+    const id = publishedPost?.id ?? publishedPost?.slug;
+    const url = publishedPost?.url;
+    if (!id || !url) throw new Error('Hashnode publish response did not include a post id and URL');
+
+    return { id, url, platform: 'hashnode', publishedAt: new Date().toISOString() };
   },
 
   setup: oauthSetup({
-    secretKey: "HASHNODE_API_TOKEN",
-    label: "Hashnode",
-    vendorDocUrl: "https://hashnode.com/settings/developer",
+    secretKey: 'HASHNODE_API_TOKEN',
+    label: 'Hashnode',
+    vendorDocUrl: 'https://hashnode.com/settings/developer',
     steps: [
-      "Open hashnode.com/settings/developer \u2192 Personal Access Tokens \u2192 Generate New Token",
-      "Copy the token (shown once)",
+      'Open hashnode.com/settings/developer -> Personal Access Tokens -> Generate New Token',
+      'Copy the token (shown once)',
     ],
   }),
 });


### PR DESCRIPTION
## Summary
- replace the Hashnode social adapter stub with a real Hashnode GraphQL publishPost call
- align the vault secret with setup by using HASHNODE_API_TOKEN for connect/post
- add focused contract and publish/error tests for the Hashnode adapter

## Duplicate check
- checked existing open/closed PRs for "hashnode" before submitting; none found
- checked #6 comments; Hashnode is only covered by the broad social stubs bucket, not an existing adapter PR

## Tests
- corepack pnpm test -- packages/social/hashnode/src/index.test.ts
- corepack pnpm --filter @profullstack/sh1pt-social-hashnode typecheck
- corepack pnpm --filter @profullstack/sh1pt-social-hashnode build
- git diff --check

Relates to #6