### PR TITLE
feat(payments): implement Stripe adapter

### DIFF
--- a/packages/payments/stripe/src/index.test.ts
+++ b/packages/payments/stripe/src/index.test.ts
@@ -1,4 +1,116 @@
+import { createHmac } from 'node:crypto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'payment', requireSupports: true });
+
+describe('payment-stripe', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates a real Stripe Checkout Session request', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: 'cs_test_123',
+        url: 'https://checkout.stripe.com/c/pay/cs_test_123',
+        expires_at: 1_700_000_000,
+      }),
+    } as Response);
+
+    const session = await adapter.createCheckout(ctx({
+      STRIPE_SECRET_KEY: 'sk_test_123',
+    }), {
+      amount: 2440,
+      currency: 'USD',
+      kind: 'one-time',
+      successUrl: 'https://example.com/ok',
+      cancelUrl: 'https://example.com/cancel',
+      customerEmail: 'buyer@example.com',
+      description: 'Launch plan',
+      metadata: { order_id: 'ord_1' },
+      platformFeeBps: 1500,
+      connectedAccountId: 'acct_123',
+    }, { apiVersion: '2024-06-20' });
+
+    expect(session).toEqual({
+      id: 'cs_test_123',
+      url: 'https://checkout.stripe.com/c/pay/cs_test_123',
+      expiresAt: '2023-11-14T22:13:20.000Z',
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.stripe.com/v1/checkout/sessions');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>).authorization).toBe('Bearer sk_test_123');
+    expect((init.headers as Record<string, string>)['stripe-version']).toBe('2024-06-20');
+
+    const body = init.body as URLSearchParams;
+    expect(body.get('mode')).toBe('payment');
+    expect(body.get('line_items[0][price_data][unit_amount]')).toBe('2440');
+    expect(body.get('line_items[0][price_data][currency]')).toBe('usd');
+    expect(body.get('line_items[0][price_data][product_data][name]')).toBe('Launch plan');
+    expect(body.get('customer_email')).toBe('buyer@example.com');
+    expect(body.get('metadata[order_id]')).toBe('ord_1');
+    expect(body.get('payment_intent_data[application_fee_amount]')).toBe('366');
+    expect(body.get('payment_intent_data[transfer_data][destination]')).toBe('acct_123');
+  });
+
+  it('verifies Stripe webhook signatures and normalizes checkout events', async () => {
+    const raw = JSON.stringify({
+      id: 'evt_123',
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_test_123',
+          status: 'complete',
+          amount_total: 2440,
+          currency: 'usd',
+          customer_email: 'buyer@example.com',
+        },
+      },
+    });
+    const secret = 'whsec_test';
+    const timestamp = '1700000000';
+    const signature = createHmac('sha256', secret)
+      .update(`${timestamp}.${raw}`)
+      .digest('hex');
+
+    const webhook = await adapter.verifyWebhook(
+      ctx({ STRIPE_WEBHOOK_SECRET: secret }),
+      raw,
+      `t=${timestamp},v1=${signature}`,
+      {},
+    );
+
+    expect(webhook).toMatchObject({
+      type: 'checkout.session.completed',
+      paymentId: 'cs_test_123',
+      status: 'succeeded',
+      amount: 2440,
+      currency: 'USD',
+      customerEmail: 'buyer@example.com',
+    });
+  });
+
+  it('rejects invalid Stripe webhook signatures', async () => {
+    await expect(adapter.verifyWebhook(
+      ctx({ STRIPE_WEBHOOK_SECRET: 'whsec_test' }),
+      JSON.stringify({ type: 'checkout.session.completed' }),
+      't=1700000000,v1=bad',
+      {},
+    )).rejects.toThrow('Invalid Stripe webhook signature');
+  });
+});
+
+function ctx(secrets: Record<string, string>) {
+  return {
+    secret(key: string) {
+      return secrets[key];
+    },
+    log: vi.fn(),
+  };
+}

--- a/packages/payments/stripe/src/index.ts
+++ b/packages/payments/stripe/src/index.ts
@@ -1,4 +1,5 @@
-import { definePayment, tokenSetup, type Webhook } from '@profullstack/sh1pt-core';
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { definePayment, tokenSetup, type CheckoutRequest, type Webhook } from '@profullstack/sh1pt-core';
 
 // Stripe — cards + ACH + Link + local payment methods. Checkout API
 // for one-time + subscriptions; Connect for marketplace payouts.
@@ -7,36 +8,78 @@ interface Config {
   apiVersion?: string;
 }
 
