### PR TITLE
feat: add DNS provider integrations (DigitalOcean, Route53, DNSimple, Azure, GCP, Namecheap)

### DIFF
--- a/packages/dns/azure/package.json
+++ b/packages/dns/azure/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@profullstack/sh1pt-dns-azure",
+  "name": "@sh1pt/dns-azure",
   "version": "0.1.0",
   "type": "module",
   "main": "./src/index.ts",
@@ -9,7 +9,7 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@profullstack/sh1pt-core": "workspace:*"
+    "@sh1pt/core": "workspace:*"
   },
   "license": "MIT",
   "repository": {

--- a/packages/dns/azure/package.json
+++ b/packages/dns/azure/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@profullstack/sh1pt-dns-azure",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "pnpm build"
+  },
+  "dependencies": {
+    "@profullstack/sh1pt-core": "workspace:*"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/profullstack/sh1pt.git",
+    "directory": "packages/dns/azure"
+  },
+  "homepage": "https://sh1pt.com",
+  "bugs": "https://github.com/profullstack/sh1pt/issues",
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
+}

--- a/packages/dns/azure/src/index.test.ts
+++ b/packages/dns/azure/src/index.test.ts
@@ -1,0 +1,7 @@
+import { contractTestDns } from '@sh1pt/core/testing';
+import dns from './index.js';
+
+contractTestDns(dns, {
+  sampleConfig: {},
+  requiredSecrets: ['AZURE_CLIENT_ID', 'AZURE_CLIENT_SECRET', 'AZURE_TENANT_ID'],
+});

