### PR TITLE
feat: implement JSR publish target adapter

### DIFF
--- a/packages/targets/pkg-jsr/src/index.test.ts
+++ b/packages/targets/pkg-jsr/src/index.test.ts
@@ -1,4 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+
+const { execMock } = vi.hoisted(() => ({
+  execMock: vi.fn(),
+}));
+
+vi.mock('@profullstack/sh1pt-core', async () => ({
+  ...await vi.importActual<typeof import('@profullstack/sh1pt-core')>('@profullstack/sh1pt-core'),
+  exec: execMock,
+}));
+
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'pkg', requireKind: true });
+
+const sampleConfig = {
+  scope: 'acme',
+  packageName: 'my-lib',
+  packageDir: 'packages/my-lib',
+};
+
+describe('pkg-jsr target adapter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('runs JSR publish dry-run during build', async () => {
+    execMock.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' });
+
+    const ctx = context();
+    const result = await adapter.build(ctx as any, sampleConfig);
+
+    expect(execMock).toHaveBeenCalledWith('npx', ['--yes', 'jsr', 'publish', '--dry-run'], {
+      cwd: '/repo/packages/my-lib',
+      log: ctx.log,
+      env: ctx.env,
+      throwOnNonZero: true,
+    });
+    expect(result).toEqual({ artifact: '/repo/packages/my-lib' });
+  });
+
+  it('does not require JSR_TOKEN in dry-run ship mode', async () => {
+    const result = await adapter.ship(shipContext({ dryRun: true }) as any, sampleConfig);
+
+    expect(result).toEqual({ id: 'dry-run' });
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  it('requires JSR_TOKEN before publishing', async () => {
+    await expect(adapter.ship(shipContext({ dryRun: false }) as any, sampleConfig))
+      .rejects.toThrow('JSR_TOKEN secret not set');
+  });
+
+  it('publishes with the JSR token and returns package metadata', async () => {
+    execMock.mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' });
+
+    const ctx = shipContext({ dryRun: false, secrets: { JSR_TOKEN: 'jsr-token' } });
+    const result = await adapter.ship(ctx as any, sampleConfig);
+
+    expect(execMock).toHaveBeenCalledWith('npx', ['--yes', 'jsr', 'publish', '--token', 'jsr-token'], {
+      cwd: '/repo/packages/my-lib',
+      log: ctx.log,
+      env: { ...ctx.env, JSR_TOKEN: 'jsr-token' },
+      throwOnNonZero: true,
+    });
+    expect(result).toEqual({
+      id: '@acme/my-lib@1.2.3',
+      url: 'https://jsr.io/@acme/my-lib',
+    });
+  });
+});
+
+function context({ secrets = {} }: { secrets?: Record<string, string> } = {}) {
+  return {
+    projectDir: '/repo',
+    outDir: '/repo/.sh1pt/out',
+    version: '1.2.3',
+    channel: 'stable',
+    env: { CI: 'true' },
+    secret: (key: string) => secrets[key],
+    log: vi.fn(),
+  };
+}
+
+function shipContext({ dryRun, secrets }: { dryRun: boolean; secrets?: Record<string, string> }) {
+  return {
+    ...context({ secrets }),
+    artifact: '/repo/packages/my-lib',
+    dryRun,
+  };
+}

--- a/packages/targets/pkg-jsr/src/index.ts
+++ b/packages/targets/pkg-jsr/src/index.ts
@@ -1,38 +1,73 @@
-import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { defineTarget, exec, manualSetup } from '@profullstack/sh1pt-core';
+import { join } from 'node:path';
 