+const STRIPE_API = 'https://api.stripe.com/v1';
+
 export default definePayment<Config>({
   id: 'payment-stripe',
   label: 'Stripe (cards / ACH / subscriptions / Connect)',
   supports: ['one-time', 'subscription'],
-  async connect(ctx) {
-    if (!ctx.secret('STRIPE_SECRET_KEY')) throw new Error('STRIPE_SECRET_KEY not in vault');
-    return { accountId: 'stripe' };
+
+  async connect(ctx, config) {
+    const secret = ctx.secret('STRIPE_SECRET_KEY');
+    if (!secret) throw new Error('STRIPE_SECRET_KEY not in vault');
+    return { accountId: config.accountId ?? 'stripe' };
   },
-  async createCheckout(ctx, req) {
+
+  async createCheckout(ctx, req, config) {
+    const secret = ctx.secret('STRIPE_SECRET_KEY');
+    if (!secret) throw new Error('STRIPE_SECRET_KEY not in vault');
+
     ctx.log(`stripe checkout · ${req.amount} ${req.currency} · ${req.kind}`);
-    // TODO: checkout.sessions.create with mode 'payment' or 'subscription';
-    // for marketplaces set payment_intent_data.application_fee_amount
-    // and transfer_data.destination = req.connectedAccountId.
+    const res = await stripeRequest(secret, '/checkout/sessions', buildCheckoutBody(req), config);
+    const session = await readStripeJson<StripeCheckoutSession>(res);
+
+    if (!session.id || !session.url) {
+      throw new Error('Stripe checkout response did not include id and url');
+    }
+
     return {
-      id: `cs_${Date.now()}`,
-      url: 'https://checkout.stripe.com/c/pay/cs_stub',
+      id: session.id,
+      url: session.url,
+      expiresAt: session.expires_at ? new Date(session.expires_at * 1000).toISOString() : undefined,
     };
   },
-  async verifyWebhook(ctx, rawBody): Promise<Webhook> {
-    if (!ctx.secret('STRIPE_WEBHOOK_SECRET')) throw new Error('STRIPE_WEBHOOK_SECRET not in vault');
-    // TODO: stripe.webhooks.constructEvent(rawBody, signature, secret)
-    const payload = JSON.parse(rawBody);
-    return { type: payload.type, payload };
+
+  async verifyWebhook(ctx, rawBody, signature): Promise<Webhook> {
+    const secret = ctx.secret('STRIPE_WEBHOOK_SECRET');
+    if (!secret) throw new Error('STRIPE_WEBHOOK_SECRET not in vault');
+    verifyStripeSignature(rawBody, signature, secret);
+
+    const payload = JSON.parse(rawBody) as StripeEvent;
+    const object = payload.data?.object ?? {};
+    return {
+      type: payload.type ?? 'unknown',
+      payload,
+      paymentId: typeof object.id === 'string' ? object.id : payload.id,
+      status: normalizeStripeStatus(object.status),
+      amount: typeof object.amount_total === 'number' ? object.amount_total : object.amount,
+      currency: typeof object.currency === 'string' ? object.currency.toUpperCase() : undefined,
+      customerEmail: object.customer_email ?? object.receipt_email,
+    };
   },
-  async refund(paymentId) {
-    return { id: `re_${Date.now()}` };
+
+  async refund(paymentId, amount) {
+    const secret = process.env.STRIPE_SECRET_KEY;
+    if (!secret) throw new Error('STRIPE_SECRET_KEY not in environment');
+    const body: Record<string, string> = { payment_intent: paymentId };
+    if (amount !== undefined) body.amount = String(amount);
+    const res = await stripeRequest(secret, '/refunds', body);
+    const refund = await readStripeJson<{ id?: string }>(res);
+    if (!refund.id) throw new Error('Stripe refund response did not include id');
+    return { id: refund.id };
   },
+
   async payout(accountId, amount, currency) {
-    // TODO: stripe.transfers.create({ amount, currency, destination: accountId })
-    return { id: `tr_${Date.now()}` };
+    const secret = process.env.STRIPE_SECRET_KEY;
+    if (!secret) throw new Error('STRIPE_SECRET_KEY not in environment');
+    const res = await stripeRequest(secret, '/transfers', {
+      amount: String(amount),
+      currency: currency.toLowerCase(),
+      destination: accountId,
+    });
+    const transfer = await readStripeJson<{ id?: string }>(res);
+    if (!transfer.id) throw new Error('Stripe transfer response did not include id');
+    return { id: transfer.id };
   },
 
   setup: tokenSetup<Config>({
@@ -46,12 +89,125 @@ export default definePayment<Config>({
     steps: [
       'Install stripe CLI from the official docs',
       'Authenticate locally: stripe login',
-      'Open dashboard.stripe.com → Developers → API keys',
-      'Copy the "Secret key" (sk_live_… or sk_test_… for test mode)',
+      'Open dashboard.stripe.com -> Developers -> API keys',
+      'Copy the "Secret key" (sk_live_... or sk_test_... for test mode)',
       'Webhook endpoint: set up https://dashboard.stripe.com/webhooks for your sh1pt cloud callback, copy the signing secret',
     ],
     fields: [
-      { key: 'STRIPE_WEBHOOK_SECRET', message: 'Paste the Stripe webhook signing secret (whsec_…):', secret: true },
+      { key: 'STRIPE_WEBHOOK_SECRET', message: 'Paste the Stripe webhook signing secret (whsec_...):', secret: true },
     ],
   }),
 });
+
+function buildCheckoutBody(req: CheckoutRequest): Record<string, string> {
+  const mode = req.kind === 'subscription' ? 'subscription' : 'payment';
+  const body: Record<string, string> = {
+    mode,
+    success_url: req.successUrl,
+    cancel_url: req.cancelUrl,
+    'line_items[0][quantity]': '1',
+  };
+
+  if (req.customerId) body.customer = req.customerId;
+  if (req.customerEmail && !req.customerId) body.customer_email = req.customerEmail;
+
+  if (req.priceId) {
+    body['line_items[0][price]'] = req.priceId;
+  } else {
+    body['line_items[0][price_data][currency]'] = req.currency.toLowerCase();
+    body['line_items[0][price_data][unit_amount]'] = String(req.amount);
+    body['line_items[0][price_data][product_data][name]'] = req.description ?? 'sh1pt checkout';
+  }
+
+  for (const [key, value] of Object.entries(req.metadata ?? {})) {
+    body[`metadata[${key}]`] = value;
+  }
+
+  if (mode === 'payment' && req.platformFeeBps && req.connectedAccountId) {
+    body['payment_intent_data[application_fee_amount]'] = String(
+      Math.round((req.amount * req.platformFeeBps) / 10_000),
+    );
+    body['payment_intent_data[transfer_data][destination]'] = req.connectedAccountId;
+  }
+
+  return body;
+}
+
+async function stripeRequest(
+  secret: string,
+  path: string,
+  body: Record<string, string>,
+  config: Config = {},
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    authorization: `Bearer ${secret}`,
+    'content-type': 'application/x-www-form-urlencoded',
+  };
+  if (config.apiVersion) headers['stripe-version'] = config.apiVersion;
+
+  return fetch(`${STRIPE_API}${path}`, {
+    method: 'POST',
+    headers,
+    body: new URLSearchParams(body),
+  });
+}
+
+async function readStripeJson<T>(res: Response): Promise<T> {
+  const json = await res.json().catch(() => ({})) as T & { error?: { message?: string } };
+  if (!res.ok) {
+    const message = json.error?.message ?? `Stripe API error ${res.status}`;
+    throw new Error(message);
+  }
+  return json;
+}
+
+function verifyStripeSignature(rawBody: string, header: string, secret: string): void {
+  const parts = Object.fromEntries(
+    header.split(',').map((part) => {
+      const [key, value] = part.split('=');
+      return [key, value];
+    }),
+  );
+  const timestamp = parts.t;
+  const signature = parts.v1;
+  if (!timestamp || !signature) throw new Error('Stripe-Signature missing t or v1');
+
+  const expected = createHmac('sha256', secret)
+    .update(`${timestamp}.${rawBody}`)
+    .digest('hex');
+
+  const actualBuffer = Buffer.from(signature, 'hex');
+  const expectedBuffer = Buffer.from(expected, 'hex');
+  if (actualBuffer.length !== expectedBuffer.length || !timingSafeEqual(actualBuffer, expectedBuffer)) {
+    throw new Error('Invalid Stripe webhook signature');
+  }
+}
+
+function normalizeStripeStatus(status: unknown): Webhook['status'] | undefined {
+  if (status === 'paid' || status === 'complete' || status === 'succeeded') return 'succeeded';
+  if (status === 'open' || status === 'processing' || status === 'requires_payment_method') return 'pending';
+  if (status === 'expired' || status === 'canceled' || status === 'failed') return 'failed';
+  return undefined;
+}
+
+interface StripeCheckoutSession {
+  id?: string;
+  url?: string;
+  expires_at?: number;
+}
+
+interface StripeEvent {
+  id?: string;
+  type?: string;
+  data?: {
+    object?: {
+      id?: string;
+      status?: string;
+      amount?: number;
+      amount_total?: number;
+      currency?: string;
+      customer_email?: string;
+      receipt_email?: string;
+    };
+  };
+}


### PR DESCRIPTION
Summary
- Replace the Stripe payment stub with Checkout Session API requests.
- Verify Stripe webhook signatures and normalize checkout event fields.
- Add refund and transfer calls for payment and payout flows.
- Cover request formatting, signature verification, and invalid signatures with focused tests.

Verification
- pnpm exec vitest run packages/payments/stripe/src/index.test.ts
- pnpm --filter @profullstack/sh1pt-payment-stripe typecheck