--- a/packages/dns/azure/src/index.ts
+++ b/packages/dns/azure/src/index.ts
@@ -1,0 +1,180 @@
+import { defineDns, tokenSetup, type DnsRecord } from '@profullstack/sh1pt-core';
+
+// Azure DNS REST API (2018-05-01). Auth: Azure AD service principal
+// (client credentials flow → access token for management.azure.com).
+// Endpoints:
+//   GET  /subscriptions/:sub/resourceGroups/:rg/providers/Microsoft.Network/dnsZones
+//   GET  /subscriptions/:sub/resourceGroups/:rg/providers/Microsoft.Network/dnsZones/:zone/recordSets
+//   PUT  /…/dnsZones/:zone/recordSets/:type/:name  — create or update
+//   DELETE /…/dnsZones/:zone/recordSets/:type/:name
+// Azure DNS ALIAS record: a RecordSet of type A/AAAA with an AliasConfiguration
+// pointing to another Azure resource. For generic CNAME-at-apex use, set
+// type=CNAME (not available on zone apex); prefer ALIAS for apex pointing.
+interface Config {
+  subscriptionId?: string;
+  resourceGroupName?: string;
+  defaultTtl?: number;
+}
+
+const MGMT = 'https://management.azure.com';
+const API_VERSION = '2018-05-01';
+
+async function getAccessToken(ctx: { secret(k: string): string | undefined }): Promise<string> {
+  const tenantId = ctx.secret('AZURE_TENANT_ID');
+  const clientId = ctx.secret('AZURE_CLIENT_ID');
+  const clientSecret = ctx.secret('AZURE_CLIENT_SECRET');
+  if (!tenantId || !clientId || !clientSecret) {
+    throw new Error('AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET not set');
+  }
+  const res = await fetch(`https://login.microsoftonline.com/${tenantId}/oauth2/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'client_credentials',
+      client_id: clientId,
+      client_secret: clientSecret,
+      resource: 'https://management.azure.com/',
+    }),
+  });
+  if (!res.ok) throw new Error(`Azure getAccessToken: ${res.status}`);
+  const { access_token } = await res.json() as { access_token: string };
+  return access_token;
+}
+
+export default defineDns<Config>({
+  id: 'dns-azure',
+  label: 'Azure DNS',
+
+  async connect(ctx) {
+    await getAccessToken(ctx);
+    return { accountId: 'azure' };
+  },
+
+  async listZones(ctx, config) {
+    const token = await getAccessToken(ctx);
+    const sub = config.subscriptionId ?? ctx.secret('AZURE_SUBSCRIPTION_ID');
+    const rg = config.resourceGroupName ?? ctx.secret('AZURE_RESOURCE_GROUP');
+    if (!sub || !rg) throw new Error('AZURE_SUBSCRIPTION_ID / AZURE_RESOURCE_GROUP not set');
+    const res = await fetch(
+      `${MGMT}/subscriptions/${sub}/resourceGroups/${rg}/providers/Microsoft.Network/dnsZones?api-version=${API_VERSION}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    if (!res.ok) throw new Error(`Azure listZones: ${res.status}`);
+    const { value } = await res.json() as { value: { name: string }[] };
+    return value.map(z => ({ id: z.name, name: z.name }));
+  },
+
+  async listRecords(zoneId, ctx, config) {
+    const token = await getAccessToken(ctx);
+    const sub = config.subscriptionId ?? ctx.secret('AZURE_SUBSCRIPTION_ID');
+    const rg = config.resourceGroupName ?? ctx.secret('AZURE_RESOURCE_GROUP');
+    if (!sub || !rg) throw new Error('AZURE_SUBSCRIPTION_ID / AZURE_RESOURCE_GROUP not set');
+    const res = await fetch(
+      `${MGMT}/subscriptions/${sub}/resourceGroups/${rg}/providers/Microsoft.Network/dnsZones/${zoneId}/recordSets?api-version=${API_VERSION}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    if (!res.ok) throw new Error(`Azure listRecords: ${res.status}`);
+    const { value } = await res.json() as {
+      value: {
+        name: string;
+        type: string;
+        properties: { TTL: number; ARecords?: { ipv4Address: string }[]; CNAMERecord?: { cname: string } };
+        etag: string;
+      }[];
+    };
+    const records: DnsRecord[] = [];
+    for (const rs of value) {
+      const rtype = rs.type.split('/').pop() ?? rs.type;
+      const fqdn = rs.name === '@' ? zoneId : `${rs.name}.${zoneId}`;
+      if (rtype === 'A' && rs.properties.ARecords) {
+        for (const a of rs.properties.ARecords) {
+          records.push({ id: rs.etag, zone: zoneId, name: fqdn, type: 'A', value: a.ipv4Address, ttl: rs.properties.TTL });
+        }
+      } else if (rtype === 'CNAME' && rs.properties.CNAMERecord) {
+        records.push({ id: rs.etag, zone: zoneId, name: fqdn, type: 'CNAME', value: rs.properties.CNAMERecord.cname, ttl: rs.properties.TTL });
+      }
+    }
+    return records;
+  },
+
+  async upsertRecord(zoneId, record, config, ctx) {
+    const token = await getAccessToken(ctx);
+    const sub = config.subscriptionId ?? ctx.secret('AZURE_SUBSCRIPTION_ID');
+    const rg = config.resourceGroupName ?? ctx.secret('AZURE_RESOURCE_GROUP');
+    if (!sub || !rg) throw new Error('AZURE_SUBSCRIPTION_ID / AZURE_RESOURCE_GROUP not set');
+    const ttl = record.ttl ?? config.defaultTtl ?? 3600;
+    const name = record.name.endsWith(`.${zoneId}`)
+      ? record.name.slice(0, -(zoneId.length + 1))
+      : record.name === zoneId ? '@' : record.name;
+    const body =
+      record.type === 'A'
+        ? { properties: { TTL: ttl, ARecords: [{ ipv4Address: record.value }] } }
+        : { properties: { TTL: ttl, CNAMERecord: { cname: record.value } } };
+
+    const res = await fetch(
+      `${MGMT}/subscriptions/${sub}/resourceGroups/${rg}/providers/Microsoft.Network/dnsZones/${zoneId}/${record.type}/${name}?api-version=${API_VERSION}`,
+      { method: 'PUT', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }, body: JSON.stringify(body) },
+    );
+    if (!res.ok) throw new Error(`Azure upsertRecord: ${res.status}`);
+    const { etag } = await res.json() as { etag: string };
+    return { ...record, id: etag, zone: zoneId };
+  },
+
+  async deleteRecord(zoneId, recordId, ctx, config) {
+    // recordId here is the record name (not Azure etag) — caller should pass the name
+    const token = await getAccessToken(ctx);
+    const sub = config.subscriptionId ?? ctx.secret('AZURE_SUBSCRIPTION_ID');
+    const rg = config.resourceGroupName ?? ctx.secret('AZURE_RESOURCE_GROUP');
+    if (!sub || !rg) throw new Error('AZURE_SUBSCRIPTION_ID / AZURE_RESOURCE_GROUP not set');
+    // Azure requires type in the URL; we cannot delete by etag alone.
+    // Convention: pass recordId as "<type>/<name>" (e.g. "A/@")
+    const [type, name] = recordId.includes('/') ? recordId.split('/') : ['A', recordId];
+    const res = await fetch(
+      `${MGMT}/subscriptions/${sub}/resourceGroups/${rg}/providers/Microsoft.Network/dnsZones/${zoneId}/${type}/${name}?api-version=${API_VERSION}`,
+      { method: 'DELETE', headers: { Authorization: `Bearer ${token}` } },
+    );
+    if (!res.ok && res.status !== 404) throw new Error(`Azure deleteRecord: ${res.status}`);
+  },
+
+  async syncRoundRobin({ zoneId, name, ips, ttl }, config, ctx) {
+    // Azure stores all A records for a name in one RecordSet; sync by PUT with full set.
+    const token = await getAccessToken(ctx);
+    const sub = config.subscriptionId ?? ctx.secret('AZURE_SUBSCRIPTION_ID');
+    const rg = config.resourceGroupName ?? ctx.secret('AZURE_RESOURCE_GROUP');
+    if (!sub || !rg) throw new Error('AZURE_SUBSCRIPTION_ID / AZURE_RESOURCE_GROUP not set');
+    const ttlFinal = ttl ?? config.defaultTtl ?? 3600;
+    const relName = name.endsWith(`.${zoneId}`) ? name.slice(0, -(zoneId.length + 1)) : '@';
+    const body = { properties: { TTL: ttlFinal, ARecords: ips.map(ip => ({ ipv4Address: ip })) } };
+    const res = await fetch(
+      `${MGMT}/subscriptions/${sub}/resourceGroups/${rg}/providers/Microsoft.Network/dnsZones/${zoneId}/A/${relName}?api-version=${API_VERSION}`,
+      { method: 'PUT', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }, body: JSON.stringify(body) },
+    );
+    if (!res.ok) throw new Error(`Azure syncRoundRobin: ${res.status}`);
+    return ips.map((ip, i) => ({
+      id: `azure-rr-${i}`,
+      zone: zoneId,
+      name,
+      type: 'A' as const,
+      value: ip,
+      ttl: ttlFinal,
+    })) satisfies DnsRecord[];
+  },
+
+  setup: tokenSetup<Config>({
+    secretKey: 'AZURE_CLIENT_ID',
+    label: 'Azure DNS',
+    vendorDocUrl: 'https://learn.microsoft.com/azure/dns/dns-alias',
+    steps: [
+      'Open Azure Portal → Microsoft Entra ID → App registrations → New registration',
+      'Add a client secret under Certificates & secrets → copy the value',
+      'Assign the DNS Zone Contributor role on your resource group to this app',
+      'Note the Tenant ID, Client ID, Subscription ID, and Resource Group name',
+    ],
+    fields: [
+      { key: 'AZURE_CLIENT_SECRET', message: 'Paste the Azure Client Secret:', secret: true, required: true },
+      { key: 'AZURE_TENANT_ID', message: 'Paste the Azure Tenant ID:', required: true },
+      { key: 'AZURE_SUBSCRIPTION_ID', message: 'Paste the Azure Subscription ID:', required: true },
+      { key: 'AZURE_RESOURCE_GROUP', message: 'Paste the Azure Resource Group name:', required: true },
+    ],
+  }),
+});

--- a/packages/dns/azure/src/index.ts
+++ b/packages/dns/azure/src/index.ts
@@ -1,4 +1,4 @@
-import { defineDns, tokenSetup, type DnsRecord } from '@profullstack/sh1pt-core';
+import { defineDns, type DnsRecord } from '@sh1pt/core';
 
 // Azure DNS REST API (2018-05-01). Auth: Azure AD service principal
 // (client credentials flow → access token for management.azure.com).
@@ -18,11 +18,12 @@ interface Config {
 
 const MGMT = 'https://management.azure.com';
 const API_VERSION = '2018-05-01';
+let _secret: (k: string) => string | undefined = () => undefined;
 
-async function getAccessToken(ctx: { secret(k: string): string | undefined }): Promise<string> {
-  const tenantId = ctx.secret('AZURE_TENANT_ID');
-  const clientId = ctx.secret('AZURE_CLIENT_ID');
-  const clientSecret = ctx.secret('AZURE_CLIENT_SECRET');
+async function getAccessToken(): Promise<string> {
+  const tenantId = _secret('AZURE_TENANT_ID');
+  const clientId = _secret('AZURE_CLIENT_ID');
+  const clientSecret = _secret('AZURE_CLIENT_SECRET');
   if (!tenantId || !clientId || !clientSecret) {
     throw new Error('AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET not set');
   }
@@ -41,20 +42,26 @@ async function getAccessToken(ctx: { secret(k: string): string | undefined }): P
   return access_token;
 }
 
+function subRg(config: Config): { sub: string; rg: string } {
+  const sub = config.subscriptionId ?? _secret('AZURE_SUBSCRIPTION_ID');
+  const rg = config.resourceGroupName ?? _secret('AZURE_RESOURCE_GROUP');
+  if (!sub || !rg) throw new Error('AZURE_SUBSCRIPTION_ID / AZURE_RESOURCE_GROUP not set');
+  return { sub, rg };
+}
+
 export default defineDns<Config>({
   id: 'dns-azure',
   label: 'Azure DNS',
 
   async connect(ctx) {
-    await getAccessToken(ctx);
+    _secret = (k) => ctx.secret(k);
+    await getAccessToken();
     return { accountId: 'azure' };
   },
 
-  async listZones(ctx, config) {
-    const token = await getAccessToken(ctx);
-    const sub = config.subscriptionId ?? ctx.secret('AZURE_SUBSCRIPTION_ID');
-    const rg = config.resourceGroupName ?? ctx.secret('AZURE_RESOURCE_GROUP');
-    if (!sub || !rg) throw new Error('AZURE_SUBSCRIPTION_ID / AZURE_RESOURCE_GROUP not set');
+  async listZones(config) {
+    const token = await getAccessToken();
+    const { sub, rg } = subRg(config);
     const res = await fetch(
       `${MGMT}/subscriptions/${sub}/resourceGroups/${rg}/providers/Microsoft.Network/dnsZones?api-version=${API_VERSION}`,
       { headers: { Authorization: `Bearer ${token}` } },
@@ -64,11 +71,9 @@ export default defineDns<Config>({
     return value.map(z => ({ id: z.name, name: z.name }));
   },
 
-  async listRecords(zoneId, ctx, config) {
-    const token = await getAccessToken(ctx);
-    const sub = config.subscriptionId ?? ctx.secret('AZURE_SUBSCRIPTION_ID');
-    const rg = config.resourceGroupName ?? ctx.secret('AZURE_RESOURCE_GROUP');
-    if (!sub || !rg) throw new Error('AZURE_SUBSCRIPTION_ID / AZURE_RESOURCE_GROUP not set');
+  async listRecords(zoneId, config) {
+    const token = await getAccessToken();
+    const { sub, rg } = subRg(config);
     const res = await fetch(
       `${MGMT}/subscriptions/${sub}/resourceGroups/${rg}/providers/Microsoft.Network/dnsZones/${zoneId}/recordSets?api-version=${API_VERSION}`,
       { headers: { Authorization: `Bearer ${token}` } },
@@ -97,11 +102,9 @@ export default defineDns<Config>({
     return records;
   },
 
-  async upsertRecord(zoneId, record, config, ctx) {
-    const token = await getAccessToken(ctx);
-    const sub = config.subscriptionId ?? ctx.secret('AZURE_SUBSCRIPTION_ID');
-    const rg = config.resourceGroupName ?? ctx.secret('AZURE_RESOURCE_GROUP');
-    if (!sub || !rg) throw new Error('AZURE_SUBSCRIPTION_ID / AZURE_RESOURCE_GROUP not set');
+  async upsertRecord(zoneId, record, config) {
+    const token = await getAccessToken();
+    const { sub, rg } = subRg(config);
     const ttl = record.ttl ?? config.defaultTtl ?? 3600;
     const name = record.name.endsWith(`.${zoneId}`)
       ? record.name.slice(0, -(zoneId.length + 1))
@@ -120,12 +123,10 @@ export default defineDns<Config>({
     return { ...record, id: etag, zone: zoneId };
   },
 
-  async deleteRecord(zoneId, recordId, ctx, config) {
+  async deleteRecord(zoneId, recordId, config) {
     // recordId here is the record name (not Azure etag) — caller should pass the name
-    const token = await getAccessToken(ctx);
-    const sub = config.subscriptionId ?? ctx.secret('AZURE_SUBSCRIPTION_ID');
-    const rg = config.resourceGroupName ?? ctx.secret('AZURE_RESOURCE_GROUP');
-    if (!sub || !rg) throw new Error('AZURE_SUBSCRIPTION_ID / AZURE_RESOURCE_GROUP not set');
+    const token = await getAccessToken();
+    const { sub, rg } = subRg(config);
     // Azure requires type in the URL; we cannot delete by etag alone.
     // Convention: pass recordId as "<type>/<name>" (e.g. "A/@")
     const [type, name] = recordId.includes('/') ? recordId.split('/') : ['A', recordId];
@@ -136,12 +137,10 @@ export default defineDns<Config>({
     if (!res.ok && res.status !== 404) throw new Error(`Azure deleteRecord: ${res.status}`);
   },
 
-  async syncRoundRobin({ zoneId, name, ips, ttl }, config, ctx) {
+  async syncRoundRobin({ zoneId, name, ips, ttl }, config) {
     // Azure stores all A records for a name in one RecordSet; sync by PUT with full set.
-    const token = await getAccessToken(ctx);
-    const sub = config.subscriptionId ?? ctx.secret('AZURE_SUBSCRIPTION_ID');
-    const rg = config.resourceGroupName ?? ctx.secret('AZURE_RESOURCE_GROUP');
-    if (!sub || !rg) throw new Error('AZURE_SUBSCRIPTION_ID / AZURE_RESOURCE_GROUP not set');
+    const token = await getAccessToken();
+    const { sub, rg } = subRg(config);
     const ttlFinal = ttl ?? config.defaultTtl ?? 3600;
     const relName = name.endsWith(`.${zoneId}`) ? name.slice(0, -(zoneId.length + 1)) : '@';
     const body = { properties: { TTL: ttlFinal, ARecords: ips.map(ip => ({ ipv4Address: ip })) } };
@@ -159,22 +158,4 @@ export default defineDns<Config>({
       ttl: ttlFinal,
     })) satisfies DnsRecord[];
   },
-
-  setup: tokenSetup<Config>({
-    secretKey: 'AZURE_CLIENT_ID',
-    label: 'Azure DNS',
-    vendorDocUrl: 'https://learn.microsoft.com/azure/dns/dns-alias',
-    steps: [
-      'Open Azure Portal → Microsoft Entra ID → App registrations → New registration',
-      'Add a client secret under Certificates & secrets → copy the value',
-      'Assign the DNS Zone Contributor role on your resource group to this app',
-      'Note the Tenant ID, Client ID, Subscription ID, and Resource Group name',
-    ],
-    fields: [
-      { key: 'AZURE_CLIENT_SECRET', message: 'Paste the Azure Client Secret:', secret: true, required: true },
-      { key: 'AZURE_TENANT_ID', message: 'Paste the Azure Tenant ID:', required: true },
-      { key: 'AZURE_SUBSCRIPTION_ID', message: 'Paste the Azure Subscription ID:', required: true },
-      { key: 'AZURE_RESOURCE_GROUP', message: 'Paste the Azure Resource Group name:', required: true },
-    ],
-  }),
 });

--- a/packages/dns/azure/tsconfig.json
+++ b/packages/dns/azure/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"]
+}

--- a/packages/dns/digitalocean/package.json
+++ b/packages/dns/digitalocean/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@profullstack/sh1pt-dns-digitalocean",
+  "name": "@sh1pt/dns-digitalocean",
   "version": "0.1.0",
   "type": "module",
   "main": "./src/index.ts",
@@ -9,7 +9,7 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@profullstack/sh1pt-core": "workspace:*"
+    "@sh1pt/core": "workspace:*"
   },
   "license": "MIT",
   "repository": {

--- a/packages/dns/digitalocean/package.json
+++ b/packages/dns/digitalocean/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@profullstack/sh1pt-dns-digitalocean",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "pnpm build"
+  },
+  "dependencies": {
+    "@profullstack/sh1pt-core": "workspace:*"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/profullstack/sh1pt.git",
+    "directory": "packages/dns/digitalocean"
+  },
+  "homepage": "https://sh1pt.com",
+  "bugs": "https://github.com/profullstack/sh1pt/issues",
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
+}

--- a/packages/dns/digitalocean/src/index.test.ts
+++ b/packages/dns/digitalocean/src/index.test.ts
@@ -1,0 +1,7 @@
+import { contractTestDns } from '@sh1pt/core/testing';
+import dns from './index.js';
+
+contractTestDns(dns, {
+  sampleConfig: {},
+  requiredSecrets: ['DO_API_TOKEN'],
+});

--- a/packages/dns/digitalocean/src/index.ts
+++ b/packages/dns/digitalocean/src/index.ts
@@ -1,0 +1,121 @@
+import { defineDns, tokenSetup, type DnsRecord } from '@profullstack/sh1pt-core';
+
+// DigitalOcean DNS API v2. Auth: Bearer personal access token.
+// Endpoints:
+//   GET  /v2/domains                         — list all domains
+//   GET  /v2/domains/:domain/records          — list DNS records
+//   POST /v2/domains/:domain/records          — create a record
+//   PUT  /v2/domains/:domain/records/:id      — update a record
+//   DELETE /v2/domains/:domain/records/:id    — delete a record
+// DigitalOcean uses A records (not ALIAS) for domain apex pointing.
+interface Config {
+  defaultTtl?: number;
+}
+
+const API = 'https://api.digitalocean.com/v2';
+
+function authHeader(ctx: { secret(k: string): string | undefined }) {
+  return { Authorization: `Bearer ${ctx.secret('DO_API_TOKEN')}` };
+}
+
+export default defineDns<Config>({
+  id: 'dns-digitalocean',
+  label: 'DigitalOcean DNS',
+
+  async connect(ctx) {
+    if (!ctx.secret('DO_API_TOKEN')) throw new Error('DO_API_TOKEN not set');
+    return { accountId: 'digitalocean' };
+  },
+
+  async listZones(ctx) {
+    const res = await fetch(`${API}/domains`, { headers: authHeader(ctx) });
+    if (!res.ok) throw new Error(`DigitalOcean listZones: ${res.status}`);
+    const { domains } = await res.json() as { domains: { name: string }[] };
+    return domains.map(d => ({ id: d.name, name: d.name }));
+  },
+
+  async listRecords(zoneId, ctx) {
+    const res = await fetch(`${API}/domains/${zoneId}/records?per_page=200`, {
+      headers: authHeader(ctx),
+    });
+    if (!res.ok) throw new Error(`DigitalOcean listRecords: ${res.status}`);
+    const { domain_records } = await res.json() as {
+      domain_records: { id: number; name: string; type: string; data: string; ttl: number }[];
+    };
+    return domain_records.map(r => ({
+      id: String(r.id),
+      zone: zoneId,
+      name: r.name === '@' ? zoneId : `${r.name}.${zoneId}`,
+      type: r.type as DnsRecord['type'],
+      value: r.data,
+      ttl: r.ttl,
+    }));
+  },
+
+  async upsertRecord(zoneId, record, config, ctx) {
+    const ttl = record.ttl ?? config.defaultTtl ?? 1800;
+    const subdomain = record.name.endsWith(`.${zoneId}`)
+      ? record.name.slice(0, -(zoneId.length + 1))
+      : record.name === zoneId ? '@' : record.name;
+
+    const existing = await this.listRecords(zoneId, ctx);
+    const match = existing.find(r => r.name === record.name && r.type === record.type);
+
+    if (match) {
+      const res = await fetch(`${API}/domains/${zoneId}/records/${match.id}`, {
+        method: 'PUT',
+        headers: { ...authHeader(ctx), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data: record.value, ttl }),
+      });
+      if (!res.ok) throw new Error(`DigitalOcean upsertRecord (update): ${res.status}`);
+      return { ...record, id: match.id, zone: zoneId };
+    }
+
+    const res = await fetch(`${API}/domains/${zoneId}/records`, {
+      method: 'POST',
+      headers: { ...authHeader(ctx), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ type: record.type, name: subdomain, data: record.value, ttl }),
+    });
+    if (!res.ok) throw new Error(`DigitalOcean upsertRecord (create): ${res.status}`);
+    const { domain_record } = await res.json() as { domain_record: { id: number } };
+    return { ...record, id: String(domain_record.id), zone: zoneId };
+  },
+
+  async deleteRecord(zoneId, recordId, ctx) {
+    const res = await fetch(`${API}/domains/${zoneId}/records/${recordId}`, {
+      method: 'DELETE',
+      headers: authHeader(ctx),
+    });
+    if (!res.ok && res.status !== 404) throw new Error(`DigitalOcean deleteRecord: ${res.status}`);
+  },
+
+  async syncRoundRobin({ zoneId, name, ips, ttl }, config, ctx) {
+    const ttlFinal = ttl ?? config.defaultTtl ?? 1800;
+    const existing = (await this.listRecords(zoneId, ctx)).filter(
+      r => r.name === name && r.type === 'A',
+    );
+
+    const toDelete = existing.filter(r => !ips.includes(r.value));
+    const toCreate = ips.filter(ip => !existing.some(r => r.value === ip));
+
+    await Promise.all(toDelete.map(r => this.deleteRecord(zoneId, r.id, ctx)));
+    const created = await Promise.all(
+      toCreate.map(ip =>
+        this.upsertRecord(zoneId, { id: '', zone: zoneId, name, type: 'A', value: ip, ttl: ttlFinal }, config, ctx),
+      ),
+    );
+
+    return [...existing.filter(r => ips.includes(r.value)), ...created] as DnsRecord[];
+  },
+
+  setup: tokenSetup<Config>({
+    secretKey: 'DO_API_TOKEN',
+    label: 'DigitalOcean DNS',
+    vendorDocUrl: 'https://cloud.digitalocean.com/account/api/tokens',
+    steps: [
+      'Open cloud.digitalocean.com → API → Tokens → Generate New Token',
+      'Give it a name (e.g. sh1pt-dns), enable Write scope',
+      'Copy the token — it is shown only once',
+    ],
+  }),
+});

--- a/packages/dns/digitalocean/src/index.ts
+++ b/packages/dns/digitalocean/src/index.ts
@@ -1,4 +1,4 @@
-import { defineDns, tokenSetup, type DnsRecord } from '@profullstack/sh1pt-core';
+import { defineDns, type DnsRecord } from '@sh1pt/core';
 
 // DigitalOcean DNS API v2. Auth: Bearer personal access token.
 // Endpoints:
@@ -13,9 +13,10 @@ interface Config {
 }
 
 const API = 'https://api.digitalocean.com/v2';
+let _secret: (k: string) => string | undefined = () => undefined;
 
-function authHeader(ctx: { secret(k: string): string | undefined }) {
-  return { Authorization: `Bearer ${ctx.secret('DO_API_TOKEN')}` };
+function authHeader() {
+  return { Authorization: `Bearer ${_secret('DO_API_TOKEN')}` };
 }
 
 export default defineDns<Config>({
@@ -23,20 +24,21 @@ export default defineDns<Config>({
   label: 'DigitalOcean DNS',
 
   async connect(ctx) {
+    _secret = (k) => ctx.secret(k);
     if (!ctx.secret('DO_API_TOKEN')) throw new Error('DO_API_TOKEN not set');
     return { accountId: 'digitalocean' };
   },
 
-  async listZones(ctx) {
-    const res = await fetch(`${API}/domains`, { headers: authHeader(ctx) });
+  async listZones() {
+    const res = await fetch(`${API}/domains`, { headers: authHeader() });
     if (!res.ok) throw new Error(`DigitalOcean listZones: ${res.status}`);
     const { domains } = await res.json() as { domains: { name: string }[] };
     return domains.map(d => ({ id: d.name, name: d.name }));
   },
 
-  async listRecords(zoneId, ctx) {
+  async listRecords(zoneId) {
     const res = await fetch(`${API}/domains/${zoneId}/records?per_page=200`, {
-      headers: authHeader(ctx),
+      headers: authHeader(),
     });
     if (!res.ok) throw new Error(`DigitalOcean listRecords: ${res.status}`);
     const { domain_records } = await res.json() as {
@@ -52,19 +54,19 @@ export default defineDns<Config>({
     }));
   },
 
-  async upsertRecord(zoneId, record, config, ctx) {
+  async upsertRecord(zoneId, record, config) {
     const ttl = record.ttl ?? config.defaultTtl ?? 1800;
     const subdomain = record.name.endsWith(`.${zoneId}`)
       ? record.name.slice(0, -(zoneId.length + 1))
       : record.name === zoneId ? '@' : record.name;
 
-    const existing = await this.listRecords(zoneId, ctx);
+    const existing = await this.listRecords(zoneId, config);
     const match = existing.find(r => r.name === record.name && r.type === record.type);
 
     if (match) {
       const res = await fetch(`${API}/domains/${zoneId}/records/${match.id}`, {
         method: 'PUT',
-        headers: { ...authHeader(ctx), 'Content-Type': 'application/json' },
+        headers: { ...authHeader(), 'Content-Type': 'application/json' },
         body: JSON.stringify({ data: record.value, ttl }),
       });
       if (!res.ok) throw new Error(`DigitalOcean upsertRecord (update): ${res.status}`);
@@ -73,7 +75,7 @@ export default defineDns<Config>({
 
     const res = await fetch(`${API}/domains/${zoneId}/records`, {
       method: 'POST',
-      headers: { ...authHeader(ctx), 'Content-Type': 'application/json' },
+      headers: { ...authHeader(), 'Content-Type': 'application/json' },
       body: JSON.stringify({ type: record.type, name: subdomain, data: record.value, ttl }),
     });
     if (!res.ok) throw new Error(`DigitalOcean upsertRecord (create): ${res.status}`);
@@ -81,41 +83,30 @@ export default defineDns<Config>({
     return { ...record, id: String(domain_record.id), zone: zoneId };
   },
 
-  async deleteRecord(zoneId, recordId, ctx) {
+  async deleteRecord(zoneId, recordId) {
     const res = await fetch(`${API}/domains/${zoneId}/records/${recordId}`, {
       method: 'DELETE',
-      headers: authHeader(ctx),
+      headers: authHeader(),
     });
     if (!res.ok && res.status !== 404) throw new Error(`DigitalOcean deleteRecord: ${res.status}`);
   },
 
-  async syncRoundRobin({ zoneId, name, ips, ttl }, config, ctx) {
+  async syncRoundRobin({ zoneId, name, ips, ttl }, config) {
     const ttlFinal = ttl ?? config.defaultTtl ?? 1800;
-    const existing = (await this.listRecords(zoneId, ctx)).filter(
+    const existing = (await this.listRecords(zoneId, config)).filter(
       r => r.name === name && r.type === 'A',
     );
 
     const toDelete = existing.filter(r => !ips.includes(r.value));
     const toCreate = ips.filter(ip => !existing.some(r => r.value === ip));
 
-    await Promise.all(toDelete.map(r => this.deleteRecord(zoneId, r.id, ctx)));
+    await Promise.all(toDelete.map(r => this.deleteRecord(zoneId, r.id, config)));
     const created = await Promise.all(
       toCreate.map(ip =>
-        this.upsertRecord(zoneId, { id: '', zone: zoneId, name, type: 'A', value: ip, ttl: ttlFinal }, config, ctx),
+        this.upsertRecord(zoneId, { zone: zoneId, name, type: 'A', value: ip, ttl: ttlFinal }, config),
       ),
     );
 
     return [...existing.filter(r => ips.includes(r.value)), ...created] as DnsRecord[];
   },
-
-  setup: tokenSetup<Config>({
-    secretKey: 'DO_API_TOKEN',
-    label: 'DigitalOcean DNS',
-    vendorDocUrl: 'https://cloud.digitalocean.com/account/api/tokens',
-    steps: [
-      'Open cloud.digitalocean.com → API → Tokens → Generate New Token',
-      'Give it a name (e.g. sh1pt-dns), enable Write scope',
-      'Copy the token — it is shown only once',
-    ],
-  }),
 });

--- a/packages/dns/digitalocean/tsconfig.json
+++ b/packages/dns/digitalocean/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"]
+}

--- a/packages/dns/dnsimple/package.json
+++ b/packages/dns/dnsimple/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@profullstack/sh1pt-dns-dnsimple",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "pnpm build"
+  },
+  "dependencies": {
+    "@profullstack/sh1pt-core": "workspace:*"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/profullstack/sh1pt.git",
+    "directory": "packages/dns/dnsimple"
+  },
+  "homepage": "https://sh1pt.com",
+  "bugs": "https://github.com/profullstack/sh1pt/issues",
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
+}

--- a/packages/dns/dnsimple/package.json
+++ b/packages/dns/dnsimple/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@profullstack/sh1pt-dns-dnsimple",
+  "name": "@sh1pt/dns-dnsimple",
   "version": "0.1.0",
   "type": "module",
   "main": "./src/index.ts",
@@ -9,7 +9,7 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@profullstack/sh1pt-core": "workspace:*"
+    "@sh1pt/core": "workspace:*"
   },
   "license": "MIT",
   "repository": {

--- a/packages/dns/dnsimple/src/index.test.ts
+++ b/packages/dns/dnsimple/src/index.test.ts
@@ -1,0 +1,7 @@
+import { contractTestDns } from '@sh1pt/core/testing';
+import dns from './index.js';
+
+contractTestDns(dns, {
+  sampleConfig: {},
+  requiredSecrets: ['DNSIMPLE_API_TOKEN'],
+});

--- a/packages/dns/dnsimple/src/index.ts
+++ b/packages/dns/dnsimple/src/index.ts
@@ -1,4 +1,4 @@
-import { defineDns, tokenSetup, type DnsRecord } from '@profullstack/sh1pt-core';
+import { defineDns, type DnsRecord } from '@sh1pt/core';
 
 // DNSimple DNS API v2. Auth: Bearer OAuth token or personal access token.
 // Endpoints (all under https://api.dnsimple.com/v2/:account_id):
@@ -15,18 +15,19 @@ interface Config {
 }
 
 const API = 'https://api.dnsimple.com/v2';
+let _secret: (k: string) => string | undefined = () => undefined;
 
-function authHeader(ctx: { secret(k: string): string | undefined }) {
+function authHeader() {
   return {
-    Authorization: `Bearer ${ctx.secret('DNSIMPLE_API_TOKEN')}`,
+    Authorization: `Bearer ${_secret('DNSIMPLE_API_TOKEN')}`,
     Accept: 'application/json',
     'Content-Type': 'application/json',
   };
 }
 
-async function resolveAccountId(ctx: { secret(k: string): string | undefined }, config: Config): Promise<string> {
+async function resolveAccountId(config: Config): Promise<string> {
   if (config.accountId) return config.accountId;
-  const res = await fetch(`${API}/whoami`, { headers: authHeader(ctx) });
+  const res = await fetch(`${API}/whoami`, { headers: authHeader() });
   if (!res.ok) throw new Error(`DNSimple whoami: ${res.status}`);
   const { data } = await res.json() as { data: { account?: { id: number } } };
   if (!data.account) throw new Error('DNSimple: not authenticated as an account (user token?)');
@@ -38,22 +39,23 @@ export default defineDns<Config>({
   label: 'DNSimple',
 
   async connect(ctx) {
+    _secret = (k) => ctx.secret(k);
     if (!ctx.secret('DNSIMPLE_API_TOKEN')) throw new Error('DNSIMPLE_API_TOKEN not set');
     return { accountId: 'dnsimple' };
   },
 
-  async listZones(ctx, config) {
-    const accountId = await resolveAccountId(ctx, config);
-    const res = await fetch(`${API}/${accountId}/domains?per_page=100`, { headers: authHeader(ctx) });
+  async listZones(config) {
+    const accountId = await resolveAccountId(config);
+    const res = await fetch(`${API}/${accountId}/domains?per_page=100`, { headers: authHeader() });
     if (!res.ok) throw new Error(`DNSimple listZones: ${res.status}`);
     const { data } = await res.json() as { data: { id: number; name: string }[] };
     return data.map(d => ({ id: d.name, name: d.name }));
   },
 
-  async listRecords(zoneId, ctx, config) {
-    const accountId = await resolveAccountId(ctx, config);
+  async listRecords(zoneId, config) {
+    const accountId = await resolveAccountId(config);
     const res = await fetch(`${API}/${accountId}/zones/${zoneId}/records?per_page=100`, {
-      headers: authHeader(ctx),
+      headers: authHeader(),
     });
     if (!res.ok) throw new Error(`DNSimple listRecords: ${res.status}`);
     const { data } = await res.json() as {
@@ -69,21 +71,21 @@ export default defineDns<Config>({
     }));
   },
 
-  async upsertRecord(zoneId, record, config, ctx) {
-    const accountId = await resolveAccountId(ctx, config);
+  async upsertRecord(zoneId, record, config) {
+    const accountId = await resolveAccountId(config);
     const ttl = record.ttl ?? config.defaultTtl ?? 3600;
     const name = record.name.endsWith(`.${zoneId}`)
       ? record.name.slice(0, -(zoneId.length + 1))
       : record.name === zoneId ? '' : record.name;
 
-    const existing = (await this.listRecords(zoneId, ctx, config)).find(
+    const existing = (await this.listRecords(zoneId, config)).find(
       r => r.name === record.name && r.type === record.type,
     );
 
     if (existing) {
       const res = await fetch(`${API}/${accountId}/zones/${zoneId}/records/${existing.id}`, {
         method: 'PATCH',
-        headers: authHeader(ctx),
+        headers: authHeader(),
         body: JSON.stringify({ content: record.value, ttl }),
       });
       if (!res.ok) throw new Error(`DNSimple upsertRecord (update): ${res.status}`);
@@ -92,7 +94,7 @@ export default defineDns<Config>({
 
     const res = await fetch(`${API}/${accountId}/zones/${zoneId}/records`, {
       method: 'POST',
-      headers: authHeader(ctx),
+      headers: authHeader(),
       body: JSON.stringify({ name, type: record.type, content: record.value, ttl }),
     });
     if (!res.ok) throw new Error(`DNSimple upsertRecord (create): ${res.status}`);
@@ -100,39 +102,28 @@ export default defineDns<Config>({
     return { ...record, id: String(data.id), zone: zoneId };
   },
 
-  async deleteRecord(zoneId, recordId, ctx, config) {
-    const accountId = await resolveAccountId(ctx, config);
+  async deleteRecord(zoneId, recordId, config) {
+    const accountId = await resolveAccountId(config);
     const res = await fetch(`${API}/${accountId}/zones/${zoneId}/records/${recordId}`, {
       method: 'DELETE',
-      headers: authHeader(ctx),
+      headers: authHeader(),
     });
     if (!res.ok && res.status !== 404) throw new Error(`DNSimple deleteRecord: ${res.status}`);
   },
 
-  async syncRoundRobin({ zoneId, name, ips, ttl }, config, ctx) {
+  async syncRoundRobin({ zoneId, name, ips, ttl }, config) {
     const ttlFinal = ttl ?? config.defaultTtl ?? 3600;
-    const existing = (await this.listRecords(zoneId, ctx, config)).filter(
+    const existing = (await this.listRecords(zoneId, config)).filter(
       r => r.name === name && r.type === 'A',
     );
     const toDelete = existing.filter(r => !ips.includes(r.value));
     const toCreate = ips.filter(ip => !existing.some(r => r.value === ip));
-    await Promise.all(toDelete.map(r => this.deleteRecord(zoneId, r.id, ctx, config)));
+    await Promise.all(toDelete.map(r => this.deleteRecord(zoneId, r.id, config)));
     const created = await Promise.all(
       toCreate.map(ip =>
-        this.upsertRecord(zoneId, { id: '', zone: zoneId, name, type: 'A', value: ip, ttl: ttlFinal }, config, ctx),
+        this.upsertRecord(zoneId, { zone: zoneId, name, type: 'A', value: ip, ttl: ttlFinal }, config),
       ),
     );
     return [...existing.filter(r => ips.includes(r.value)), ...created] as DnsRecord[];
   },
-
-  setup: tokenSetup<Config>({
-    secretKey: 'DNSIMPLE_API_TOKEN',
-    label: 'DNSimple',
-    vendorDocUrl: 'https://support.dnsimple.com/articles/api-access-token/',
-    steps: [
-      'Open dnsimple.com → your account → API Access Tokens → New Access Token',
-      'Give it a name and choose account-level access',
-      'Copy the token — shown only once',
-    ],
-  }),
 });

--- a/packages/dns/dnsimple/src/index.ts
+++ b/packages/dns/dnsimple/src/index.ts
@@ -1,0 +1,138 @@
+import { defineDns, tokenSetup, type DnsRecord } from '@profullstack/sh1pt-core';
+
+// DNSimple DNS API v2. Auth: Bearer OAuth token or personal access token.
+// Endpoints (all under https://api.dnsimple.com/v2/:account_id):
+//   GET  /domains                              — list domains (zones)
+//   GET  /zones/:zone/records                  — list records
+//   POST /zones/:zone/records                  — create a record
+//   PATCH /zones/:zone/records/:id             — update a record
+//   DELETE /zones/:zone/records/:id            — delete a record
+// DNSimple ALIAS record: type=ALIAS, content=target hostname (FQDN).
+// ALIAS is the recommended way to point a bare domain to another hostname.
+interface Config {
+  accountId?: string;  // if empty, fetched from /whoami
+  defaultTtl?: number;
+}
+
+const API = 'https://api.dnsimple.com/v2';
+
+function authHeader(ctx: { secret(k: string): string | undefined }) {
+  return {
+    Authorization: `Bearer ${ctx.secret('DNSIMPLE_API_TOKEN')}`,
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+  };
+}
+
+async function resolveAccountId(ctx: { secret(k: string): string | undefined }, config: Config): Promise<string> {
+  if (config.accountId) return config.accountId;
+  const res = await fetch(`${API}/whoami`, { headers: authHeader(ctx) });
+  if (!res.ok) throw new Error(`DNSimple whoami: ${res.status}`);
+  const { data } = await res.json() as { data: { account?: { id: number } } };
+  if (!data.account) throw new Error('DNSimple: not authenticated as an account (user token?)');
+  return String(data.account.id);
+}
+
+export default defineDns<Config>({
+  id: 'dns-dnsimple',
+  label: 'DNSimple',
+
+  async connect(ctx) {
+    if (!ctx.secret('DNSIMPLE_API_TOKEN')) throw new Error('DNSIMPLE_API_TOKEN not set');
+    return { accountId: 'dnsimple' };
+  },
+
+  async listZones(ctx, config) {
+    const accountId = await resolveAccountId(ctx, config);
+    const res = await fetch(`${API}/${accountId}/domains?per_page=100`, { headers: authHeader(ctx) });
+    if (!res.ok) throw new Error(`DNSimple listZones: ${res.status}`);
+    const { data } = await res.json() as { data: { id: number; name: string }[] };
+    return data.map(d => ({ id: d.name, name: d.name }));
+  },
+
+  async listRecords(zoneId, ctx, config) {
+    const accountId = await resolveAccountId(ctx, config);
+    const res = await fetch(`${API}/${accountId}/zones/${zoneId}/records?per_page=100`, {
+      headers: authHeader(ctx),
+    });
+    if (!res.ok) throw new Error(`DNSimple listRecords: ${res.status}`);
+    const { data } = await res.json() as {
+      data: { id: number; name: string; type: string; content: string; ttl: number }[];
+    };
+    return data.map(r => ({
+      id: String(r.id),
+      zone: zoneId,
+      name: r.name ? `${r.name}.${zoneId}` : zoneId,
+      type: r.type as DnsRecord['type'],
+      value: r.content,
+      ttl: r.ttl,
+    }));
+  },
+
+  async upsertRecord(zoneId, record, config, ctx) {
+    const accountId = await resolveAccountId(ctx, config);
+    const ttl = record.ttl ?? config.defaultTtl ?? 3600;
+    const name = record.name.endsWith(`.${zoneId}`)
+      ? record.name.slice(0, -(zoneId.length + 1))
+      : record.name === zoneId ? '' : record.name;
+
+    const existing = (await this.listRecords(zoneId, ctx, config)).find(
+      r => r.name === record.name && r.type === record.type,
+    );
+
+    if (existing) {
+      const res = await fetch(`${API}/${accountId}/zones/${zoneId}/records/${existing.id}`, {
+        method: 'PATCH',
+        headers: authHeader(ctx),
+        body: JSON.stringify({ content: record.value, ttl }),
+      });
+      if (!res.ok) throw new Error(`DNSimple upsertRecord (update): ${res.status}`);
+      return { ...record, id: existing.id, zone: zoneId };
+    }
+
+    const res = await fetch(`${API}/${accountId}/zones/${zoneId}/records`, {
+      method: 'POST',
+      headers: authHeader(ctx),
+      body: JSON.stringify({ name, type: record.type, content: record.value, ttl }),
+    });
+    if (!res.ok) throw new Error(`DNSimple upsertRecord (create): ${res.status}`);
+    const { data } = await res.json() as { data: { id: number } };
+    return { ...record, id: String(data.id), zone: zoneId };
+  },
+
+  async deleteRecord(zoneId, recordId, ctx, config) {
+    const accountId = await resolveAccountId(ctx, config);
+    const res = await fetch(`${API}/${accountId}/zones/${zoneId}/records/${recordId}`, {
+      method: 'DELETE',
+      headers: authHeader(ctx),
+    });
+    if (!res.ok && res.status !== 404) throw new Error(`DNSimple deleteRecord: ${res.status}`);
+  },
+
+  async syncRoundRobin({ zoneId, name, ips, ttl }, config, ctx) {
+    const ttlFinal = ttl ?? config.defaultTtl ?? 3600;
+    const existing = (await this.listRecords(zoneId, ctx, config)).filter(
+      r => r.name === name && r.type === 'A',
+    );
+    const toDelete = existing.filter(r => !ips.includes(r.value));
+    const toCreate = ips.filter(ip => !existing.some(r => r.value === ip));
+    await Promise.all(toDelete.map(r => this.deleteRecord(zoneId, r.id, ctx, config)));
+    const created = await Promise.all(
+      toCreate.map(ip =>
+        this.upsertRecord(zoneId, { id: '', zone: zoneId, name, type: 'A', value: ip, ttl: ttlFinal }, config, ctx),
+      ),
+    );
+    return [...existing.filter(r => ips.includes(r.value)), ...created] as DnsRecord[];
+  },
+
+  setup: tokenSetup<Config>({
+    secretKey: 'DNSIMPLE_API_TOKEN',
+    label: 'DNSimple',
+    vendorDocUrl: 'https://support.dnsimple.com/articles/api-access-token/',
+    steps: [
+      'Open dnsimple.com → your account → API Access Tokens → New Access Token',
+      'Give it a name and choose account-level access',
+      'Copy the token — shown only once',
+    ],
+  }),
+});

--- a/packages/dns/dnsimple/tsconfig.json
+++ b/packages/dns/dnsimple/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"]
+}

--- a/packages/dns/googledns/package.json
+++ b/packages/dns/googledns/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@profullstack/sh1pt-dns-googledns",
+  "name": "@sh1pt/dns-googledns",
   "version": "0.1.0",
   "type": "module",
   "main": "./src/index.ts",
@@ -9,7 +9,7 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@profullstack/sh1pt-core": "workspace:*"
+    "@sh1pt/core": "workspace:*"
   },
   "license": "MIT",
   "repository": {

--- a/packages/dns/googledns/package.json
+++ b/packages/dns/googledns/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@profullstack/sh1pt-dns-googledns",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "pnpm build"
+  },
+  "dependencies": {
+    "@profullstack/sh1pt-core": "workspace:*"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/profullstack/sh1pt.git",
+    "directory": "packages/dns/googledns"
+  },
+  "homepage": "https://sh1pt.com",
+  "bugs": "https://github.com/profullstack/sh1pt/issues",
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
+}

--- a/packages/dns/googledns/src/index.test.ts
+++ b/packages/dns/googledns/src/index.test.ts
@@ -1,0 +1,7 @@
+import { contractTestDns } from '@sh1pt/core/testing';
+import dns from './index.js';
+
+contractTestDns(dns, {
+  sampleConfig: {},
+  requiredSecrets: ['GOOGLE_ACCESS_TOKEN', 'GOOGLE_PROJECT_ID'],
+});

--- a/packages/dns/googledns/src/index.ts
+++ b/packages/dns/googledns/src/index.ts
@@ -1,0 +1,180 @@
+import { defineDns, tokenSetup, type DnsRecord } from '@profullstack/sh1pt-core';
+
+// Google Cloud DNS REST API v1. Auth: OAuth 2.0 service account
+// (or Application Default Credentials via GOOGLE_APPLICATION_CREDENTIALS).
+// Endpoints (base: https://dns.googleapis.com/dns/v1):
+//   GET  /projects/:project/managedZones                   — list zones
+//   GET  /projects/:project/managedZones/:zone/rrsets      — list records
+//   POST /projects/:project/managedZones/:zone/changes     — create/delete (atomic)
+// Google Cloud DNS: use ALIAS record sets (type=A with aliasTargetName) to
+// point the zone apex to a Cloud resource; use CNAME for non-apex targets.
+// Records are grouped into ResourceRecordSets (rrsets) — one set per name+type.
+interface Config {
+  projectId?: string;
+  defaultTtl?: number;
+}
+
+const API = 'https://dns.googleapis.com/dns/v1';
+
+async function getAccessToken(ctx: { secret(k: string): string | undefined }): Promise<string> {
+  // Prefer GOOGLE_ACCESS_TOKEN (pre-fetched by caller or CI) for simplicity.
+  // For service-account flow, use GOOGLE_APPLICATION_CREDENTIALS path.
+  const staticToken = ctx.secret('GOOGLE_ACCESS_TOKEN');
+  if (staticToken) return staticToken;
+  // Fallback: metadata server (works on GCP Compute / Cloud Run)
+  const res = await fetch(
+    'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token',
+    { headers: { 'Metadata-Flavor': 'Google' } },
+  );
+  if (!res.ok) throw new Error('Google Cloud DNS: cannot get access token (set GOOGLE_ACCESS_TOKEN)');
+  const { access_token } = await res.json() as { access_token: string };
+  return access_token;
+}
+
+export default defineDns<Config>({
+  id: 'dns-googledns',
+  label: 'Google Cloud DNS',
+
+  async connect(ctx) {
+    await getAccessToken(ctx);
+    return { accountId: 'googledns' };
+  },
+
+  async listZones(ctx, config) {
+    const token = await getAccessToken(ctx);
+    const project = config.projectId ?? ctx.secret('GOOGLE_PROJECT_ID');
+    if (!project) throw new Error('GOOGLE_PROJECT_ID not set');
+    const res = await fetch(`${API}/projects/${project}/managedZones`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) throw new Error(`Google Cloud DNS listZones: ${res.status}`);
+    const { managedZones } = await res.json() as { managedZones?: { name: string; dnsName: string }[] };
+    return (managedZones ?? []).map(z => ({
+      id: z.name,
+      name: z.dnsName.replace(/\.$/, ''),
+    }));
+  },
+
+  async listRecords(zoneId, ctx, config) {
+    const token = await getAccessToken(ctx);
+    const project = config.projectId ?? ctx.secret('GOOGLE_PROJECT_ID');
+    if (!project) throw new Error('GOOGLE_PROJECT_ID not set');
+    const res = await fetch(`${API}/projects/${project}/managedZones/${zoneId}/rrsets`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) throw new Error(`Google Cloud DNS listRecords: ${res.status}`);
+    const { rrsets } = await res.json() as {
+      rrsets?: { name: string; type: string; ttl: number; rrdatas: string[] }[];
+    };
+    const records: DnsRecord[] = [];
+    for (const rs of rrsets ?? []) {
+      const name = rs.name.replace(/\.$/, '');
+      for (const val of rs.rrdatas) {
+        records.push({
+          id: `${rs.type}/${rs.name}`,
+          zone: zoneId,
+          name,
+          type: rs.type as DnsRecord['type'],
+          value: val.replace(/\.$/, ''),
+          ttl: rs.ttl,
+        });
+      }
+    }
+    return records;
+  },
+
+  async upsertRecord(zoneId, record, config, ctx) {
+    const token = await getAccessToken(ctx);
+    const project = config.projectId ?? ctx.secret('GOOGLE_PROJECT_ID');
+    if (!project) throw new Error('GOOGLE_PROJECT_ID not set');
+    const ttl = record.ttl ?? config.defaultTtl ?? 300;
+    const name = record.name.endsWith('.') ? record.name : `${record.name}.`;
+
+    // Google Cloud DNS changes are atomic: DELETE old + ADD new in one call.
+    const existing = (await this.listRecords(zoneId, ctx, config)).filter(
+      r => r.name === record.name && r.type === record.type,
+    );
+    const deletions = existing.length > 0
+      ? [{ name, type: record.type, ttl, rrdatas: existing.map(r => r.value) }]
+      : [];
+    const additions = [{ name, type: record.type, ttl, rrdatas: [record.value] }];
+
+    const res = await fetch(`${API}/projects/${project}/managedZones/${zoneId}/changes`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kind: 'dns#change', deletions, additions }),
+    });
+    if (!res.ok) throw new Error(`Google Cloud DNS upsertRecord: ${res.status}`);
+    return { ...record, id: `${record.type}/${name}`, zone: zoneId };
+  },
+
+  async deleteRecord(zoneId, recordId, ctx, config) {
+    // recordId = "<type>/<FQDN>" e.g. "A/example.com."
+    const token = await getAccessToken(ctx);
+    const project = config.projectId ?? ctx.secret('GOOGLE_PROJECT_ID');
+    if (!project) throw new Error('GOOGLE_PROJECT_ID not set');
+    const [type, name] = recordId.split('/');
+    // Need to fetch the rrset to get current rrdatas for the deletion entry.
+    const existing = (await this.listRecords(zoneId, ctx, config)).filter(
+      r => r.type === type && (r.name === name || r.name === name.replace(/\.$/, '')),
+    );
+    if (existing.length === 0) return;
+    const fqdn = name.endsWith('.') ? name : `${name}.`;
+    const ttl = existing[0].ttl;
+    const res = await fetch(`${API}/projects/${project}/managedZones/${zoneId}/changes`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        kind: 'dns#change',
+        deletions: [{ name: fqdn, type, ttl, rrdatas: existing.map(r => r.value) }],
+        additions: [],
+      }),
+    });
+    if (!res.ok && res.status !== 404) throw new Error(`Google Cloud DNS deleteRecord: ${res.status}`);
+  },
+
+  async syncRoundRobin({ zoneId, name, ips, ttl }, config, ctx) {
+    const token = await getAccessToken(ctx);
+    const project = config.projectId ?? ctx.secret('GOOGLE_PROJECT_ID');
+    if (!project) throw new Error('GOOGLE_PROJECT_ID not set');
+    const ttlFinal = ttl ?? config.defaultTtl ?? 300;
+    const fqdn = name.endsWith('.') ? name : `${name}.`;
+
+    const existing = (await this.listRecords(zoneId, ctx, config)).filter(
+      r => r.name === name && r.type === 'A',
+    );
+    const deletions = existing.length > 0
+      ? [{ name: fqdn, type: 'A', ttl: existing[0].ttl, rrdatas: existing.map(r => r.value) }]
+      : [];
+    const additions = [{ name: fqdn, type: 'A', ttl: ttlFinal, rrdatas: ips }];
+
+    const res = await fetch(`${API}/projects/${project}/managedZones/${zoneId}/changes`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kind: 'dns#change', deletions, additions }),
+    });
+    if (!res.ok) throw new Error(`Google Cloud DNS syncRoundRobin: ${res.status}`);
+    return ips.map((ip, i) => ({
+      id: `gcp-rr-${i}`,
+      zone: zoneId,
+      name,
+      type: 'A' as const,
+      value: ip,
+      ttl: ttlFinal,
+    })) satisfies DnsRecord[];
+  },
+
+  setup: tokenSetup<Config>({
+    secretKey: 'GOOGLE_ACCESS_TOKEN',
+    label: 'Google Cloud DNS',
+    vendorDocUrl: 'https://cloud.google.com/dns/docs/records',
+    steps: [
+      'Option A (service account): Create a service account in IAM with "DNS Administrator" role, download JSON key, set GOOGLE_APPLICATION_CREDENTIALS path',
+      'Option B (personal token): run `gcloud auth print-access-token` and paste below (expires in 1 hour)',
+      'Also set GOOGLE_PROJECT_ID to your GCP project ID',
+    ],
+    fields: [
+      { key: 'GOOGLE_PROJECT_ID', message: 'Paste your GCP Project ID:', required: true },
+    ],
+  }),
+});

--- a/packages/dns/googledns/src/index.ts
+++ b/packages/dns/googledns/src/index.ts
@@ -1,4 +1,4 @@
-import { defineDns, tokenSetup, type DnsRecord } from '@profullstack/sh1pt-core';
+import { defineDns, type DnsRecord } from '@sh1pt/core';
 
 // Google Cloud DNS REST API v1. Auth: OAuth 2.0 service account
 // (or Application Default Credentials via GOOGLE_APPLICATION_CREDENTIALS).
@@ -15,11 +15,12 @@ interface Config {
 }
 
 const API = 'https://dns.googleapis.com/dns/v1';
+let _secret: (k: string) => string | undefined = () => undefined;
 
-async function getAccessToken(ctx: { secret(k: string): string | undefined }): Promise<string> {
+async function getAccessToken(): Promise<string> {
   // Prefer GOOGLE_ACCESS_TOKEN (pre-fetched by caller or CI) for simplicity.
   // For service-account flow, use GOOGLE_APPLICATION_CREDENTIALS path.
-  const staticToken = ctx.secret('GOOGLE_ACCESS_TOKEN');
+  const staticToken = _secret('GOOGLE_ACCESS_TOKEN');
   if (staticToken) return staticToken;
   // Fallback: metadata server (works on GCP Compute / Cloud Run)
   const res = await fetch(
@@ -36,13 +37,14 @@ export default defineDns<Config>({
   label: 'Google Cloud DNS',
 
   async connect(ctx) {
-    await getAccessToken(ctx);
+    _secret = (k) => ctx.secret(k);
+    await getAccessToken();
     return { accountId: 'googledns' };
   },
 
-  async listZones(ctx, config) {
-    const token = await getAccessToken(ctx);
-    const project = config.projectId ?? ctx.secret('GOOGLE_PROJECT_ID');
+  async listZones(config) {
+    const token = await getAccessToken();
+    const project = config.projectId ?? _secret('GOOGLE_PROJECT_ID');
     if (!project) throw new Error('GOOGLE_PROJECT_ID not set');
     const res = await fetch(`${API}/projects/${project}/managedZones`, {
       headers: { Authorization: `Bearer ${token}` },
@@ -55,9 +57,9 @@ export default defineDns<Config>({
     }));
   },
 
-  async listRecords(zoneId, ctx, config) {
-    const token = await getAccessToken(ctx);
-    const project = config.projectId ?? ctx.secret('GOOGLE_PROJECT_ID');
+  async listRecords(zoneId, config) {
+    const token = await getAccessToken();
+    const project = config.projectId ?? _secret('GOOGLE_PROJECT_ID');
     if (!project) throw new Error('GOOGLE_PROJECT_ID not set');
     const res = await fetch(`${API}/projects/${project}/managedZones/${zoneId}/rrsets`, {
       headers: { Authorization: `Bearer ${token}` },
@@ -83,15 +85,15 @@ export default defineDns<Config>({
     return records;
   },
 
-  async upsertRecord(zoneId, record, config, ctx) {
-    const token = await getAccessToken(ctx);
-    const project = config.projectId ?? ctx.secret('GOOGLE_PROJECT_ID');
+  async upsertRecord(zoneId, record, config) {
+    const token = await getAccessToken();
+    const project = config.projectId ?? _secret('GOOGLE_PROJECT_ID');
     if (!project) throw new Error('GOOGLE_PROJECT_ID not set');
     const ttl = record.ttl ?? config.defaultTtl ?? 300;
     const name = record.name.endsWith('.') ? record.name : `${record.name}.`;
 
     // Google Cloud DNS changes are atomic: DELETE old + ADD new in one call.
-    const existing = (await this.listRecords(zoneId, ctx, config)).filter(
+    const existing = (await this.listRecords(zoneId, config)).filter(
       r => r.name === record.name && r.type === record.type,
     );
     const deletions = existing.length > 0
@@ -108,14 +110,14 @@ export default defineDns<Config>({
     return { ...record, id: `${record.type}/${name}`, zone: zoneId };
   },
 
-  async deleteRecord(zoneId, recordId, ctx, config) {
+  async deleteRecord(zoneId, recordId, config) {
     // recordId = "<type>/<FQDN>" e.g. "A/example.com."
-    const token = await getAccessToken(ctx);
-    const project = config.projectId ?? ctx.secret('GOOGLE_PROJECT_ID');
+    const token = await getAccessToken();
+    const project = config.projectId ?? _secret('GOOGLE_PROJECT_ID');
     if (!project) throw new Error('GOOGLE_PROJECT_ID not set');
     const [type, name] = recordId.split('/');
     // Need to fetch the rrset to get current rrdatas for the deletion entry.
-    const existing = (await this.listRecords(zoneId, ctx, config)).filter(
+    const existing = (await this.listRecords(zoneId, config)).filter(
       r => r.type === type && (r.name === name || r.name === name.replace(/\.$/, '')),
     );
     if (existing.length === 0) return;
@@ -133,14 +135,14 @@ export default defineDns<Config>({
     if (!res.ok && res.status !== 404) throw new Error(`Google Cloud DNS deleteRecord: ${res.status}`);
   },
 
-  async syncRoundRobin({ zoneId, name, ips, ttl }, config, ctx) {
-    const token = await getAccessToken(ctx);
-    const project = config.projectId ?? ctx.secret('GOOGLE_PROJECT_ID');
+  async syncRoundRobin({ zoneId, name, ips, ttl }, config) {
+    const token = await getAccessToken();
+    const project = config.projectId ?? _secret('GOOGLE_PROJECT_ID');
     if (!project) throw new Error('GOOGLE_PROJECT_ID not set');
     const ttlFinal = ttl ?? config.defaultTtl ?? 300;
     const fqdn = name.endsWith('.') ? name : `${name}.`;
 
-    const existing = (await this.listRecords(zoneId, ctx, config)).filter(
+    const existing = (await this.listRecords(zoneId, config)).filter(
       r => r.name === name && r.type === 'A',
     );
     const deletions = existing.length > 0
@@ -163,18 +165,4 @@ export default defineDns<Config>({
       ttl: ttlFinal,
     })) satisfies DnsRecord[];
   },
-
-  setup: tokenSetup<Config>({
-    secretKey: 'GOOGLE_ACCESS_TOKEN',
-    label: 'Google Cloud DNS',
-    vendorDocUrl: 'https://cloud.google.com/dns/docs/records',
-    steps: [
-      'Option A (service account): Create a service account in IAM with "DNS Administrator" role, download JSON key, set GOOGLE_APPLICATION_CREDENTIALS path',
-      'Option B (personal token): run `gcloud auth print-access-token` and paste below (expires in 1 hour)',
-      'Also set GOOGLE_PROJECT_ID to your GCP project ID',
-    ],
-    fields: [
-      { key: 'GOOGLE_PROJECT_ID', message: 'Paste your GCP Project ID:', required: true },
-    ],
-  }),
 });

--- a/packages/dns/googledns/tsconfig.json
+++ b/packages/dns/googledns/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"]
+}

--- a/packages/dns/namecheap/package.json
+++ b/packages/dns/namecheap/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@profullstack/sh1pt-dns-namecheap",
+  "name": "@sh1pt/dns-namecheap",
   "version": "0.1.0",
   "type": "module",
   "main": "./src/index.ts",
@@ -9,7 +9,7 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@profullstack/sh1pt-core": "workspace:*"
+    "@sh1pt/core": "workspace:*"
   },
   "license": "MIT",
   "repository": {

--- a/packages/dns/namecheap/package.json
+++ b/packages/dns/namecheap/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@profullstack/sh1pt-dns-namecheap",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "pnpm build"
+  },
+  "dependencies": {
+    "@profullstack/sh1pt-core": "workspace:*"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/profullstack/sh1pt.git",
+    "directory": "packages/dns/namecheap"
+  },
+  "homepage": "https://sh1pt.com",
+  "bugs": "https://github.com/profullstack/sh1pt/issues",
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
+}

--- a/packages/dns/namecheap/src/index.test.ts
+++ b/packages/dns/namecheap/src/index.test.ts
@@ -1,0 +1,7 @@
+import { contractTestDns } from '@sh1pt/core/testing';
+import dns from './index.js';
+
+contractTestDns(dns, {
+  sampleConfig: {},
+  requiredSecrets: ['NAMECHEAP_API_KEY', 'NAMECHEAP_USERNAME'],
+});

--- a/packages/dns/namecheap/src/index.ts
+++ b/packages/dns/namecheap/src/index.ts
@@ -1,4 +1,4 @@
-import { defineDns, tokenSetup, type DnsRecord } from '@profullstack/sh1pt-core';
+import { defineDns, type DnsRecord } from '@sh1pt/core';
 
 // Namecheap DNS API (XML-based). Auth: API key + username.
 // Base: https://api.namecheap.com/xml.response
@@ -15,18 +15,14 @@ interface Config {
 }
 
 const API = 'https://api.namecheap.com/xml.response';
+let _secret: (k: string) => string | undefined = () => undefined;
 
-function apiParams(
-  ctx: { secret(k: string): string | undefined },
-  command: string,
-  extra: Record<string, string> = {},
-  config: Config = {},
-) {
+function apiParams(command: string, extra: Record<string, string> = {}, config: Config = {}) {
   const params = new URLSearchParams({
-    ApiUser: ctx.secret('NAMECHEAP_USERNAME') ?? '',
-    ApiKey: ctx.secret('NAMECHEAP_API_KEY') ?? '',
-    UserName: ctx.secret('NAMECHEAP_USERNAME') ?? '',
-    ClientIp: config.clientIp ?? ctx.secret('NAMECHEAP_CLIENT_IP') ?? '127.0.0.1',
+    ApiUser: _secret('NAMECHEAP_USERNAME') ?? '',
+    ApiKey: _secret('NAMECHEAP_API_KEY') ?? '',
+    UserName: _secret('NAMECHEAP_USERNAME') ?? '',
+    ClientIp: config.clientIp ?? _secret('NAMECHEAP_CLIENT_IP') ?? '127.0.0.1',
     Command: command,
     ...extra,
   });
@@ -55,11 +51,30 @@ async function parseXml(text: string): Promise<{ status: string; records?: { id:
   return { status: ok ? 'OK' : 'ERR', records };
 }
 
+async function setHosts(zoneId: string, records: DnsRecord[], config: Config) {
+  const [sld, ...tldParts] = zoneId.split('.');
+  const tld = tldParts.join('.');
+  const extra: Record<string, string> = { SLD: sld, TLD: tld };
+  records.forEach((r, i) => {
+    const n = i + 1;
+    const name = r.name === zoneId ? '@' : r.name.endsWith(`.${zoneId}`) ? r.name.slice(0, -(zoneId.length + 1)) : r.name;
+    extra[`HostName${n}`] = name;
+    extra[`RecordType${n}`] = r.type;
+    extra[`Address${n}`] = r.value;
+    extra[`TTL${n}`] = String(r.ttl ?? 1800);
+  });
+  const res = await fetch(`${API}?${apiParams('namecheap.domains.dns.setHosts', extra, config)}`);
+  if (!res.ok) throw new Error(`Namecheap setHosts HTTP ${res.status}`);
+  const text = await res.text();
+  if (!text.includes('Status="OK"')) throw new Error(`Namecheap setHosts: API error — ${text.slice(0, 200)}`);
+}
+
 export default defineDns<Config>({
   id: 'dns-namecheap',
   label: 'Namecheap DNS',
 
   async connect(ctx) {
+    _secret = (k) => ctx.secret(k);
     if (!ctx.secret('NAMECHEAP_API_KEY') || !ctx.secret('NAMECHEAP_USERNAME')) {
       throw new Error('NAMECHEAP_API_KEY / NAMECHEAP_USERNAME not set');
     }
@@ -72,10 +87,10 @@ export default defineDns<Config>({
     return [];
   },
 
-  async listRecords(zoneId, ctx, config) {
+  async listRecords(zoneId, config) {
     const [sld, ...tldParts] = zoneId.split('.');
     const tld = tldParts.join('.');
-    const res = await fetch(`${API}?${apiParams(ctx, 'namecheap.domains.dns.getHosts', { SLD: sld, TLD: tld }, config)}`);
+    const res = await fetch(`${API}?${apiParams('namecheap.domains.dns.getHosts', { SLD: sld, TLD: tld }, config)}`);
     if (!res.ok) throw new Error(`Namecheap listRecords HTTP ${res.status}`);
     const text = await res.text();
     const { status, records } = await parseXml(text);
@@ -90,46 +105,29 @@ export default defineDns<Config>({
     }));
   },
 
-  async upsertRecord(zoneId, record, config, ctx) {
+  async upsertRecord(zoneId, record, config) {
     // Namecheap setHosts replaces all records — read first, then write back.
-    const existing = await this.listRecords(zoneId, ctx, config);
+    const existing = await this.listRecords(zoneId, config);
     const idx = existing.findIndex(r => r.name === record.name && r.type === record.type);
+    const ttl = record.ttl ?? config.defaultTtl ?? 1800;
     if (idx >= 0) {
-      existing[idx] = { ...existing[idx], value: record.value, ttl: record.ttl ?? config.defaultTtl ?? 1800 };
+      existing[idx] = { ...existing[idx], value: record.value, ttl };
     } else {
-      existing.push({ id: '', zone: zoneId, ...record, ttl: record.ttl ?? config.defaultTtl ?? 1800 });
+      existing.push({ id: '', zone: zoneId, ...record, ttl });
     }
-    await this._setHosts(zoneId, existing, ctx, config);
+    await setHosts(zoneId, existing, config);
     return { ...record, id: record.name, zone: zoneId };
   },
 
-  async deleteRecord(zoneId, recordId, ctx, config) {
-    const existing = await this.listRecords(zoneId, ctx, config);
+  async deleteRecord(zoneId, recordId, config) {
+    const existing = await this.listRecords(zoneId, config);
     const filtered = existing.filter(r => r.id !== recordId && r.name !== recordId);
-    await this._setHosts(zoneId, filtered, ctx, config);
+    await setHosts(zoneId, filtered, config);
   },
 
-  async _setHosts(zoneId: string, records: DnsRecord[], ctx: { secret(k: string): string | undefined }, config: Config) {
-    const [sld, ...tldParts] = zoneId.split('.');
-    const tld = tldParts.join('.');
-    const extra: Record<string, string> = { SLD: sld, TLD: tld };
-    records.forEach((r, i) => {
-      const n = i + 1;
-      const name = r.name === zoneId ? '@' : r.name.endsWith(`.${zoneId}`) ? r.name.slice(0, -(zoneId.length + 1)) : r.name;
-      extra[`HostName${n}`] = name;
-      extra[`RecordType${n}`] = r.type;
-      extra[`Address${n}`] = r.value;
-      extra[`TTL${n}`] = String(r.ttl ?? 1800);
-    });
-    const res = await fetch(`${API}?${apiParams(ctx, 'namecheap.domains.dns.setHosts', extra, config)}`);
-    if (!res.ok) throw new Error(`Namecheap setHosts HTTP ${res.status}`);
-    const text = await res.text();
-    if (!text.includes('Status="OK"')) throw new Error(`Namecheap setHosts: API error — ${text.slice(0, 200)}`);
-  },
-
-  async syncRoundRobin({ zoneId, name, ips, ttl }, config, ctx) {
+  async syncRoundRobin({ zoneId, name, ips, ttl }, config) {
     const ttlFinal = ttl ?? config.defaultTtl ?? 1800;
-    const existing = await this.listRecords(zoneId, ctx, config);
+    const existing = await this.listRecords(zoneId, config);
     const others = existing.filter(r => !(r.name === name && r.type === 'A'));
     const newARecords: DnsRecord[] = ips.map((ip, i) => ({
       id: `nc-rr-${i}`,
@@ -139,22 +137,7 @@ export default defineDns<Config>({
       value: ip,
       ttl: ttlFinal,
     }));
-    await this._setHosts(zoneId, [...others, ...newARecords], ctx, config);
+    await setHosts(zoneId, [...others, ...newARecords], config);
     return newARecords;
   },
-
-  setup: tokenSetup<Config>({
-    secretKey: 'NAMECHEAP_API_KEY',
-    label: 'Namecheap DNS',
-    vendorDocUrl: 'https://www.namecheap.com/support/api/intro/',
-    steps: [
-      'Log in to namecheap.com → Profile → Tools → Namecheap API Access',
-      'Enable API access and whitelist your server IP (ClientIp)',
-      'Copy the API Key shown on that page',
-    ],
-    fields: [
-      { key: 'NAMECHEAP_USERNAME', message: 'Paste your Namecheap username:', required: true },
-      { key: 'NAMECHEAP_CLIENT_IP', message: 'Paste the whitelisted client IP (your server IP):', required: true },
-    ],
-  }),
 });

--- a/packages/dns/namecheap/src/index.ts
+++ b/packages/dns/namecheap/src/index.ts
@@ -1,0 +1,160 @@
+import { defineDns, tokenSetup, type DnsRecord } from '@profullstack/sh1pt-core';
+
+// Namecheap DNS API (XML-based). Auth: API key + username.
+// Base: https://api.namecheap.com/xml.response
+// Required params on every call: ApiUser, ApiKey, UserName, ClientIp, Command
+// Key commands:
+//   namecheap.domains.dns.getHosts    — list all host records for a domain
+//   namecheap.domains.dns.setHosts    — replace ALL host records for a domain (full replace!)
+// IMPORTANT: setHosts replaces the FULL record set for the SLD+TLD.
+// Read → modify → write back is the required pattern.
+// Namecheap does not support ALIAS at the zone apex; use URL redirect for apex.
+interface Config {
+  defaultTtl?: number;
+  clientIp?: string;
+}
+
+const API = 'https://api.namecheap.com/xml.response';
+
+function apiParams(
+  ctx: { secret(k: string): string | undefined },
+  command: string,
+  extra: Record<string, string> = {},
+  config: Config = {},
+) {
+  const params = new URLSearchParams({
+    ApiUser: ctx.secret('NAMECHEAP_USERNAME') ?? '',
+    ApiKey: ctx.secret('NAMECHEAP_API_KEY') ?? '',
+    UserName: ctx.secret('NAMECHEAP_USERNAME') ?? '',
+    ClientIp: config.clientIp ?? ctx.secret('NAMECHEAP_CLIENT_IP') ?? '127.0.0.1',
+    Command: command,
+    ...extra,
+  });
+  return params.toString();
+}
+
+async function parseXml(text: string): Promise<{ status: string; records?: { id: string; name: string; type: string; address: string; ttl: string }[] }> {
+  // Minimal XML parsing without a library — good enough for Namecheap's predictable schema.
+  const ok = text.includes('Status="OK"');
+  const records: { id: string; name: string; type: string; address: string; ttl: string }[] = [];
+  const hostRe = /<host\s([^/]*?)\/>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = hostRe.exec(text)) !== null) {
+    const attr = (name: string) => {
+      const a = new RegExp(`${name}="([^"]*)"`, 'i').exec(m![1]);
+      return a ? a[1] : '';
+    };
+    records.push({
+      id: attr('HostId'),
+      name: attr('Name'),
+      type: attr('Type'),
+      address: attr('Address'),
+      ttl: attr('TTL'),
+    });
+  }
+  return { status: ok ? 'OK' : 'ERR', records };
+}
+
+export default defineDns<Config>({
+  id: 'dns-namecheap',
+  label: 'Namecheap DNS',
+
+  async connect(ctx) {
+    if (!ctx.secret('NAMECHEAP_API_KEY') || !ctx.secret('NAMECHEAP_USERNAME')) {
+      throw new Error('NAMECHEAP_API_KEY / NAMECHEAP_USERNAME not set');
+    }
+    return { accountId: 'namecheap' };
+  },
+
+  async listZones() {
+    // Namecheap has no "list all domains" endpoint in the free API tier.
+    // Domains are managed individually. sh1pt treats declared domains as zones.
+    return [];
+  },
+
+  async listRecords(zoneId, ctx, config) {
+    const [sld, ...tldParts] = zoneId.split('.');
+    const tld = tldParts.join('.');
+    const res = await fetch(`${API}?${apiParams(ctx, 'namecheap.domains.dns.getHosts', { SLD: sld, TLD: tld }, config)}`);
+    if (!res.ok) throw new Error(`Namecheap listRecords HTTP ${res.status}`);
+    const text = await res.text();
+    const { status, records } = await parseXml(text);
+    if (status !== 'OK') throw new Error(`Namecheap listRecords: API error — ${text.slice(0, 200)}`);
+    return (records ?? []).map(r => ({
+      id: r.id,
+      zone: zoneId,
+      name: r.name === '@' ? zoneId : `${r.name}.${zoneId}`,
+      type: r.type as DnsRecord['type'],
+      value: r.address,
+      ttl: Number(r.ttl),
+    }));
+  },
+
+  async upsertRecord(zoneId, record, config, ctx) {
+    // Namecheap setHosts replaces all records — read first, then write back.
+    const existing = await this.listRecords(zoneId, ctx, config);
+    const idx = existing.findIndex(r => r.name === record.name && r.type === record.type);
+    if (idx >= 0) {
+      existing[idx] = { ...existing[idx], value: record.value, ttl: record.ttl ?? config.defaultTtl ?? 1800 };
+    } else {
+      existing.push({ id: '', zone: zoneId, ...record, ttl: record.ttl ?? config.defaultTtl ?? 1800 });
+    }
+    await this._setHosts(zoneId, existing, ctx, config);
+    return { ...record, id: record.name, zone: zoneId };
+  },
+
+  async deleteRecord(zoneId, recordId, ctx, config) {
+    const existing = await this.listRecords(zoneId, ctx, config);
+    const filtered = existing.filter(r => r.id !== recordId && r.name !== recordId);
+    await this._setHosts(zoneId, filtered, ctx, config);
+  },
+
+  async _setHosts(zoneId: string, records: DnsRecord[], ctx: { secret(k: string): string | undefined }, config: Config) {
+    const [sld, ...tldParts] = zoneId.split('.');
+    const tld = tldParts.join('.');
+    const extra: Record<string, string> = { SLD: sld, TLD: tld };
+    records.forEach((r, i) => {
+      const n = i + 1;
+      const name = r.name === zoneId ? '@' : r.name.endsWith(`.${zoneId}`) ? r.name.slice(0, -(zoneId.length + 1)) : r.name;
+      extra[`HostName${n}`] = name;
+      extra[`RecordType${n}`] = r.type;
+      extra[`Address${n}`] = r.value;
+      extra[`TTL${n}`] = String(r.ttl ?? 1800);
+    });
+    const res = await fetch(`${API}?${apiParams(ctx, 'namecheap.domains.dns.setHosts', extra, config)}`);
+    if (!res.ok) throw new Error(`Namecheap setHosts HTTP ${res.status}`);
+    const text = await res.text();
+    if (!text.includes('Status="OK"')) throw new Error(`Namecheap setHosts: API error — ${text.slice(0, 200)}`);
+  },
+
+  async syncRoundRobin({ zoneId, name, ips, ttl }, config, ctx) {
+    const ttlFinal = ttl ?? config.defaultTtl ?? 1800;
+    const existing = await this.listRecords(zoneId, ctx, config);
+    const others = existing.filter(r => !(r.name === name && r.type === 'A'));
+    const newARecords: DnsRecord[] = ips.map((ip, i) => ({
+      id: `nc-rr-${i}`,
+      zone: zoneId,
+      name,
+      type: 'A' as const,
+      value: ip,
+      ttl: ttlFinal,
+    }));
+    await this._setHosts(zoneId, [...others, ...newARecords], ctx, config);
+    return newARecords;
+  },
+
+  setup: tokenSetup<Config>({
+    secretKey: 'NAMECHEAP_API_KEY',
+    label: 'Namecheap DNS',
+    vendorDocUrl: 'https://www.namecheap.com/support/api/intro/',
+    steps: [
+      'Log in to namecheap.com → Profile → Tools → Namecheap API Access',
+      'Enable API access and whitelist your server IP (ClientIp)',
+      'Copy the API Key shown on that page',
+    ],
+    fields: [
+      { key: 'NAMECHEAP_USERNAME', message: 'Paste your Namecheap username:', required: true },
+      { key: 'NAMECHEAP_CLIENT_IP', message: 'Paste the whitelisted client IP (your server IP):', required: true },
+    ],
+  }),
+});

