### PR TITLE
Implement dotenvx secrets provider

### DIFF
--- a/packages/secrets/dotenvx/src/index.test.ts
+++ b/packages/secrets/dotenvx/src/index.test.ts
@@ -1,4 +1,69 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'secrets' });
+
+const tempDirs: string[] = [];
+
+async function tempEnvFile(contents = ''): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'sh1pt-dotenvx-'));
+  tempDirs.push(dir);
+  const envFile = join(dir, '.env');
+  await writeFile(envFile, contents, 'utf8');
+  return envFile;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('dotenvx secret provider', () => {
+  it('pulls values from env files with comments, export prefixes, and quotes', async () => {
+    const envFile = await tempEnvFile([
+      '# keep comments out of pull results',
+      'export API_KEY=abc123',
+      'QUOTED="hello world"',
+      "SINGLE='single value'",
+      'ESCAPED="line\\nnext"',
+      'EMPTY=',
+      '',
+    ].join('\n'));
+
+    await expect(adapter.pull({ secret: () => undefined, log: () => {} }, { envFile })).resolves.toEqual([
+      { key: 'API_KEY', value: 'abc123', path: envFile },
+      { key: 'QUOTED', value: 'hello world', path: envFile },
+      { key: 'SINGLE', value: 'single value', path: envFile },
+      { key: 'ESCAPED', value: 'line\nnext', path: envFile },
+      { key: 'EMPTY', value: '', path: envFile },
+    ]);
+  });
+
+  it('upserts pushed values while preserving unrelated lines', async () => {
+    const envFile = await tempEnvFile([
+      '# existing env',
+      'EXISTING=old',
+      'UNCHANGED=1',
+      '',
+    ].join('\n'));
+
+    await expect(adapter.push({ secret: () => undefined, log: () => {} }, [
+      { key: 'EXISTING', value: 'new value' },
+      { key: 'ADDED', value: 'plain-value' },
+      { key: 'MULTILINE', value: 'line\nnext' },
+    ], { envFile })).resolves.toEqual({ count: 3 });
+
+    await expect(readFile(envFile, 'utf8')).resolves.toBe([
+      '# existing env',
+      'EXISTING="new value"',
+      'UNCHANGED=1',
+      '',
+      'ADDED=plain-value',
+      'MULTILINE="line\\nnext"',
+      '',
+    ].join('\n'));
+  });
+});

--- a/packages/secrets/dotenvx/src/index.ts
+++ b/packages/secrets/dotenvx/src/index.ts
@@ -1,7 +1,57 @@
+import { readFile, writeFile } from 'node:fs/promises';
 import { defineSecretProvider, manualSetup, type SecretRef } from '@profullstack/sh1pt-core';
 
 interface Config {
   envFile?: string;
+}
+
+const DEFAULT_ENV_FILE = '.env';
+const ENV_ENTRY = /^(\s*(?:export\s+)?)([A-Za-z_][A-Za-z0-9_]*)(\s*=\s*)(.*)$/;
+
+function envFile(config: Config): string {
+  return config.envFile ?? DEFAULT_ENV_FILE;
+}
+
+async function readEnvFile(path: string): Promise<string> {
+  try {
+    return await readFile(path, 'utf8');
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return '';
+    throw error;
+  }
+}
+
+function unquoteValue(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1).replace(/\\([nrt"\\])/g, (_match, escaped: string) => {
+      if (escaped === 'n') return '\n';
+      if (escaped === 'r') return '\r';
+      if (escaped === 't') return '\t';
+      return escaped;
+    });
+  }
+  if (trimmed.startsWith("'") && trimmed.endsWith("'")) return trimmed.slice(1, -1);
+  return trimmed;
+}
+
+function formatValue(value: string): string {
+  if (value === '') return '';
+  if (/^[A-Za-z0-9_./:@%+-]+$/.test(value)) return value;
+  return `"${value
+    .replace(/\\/g, '\\\\')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t')
+    .replace(/"/g, '\\"')}"`;
+}
+
+function parseEntry(line: string): { prefix: string; key: string; spacing: string; value: string } | undefined {
+  const match = ENV_ENTRY.exec(line);
+  if (!match) return undefined;
+  const [, prefix, key, spacing, value] = match;
+  if (prefix === undefined || key === undefined || spacing === undefined || value === undefined) return undefined;
+  return { prefix, key, spacing, value };
 }
 
 export default defineSecretProvider<Config>({
@@ -9,15 +59,47 @@ export default defineSecretProvider<Config>({
   label: 'dotenvx',
   cli: 'dotenvx',
   async connect(ctx, config) {
-    ctx.log(`dotenvx status · file=${config.envFile ?? '.env'}`);
-    return { accountId: config.envFile ?? '.env' };
+    const file = envFile(config);
+    ctx.log(`dotenvx status · file=${file}`);
+    return { accountId: file };
   },
   async pull(ctx, config): Promise<SecretRef[]> {
-    ctx.log(`dotenvx get --all --env-file ${config.envFile ?? '.env'}`);
-    return [];
+    const file = envFile(config);
+    ctx.log(`dotenvx get --all --env-file ${file}`);
+    const text = await readEnvFile(file);
+    return text
+      .split(/\r?\n/)
+      .flatMap((line) => {
+        const entry = parseEntry(line);
+        if (!entry) return [];
+        return [{ key: entry.key, value: unquoteValue(entry.value), path: file }];
+      });
   },
   async push(ctx, secrets, config) {
-    ctx.log(`dotenvx set <${secrets.length} keys> --env-file ${config.envFile ?? '.env'}`);
+    const file = envFile(config);
+    ctx.log(`dotenvx set <${secrets.length} keys> --env-file ${file}`);
+    const pending = new Map(secrets.map((secret) => [secret.key, secret.value ?? '']));
+    const text = await readEnvFile(file);
+    const lines = text === '' ? [''] : text.split(/\r?\n/);
+    const nextLines = lines.map((line) => {
+      const entry = parseEntry(line);
+      if (!entry || !pending.has(entry.key)) return line;
+      const value = pending.get(entry.key)!;
+      pending.delete(entry.key);
+      return `${entry.prefix}${entry.key}${entry.spacing}${formatValue(value)}`;
+    });
+
+    const additions = [...pending].map(([key, value]) => `${key}=${formatValue(value)}`);
+    if (additions.length) {
+      if (nextLines.length === 1 && nextLines[0] === '') {
+        nextLines.splice(0, 1, ...additions, '');
+      } else if (nextLines[nextLines.length - 1] === '') {
+        nextLines.push(...additions, '');
+      } else {
+        nextLines.push(...additions);
+      }
+    }
+    await writeFile(file, nextLines.join('\n'), 'utf8');
     return { count: secrets.length };
   },
   setup: manualSetup({


### PR DESCRIPTION
## Summary
- replace the dotenvx secrets stub with local .env pull/push behavior
- parse comments, export-prefixed variables, quoted values, escaped values, and empty values on pull
- upsert pushed secret values while preserving unrelated .env lines and comments

## Duplicate check
- checked existing open/closed PRs for "dotenvx", "secrets-dotenvx", and "dotenv" before submitting; none found
- checked #6 comments; dotenvx is only covered by the broad secrets/ stubs bucket, not an existing adapter PR

## Tests
- corepack pnpm test -- packages/secrets/dotenvx/src/index.test.ts
- corepack pnpm --filter @profullstack/sh1pt-secrets-dotenvx typecheck
- corepack pnpm --filter @profullstack/sh1pt-secrets-dotenvx build
- git diff --check

Relates to #6