### PR TITLE
Implement Sentry release creation

### DIFF
--- a/packages/observability/sentry/src/index.test.ts
+++ b/packages/observability/sentry/src/index.test.ts
@@ -1,4 +1,73 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'observability' });
+
+describe('Sentry release API integration', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('creates a release and deployment through the Sentry REST API', async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    vi.stubGlobal('fetch', async (url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      if (url.endsWith('/deploys/')) {
+        return new Response(JSON.stringify({ environment: 'production' }), {
+          status: 201,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({
+        version: 'web@1.2.3',
+        url: 'https://sentry.io/organizations/acme/releases/web@1.2.3/',
+      }), { status: 201, headers: { 'content-type': 'application/json' } });
+    });
+
+    const result = await adapter.createRelease({
+      secret: (key) => key === 'SENTRY_AUTH_TOKEN' ? 'token_123' : undefined,
+      log: () => {},
+    }, {
+      version: 'web@1.2.3',
+      environment: 'production',
+    }, {
+      org: 'acme',
+      project: 'frontend',
+    });
+
+    expect(result).toEqual({
+      id: 'web@1.2.3',
+      url: 'https://sentry.io/organizations/acme/releases/web@1.2.3/',
+    });
+    expect(calls).toHaveLength(2);
+    const [releaseRequest, deployRequest] = calls;
+    expect(releaseRequest!.url).toBe('https://sentry.io/api/0/organizations/acme/releases/');
+    expect(releaseRequest!.init.method).toBe('POST');
+    expect(releaseRequest!.init.headers).toMatchObject({
+      Authorization: 'Bearer token_123',
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    });
+    expect(JSON.parse(releaseRequest!.init.body as string)).toEqual({
+      version: 'web@1.2.3',
+      projects: ['frontend'],
+    });
+    expect(deployRequest!.url).toBe('https://sentry.io/api/0/organizations/acme/releases/web%401.2.3/deploys/');
+    expect(JSON.parse(deployRequest!.init.body as string)).toEqual({ environment: 'production' });
+  });
+
+  it('surfaces Sentry API errors', async () => {
+    vi.stubGlobal('fetch', async () => new Response('invalid release', { status: 400 }));
+
+    await expect(adapter.createRelease({
+      secret: (key) => key === 'SENTRY_AUTH_TOKEN' ? 'token_123' : undefined,
+      log: () => {},
+    }, {
+      version: 'bad',
+    }, {
+      org: 'acme',
+      project: 'frontend',
+    })).rejects.toThrow('invalid release');
+  });
+});

--- a/packages/observability/sentry/src/index.ts
+++ b/packages/observability/sentry/src/index.ts
@@ -3,6 +3,46 @@ import { defineObservabilityProvider, manualSetup, type ObservabilityRelease } f
 interface Config {
   org: string;
   project: string;
+  baseUrl?: string;
+}
+
+type SentryReleaseResponse = {
+  version?: string;
+  url?: string;
+};
+
+const DEFAULT_BASE_URL = 'https://sentry.io';
+const SENTRY_TOKEN_SECRET = 'SENTRY_AUTH_TOKEN';
+
+function sentryBaseUrl(config: Config): string {
+  return (config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, '');
+}
+
+function apiUrl(config: Config, path: string): string {
+  return `${sentryBaseUrl(config)}/api/0${path}`;
+}
+
+function authorizationHeader(token: string): string {
+  return token.toLowerCase().startsWith('bearer ') ? token : `Bearer ${token}`;
+}
+
+async function sentryPost<T>(token: string, url: string, body: unknown): Promise<T> {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: authorizationHeader(token),
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Sentry API request failed (${response.status}): ${text.slice(0, 300)}`);
+  }
+
+  return await response.json() as T;
 }
 
 export default defineObservabilityProvider<Config>({
@@ -10,24 +50,46 @@ export default defineObservabilityProvider<Config>({
   label: 'Sentry',
   cli: 'sentry-cli',
   async connect(ctx, config) {
-    if (!ctx.secret('SENTRY_AUTH_TOKEN')) throw new Error('SENTRY_AUTH_TOKEN not in vault');
+    if (!ctx.secret(SENTRY_TOKEN_SECRET)) throw new Error(`${SENTRY_TOKEN_SECRET} not in vault`);
     ctx.log(`sentry-cli info · org=${config.org} · project=${config.project}`);
     return { accountId: `${config.org}/${config.project}` };
   },
   async createRelease(ctx, release: ObservabilityRelease, config) {
+    const token = ctx.secret(SENTRY_TOKEN_SECRET);
+    if (!token) throw new Error(`${SENTRY_TOKEN_SECRET} not in vault`);
     const version = release.version;
-    ctx.log(`sentry-cli releases new ${version} --org ${config.org} --project ${config.project}`);
+    const project = release.project ?? config.project;
+    ctx.log(`sentry release create · org=${config.org} · project=${project} · version=${version}`);
+
+    const created = await sentryPost<SentryReleaseResponse>(
+      token,
+      apiUrl(config, `/organizations/${config.org}/releases/`),
+      { version, projects: [project] },
+    );
+
+    if (release.environment) {
+      ctx.log(`sentry deploy create · release=${version} · environment=${release.environment}`);
+      await sentryPost<Record<string, unknown>>(
+        token,
+        apiUrl(config, `/organizations/${config.org}/releases/${encodeURIComponent(version)}/deploys/`),
+        { environment: release.environment },
+      );
+    }
+
     for (const artifact of release.artifacts ?? []) {
       ctx.log(`sentry-cli sourcemaps upload ${artifact} --release ${version}`);
     }
-    return { id: version, url: `https://sentry.io/organizations/${config.org}/releases/${version}/` };
+    return {
+      id: created.version ?? version,
+      url: created.url ?? `${sentryBaseUrl(config)}/organizations/${config.org}/releases/${encodeURIComponent(version)}/`,
+    };
   },
   setup: manualSetup({
     label: 'Sentry CLI',
-    vendorDocUrl: 'https://cli.sentry.dev/',
+    vendorDocUrl: 'https://docs.sentry.io/api/releases/create-a-new-release-for-an-organization/',
     steps: [
-      'Install sentry-cli from the official docs',
-      'Create an auth token with project:releases and org:read scopes',
+      'Create a Sentry auth token with project:releases scope',
+      'Add org:read too if you also use sentry-cli locally',
       'Run: sh1pt secret set SENTRY_AUTH_TOKEN <token>',
     ],
   }),


### PR DESCRIPTION
## Summary
- replace the Sentry observability stub with real Sentry REST API release creation
- create optional deploy records when the release includes an environment
- surface Sentry API errors and keep setup guidance aligned with the release API scopes

## Duplicate check
- checked existing open/closed PRs for "sentry" and "observability-sentry" before submitting; none found
- checked #6 comments; Sentry is only covered by the broad observability stub bucket, not an existing adapter PR

## Tests
- corepack pnpm test -- packages/observability/sentry/src/index.test.ts
- corepack pnpm --filter @profullstack/sh1pt-observability-sentry typecheck
- corepack pnpm --filter @profullstack/sh1pt-observability-sentry build
- git diff --check

Relates to #6