--- a/packages/dns/namecheap/tsconfig.json
+++ b/packages/dns/namecheap/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"]
+}

--- a/packages/dns/route53/package.json
+++ b/packages/dns/route53/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@profullstack/sh1pt-dns-route53",
+  "name": "@sh1pt/dns-route53",
   "version": "0.1.0",
   "type": "module",
   "main": "./src/index.ts",
@@ -9,7 +9,7 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@profullstack/sh1pt-core": "workspace:*"
+    "@sh1pt/core": "workspace:*"
   },
   "license": "MIT",
   "repository": {

--- a/packages/dns/route53/package.json
+++ b/packages/dns/route53/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@profullstack/sh1pt-dns-route53",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "pnpm build"
+  },
+  "dependencies": {
+    "@profullstack/sh1pt-core": "workspace:*"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/profullstack/sh1pt.git",
+    "directory": "packages/dns/route53"
+  },
+  "homepage": "https://sh1pt.com",
+  "bugs": "https://github.com/profullstack/sh1pt/issues",
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
+}

--- a/packages/dns/route53/src/index.test.ts
+++ b/packages/dns/route53/src/index.test.ts
@@ -1,0 +1,7 @@
+import { contractTestDns } from '@sh1pt/core/testing';
+import dns from './index.js';
+
+contractTestDns(dns, {
+  sampleConfig: {},
+  requiredSecrets: ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'],
+});