-// JSR (jsr.io) — TS-native registry. Publishes source TS directly; the
-// registry handles transpilation for Node/Deno/Bun consumers. No
-// pre-publish build step required. Scoped packages only (@scope/name).
+// JSR (jsr.io) - TS-native registry. Publishes source TS directly; the
+// registry handles transpilation for Node/Deno/Bun consumers. Scoped packages
+// only (@scope/name).
 interface Config {
   scope: string;                 // e.g. 'acme'
-  packageName: string;           // e.g. 'my-lib' → @acme/my-lib
+  packageName: string;           // e.g. 'my-lib' -> @acme/my-lib
   packageDir?: string;           // path with jsr.json / deno.json
+}
+
+function packagePath(ctx: { projectDir: string }, config: Config): string {
+  return config.packageDir ? join(ctx.projectDir, config.packageDir) : ctx.projectDir;
+}
+
+function packageId(config: Config, version: string): string {
+  return `@${config.scope}/${config.packageName}@${version}`;
+}
+
+function packageUrl(config: Config): string {
+  return `https://jsr.io/@${config.scope}/${config.packageName}`;
 }
 
 export default defineTarget<Config>({
   id: 'pkg-jsr',
   kind: 'sdk',
-  label: 'JSR (jsr.io — TS-native registry)',
+  label: 'JSR (jsr.io - TS-native registry)',
   async build(ctx, config) {
-    ctx.log(`jsr publish --dry-run · pkg=@${config.scope}/${config.packageName}`);
-    // TODO: run `jsr publish --dry-run` to validate jsr.json and type coverage
-    return { artifact: config.packageDir ?? ctx.projectDir };
+    const cwd = packagePath(ctx, config);
+    ctx.log(`jsr publish --dry-run for @${config.scope}/${config.packageName}`);
+    await exec('npx', ['--yes', 'jsr', 'publish', '--dry-run'], {
+      cwd,
+      log: ctx.log,
+      env: ctx.env,
+      throwOnNonZero: true,
+    });
+    return { artifact: cwd };
   },
   async ship(ctx, config) {
-    ctx.log(`jsr publish · @${config.scope}/${config.packageName}@${ctx.version}`);
+    ctx.log(`jsr publish for @${config.scope}/${config.packageName}@${ctx.version}`);
     if (ctx.dryRun) return { id: 'dry-run' };
-    // TODO: `npx jsr publish` or `deno publish` with JSR_TOKEN
+
+    const token = ctx.secret('JSR_TOKEN');
+    if (!token) {
+      throw new Error('JSR_TOKEN secret not set. Run: sh1pt secret set JSR_TOKEN <token>');
+    }
+
+    await exec('npx', ['--yes', 'jsr', 'publish', '--token', token], {
+      cwd: packagePath(ctx, config),
+      log: ctx.log,
+      env: { ...ctx.env, JSR_TOKEN: token },
+      throwOnNonZero: true,
+    });
+
     return {
-      id: `@${config.scope}/${config.packageName}@${ctx.version}`,
-      url: `https://jsr.io/@${config.scope}/${config.packageName}`,
+      id: packageId(config, ctx.version),
+      url: packageUrl(config),
     };
+  },
+  async status(id) {
+    return { state: 'live', version: id };
   },
 
   setup: manualSetup({
     label: "JSR (jsr.io)",
     vendorDocUrl: "https://jsr.io/account/tokens",
     steps: [
-      "Open jsr.io \u2192 sign in with GitHub \u2192 Account \u2192 Tokens \u2192 Create",
+      "Open jsr.io -> sign in with GitHub -> Account -> Tokens -> Create",
+      "Create a token with Publish permission for the target scope",
       "Run: sh1pt secret set JSR_TOKEN <token>",
     ],
   }),


### PR DESCRIPTION
## Summary

Implements the `pkg-jsr` target adapter so sh1pt can validate and publish TypeScript packages to JSR.

## Changes

- Run `npx --yes jsr publish --dry-run` during `build` from the configured package directory.
- Publish with `npx --yes jsr publish --token <token>` during `ship`, requiring the `JSR_TOKEN` secret for real publishes.
- Return the published JSR package id and package URL, and expose a simple live status response.
- Expand tests from smoke coverage to dry-run, token validation, publish command, metadata, and existing adapter smoke coverage.

## Validation

- `corepack pnpm test -- packages/targets/pkg-jsr/src/index.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt-target-pkg-jsr typecheck`

Prepared with AI assistance and manually validated in a fresh checkout.