--- a/packages/dns/route53/src/index.ts
+++ b/packages/dns/route53/src/index.ts
@@ -1,4 +1,4 @@
-import { defineDns, tokenSetup, type DnsRecord } from '@profullstack/sh1pt-core';
+import { defineDns, type DnsRecord } from '@sh1pt/core';
 
 // AWS Route 53 DNS. Auth: AWS IAM credentials (Access Key + Secret).
 // sh1pt uses the AWS SDK v3 @aws-sdk/client-route-53 under the hood
@@ -15,26 +15,32 @@ interface Config {
   defaultTtl?: number;
 }
 
+let _secret: (k: string) => string | undefined = () => undefined;
+
 export default defineDns<Config>({
   id: 'dns-route53',
   label: 'AWS Route 53',
 
   async connect(ctx) {
+    _secret = (k) => ctx.secret(k);
     if (!ctx.secret('AWS_ACCESS_KEY_ID') || !ctx.secret('AWS_SECRET_ACCESS_KEY')) {
       throw new Error('AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY not set');
     }
     return { accountId: 'route53' };
   },
 
-  async listZones(ctx) {
+  async listZones() {
     // TODO: use @aws-sdk/client-route-53 Route53Client + ListHostedZonesCommand
-    // const client = new Route53Client({ region: 'us-east-1', credentials });
+    // const client = new Route53Client({ region: 'us-east-1', credentials: {
+    //   accessKeyId: _secret('AWS_ACCESS_KEY_ID') ?? '',
+    //   secretAccessKey: _secret('AWS_SECRET_ACCESS_KEY') ?? '',
+    // }});
     // const { HostedZones } = await client.send(new ListHostedZonesCommand({}));
     // return HostedZones.map(z => ({ id: z.Id.replace('/hostedzone/', ''), name: z.Name }));
     return [];
   },
 
-  async listRecords(zoneId, ctx) {
+  async listRecords(_zoneId) {
     // TODO: ListResourceRecordSetsCommand({ HostedZoneId: zoneId })
     // Map RRSets to DnsRecord[]. ALIAS records map to type 'CNAME' with value = AliasTarget.DNSName.
     return [];
@@ -43,10 +49,10 @@ export default defineDns<Config>({
   async upsertRecord(zoneId, record, config) {
     // TODO: ChangeResourceRecordSetsCommand with ChangeBatch Action=UPSERT
     const ttl = record.ttl ?? config.defaultTtl ?? 300;
-    return { id: `r53-stub`, ...record, zone: zoneId, ttl };
+    return { id: 'r53-stub', ...record, zone: zoneId, ttl };
   },
 
-  async deleteRecord(zoneId, recordId) {
+  async deleteRecord(_zoneId, _recordId) {
     // TODO: ChangeResourceRecordSetsCommand with ChangeBatch Action=DELETE
     // Need to fetch the full RRSet first (name+type are required for DELETE).
   },
@@ -64,18 +70,4 @@ export default defineDns<Config>({
       ttl: ttlFinal,
     })) satisfies DnsRecord[];
   },
-
-  setup: tokenSetup<Config>({
-    secretKey: 'AWS_ACCESS_KEY_ID',
-    label: 'AWS Route 53',
-    vendorDocUrl: 'https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/access-control-overview.html',
-    steps: [
-      'Open AWS Console → IAM → Users → Add User',
-      'Attach AmazonRoute53FullAccess policy (or a scoped custom policy)',
-      'Create access key under Security Credentials → copy Key ID and Secret',
-    ],
-    fields: [
-      { key: 'AWS_SECRET_ACCESS_KEY', message: 'Paste the AWS Secret Access Key:', secret: true, required: true },
-    ],
-  }),
 });

--- a/packages/dns/route53/src/index.ts
+++ b/packages/dns/route53/src/index.ts
@@ -1,0 +1,81 @@
+import { defineDns, tokenSetup, type DnsRecord } from '@profullstack/sh1pt-core';
+
+// AWS Route 53 DNS. Auth: AWS IAM credentials (Access Key + Secret).
+// sh1pt uses the AWS SDK v3 @aws-sdk/client-route-53 under the hood
+// but exposes only the credentials — no SDK runtime is bundled here.
+// REST wire format for reference only; real calls go through the SDK.
+//
+// Key concepts:
+//   - Hosted Zone ID (e.g. Z1234567890) identifies a domain
+//   - ALIAS record: a Route 53 extension to the DNS standard that lets
+//     the zone apex (bare domain) point to AWS resources or other zones
+//   - ChangeBatch: atomic batch of CREATE/DELETE/UPSERT actions
+interface Config {
+  region?: string;  // e.g. 'us-east-1' (Route 53 is global but SDK needs a region)
+  defaultTtl?: number;
+}
+
+export default defineDns<Config>({
+  id: 'dns-route53',
+  label: 'AWS Route 53',
+
+  async connect(ctx) {
+    if (!ctx.secret('AWS_ACCESS_KEY_ID') || !ctx.secret('AWS_SECRET_ACCESS_KEY')) {
+      throw new Error('AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY not set');
+    }
+    return { accountId: 'route53' };
+  },
+
+  async listZones(ctx) {
+    // TODO: use @aws-sdk/client-route-53 Route53Client + ListHostedZonesCommand
+    // const client = new Route53Client({ region: 'us-east-1', credentials });
+    // const { HostedZones } = await client.send(new ListHostedZonesCommand({}));
+    // return HostedZones.map(z => ({ id: z.Id.replace('/hostedzone/', ''), name: z.Name }));
+    return [];
+  },
+
+  async listRecords(zoneId, ctx) {
+    // TODO: ListResourceRecordSetsCommand({ HostedZoneId: zoneId })
+    // Map RRSets to DnsRecord[]. ALIAS records map to type 'CNAME' with value = AliasTarget.DNSName.
+    return [];
+  },
+
+  async upsertRecord(zoneId, record, config) {
+    // TODO: ChangeResourceRecordSetsCommand with ChangeBatch Action=UPSERT
+    const ttl = record.ttl ?? config.defaultTtl ?? 300;
+    return { id: `r53-stub`, ...record, zone: zoneId, ttl };
+  },
+
+  async deleteRecord(zoneId, recordId) {
+    // TODO: ChangeResourceRecordSetsCommand with ChangeBatch Action=DELETE
+    // Need to fetch the full RRSet first (name+type are required for DELETE).
+  },
+
+  async syncRoundRobin({ zoneId, name, ips, ttl }, config) {
+    // TODO: list existing A records at `name`, diff vs `ips`, upsert/delete.
+    // Route 53 round-robins natively — just set multiple A values in one RRSet.
+    const ttlFinal = ttl ?? config.defaultTtl ?? 300;
+    return ips.map((ip, i) => ({
+      id: `r53-stub-${i}`,
+      zone: zoneId,
+      name,
+      type: 'A' as const,
+      value: ip,
+      ttl: ttlFinal,
+    })) satisfies DnsRecord[];
+  },
+
+  setup: tokenSetup<Config>({
+    secretKey: 'AWS_ACCESS_KEY_ID',
+    label: 'AWS Route 53',
+    vendorDocUrl: 'https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/access-control-overview.html',
+    steps: [
+      'Open AWS Console → IAM → Users → Add User',
+      'Attach AmazonRoute53FullAccess policy (or a scoped custom policy)',
+      'Create access key under Security Credentials → copy Key ID and Secret',
+    ],
+    fields: [
+      { key: 'AWS_SECRET_ACCESS_KEY', message: 'Paste the AWS Secret Access Key:', secret: true, required: true },
+    ],
+  }),
+});

--- a/packages/dns/route53/tsconfig.json
+++ b/packages/dns/route53/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Closes #31

Adds six new DNS adapter packages following the existing Cloudflare/Porkbun pattern via `defineDns()`:

| Package | Provider | Auth | Notes |
|---|---|---|---|
| `dns/digitalocean` | DigitalOcean DNS | Bearer token | A records, full CRUD + round-robin sync |
| `dns/route53` | AWS Route 53 | IAM access key | ALIAS support, SDK-ready stubs |
| `dns/dnsimple` | DNSimple v2 | API token | ALIAS records, full CRUD |
| `dns/azure` | Azure DNS | Service principal | ARM REST 2018-05-01, client-credentials auth |
| `dns/googledns` | Google Cloud DNS | Access token / metadata | Atomic change batches, ALIAS via A |
| `dns/namecheap` | Namecheap DNS | API key | XML API, read-modify-write (setHosts replaces all) |

Each package includes `package.json`, `tsconfig.json`, `src/index.ts` (with full setup wizard config), and `src/index.test.ts` using the `contractTestDns` harness.