### PR TITLE
feat(social): implement Forem adapter

### DIFF
--- a/packages/social/forem/src/index.test.ts
+++ b/packages/social/forem/src/index.test.ts
@@ -1,4 +1,87 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { contractTestSocial, fakeConnectContext } from '@profullstack/sh1pt-core/testing';
 import adapter from './index.js';
 
-smokeTest(adapter, { idPrefix: 'social' });
+contractTestSocial(adapter, {
+  sampleConfig: { host: 'community.codenewbie.org', published: false },
+  samplePost: { title: 'Hello Forem', body: 'hello from sh1pt contract tests' },
+  requiredSecrets: ['FOREM_API_KEY_COMMUNITY_CODENEWBIE_ORG'],
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('social-forem posting', () => {
+  it('creates an article on the configured Forem host', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        id: 313,
+        url: 'https://community.codenewbie.org/sh1pt/release-notes',
+        published_at: '2026-05-11T20:00:00Z',
+      }),
+    } as Response);
+
+    const ctx = {
+      ...fakeConnectContext({ FOREM_API_KEY_COMMUNITY_CODENEWBIE_ORG: 'forem-key' }),
+      dryRun: false,
+    };
+
+    const result = await adapter.post(ctx as any, {
+      title: 'Release notes',
+      body: 'Article body',
+      hashtags: ['forem', 'api', 'typescript', 'automation', 'ignored'],
+      link: 'https://sh1pt.com',
+    }, {
+      host: 'https://community.codenewbie.org/',
+      published: true,
+      canonicalUrl: 'https://example.com/source',
+      organizationId: 123,
+    });
+
+    expect(result).toEqual({
+      id: '313',
+      url: 'https://community.codenewbie.org/sh1pt/release-notes',
+      platform: 'forem',
+      publishedAt: '2026-05-11T20:00:00.000Z',
+    });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://community.codenewbie.org/api/articles');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).headers).toMatchObject({
+      'api-key': 'forem-key',
+      'content-type': 'application/json',
+    });
+    expect(JSON.parse(String((init as RequestInit).body))).toEqual({
+      article: {
+        title: 'Release notes',
+        body_markdown: 'Article body\n\nhttps://sh1pt.com',
+        published: true,
+        tags: ['forem', 'api', 'typescript', 'automation'],
+        canonical_url: 'https://example.com/source',
+        organization_id: 123,
+      },
+    });
+  });
+
+  it('throws Forem API error messages when article creation fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 422,
+      statusText: 'Unprocessable Entity',
+      text: async () => JSON.stringify({ errors: ['Title has already been taken'] }),
+    } as Response);
+
+    const ctx = {
+      ...fakeConnectContext({ FOREM_API_KEY_COMMUNITY_CODENEWBIE_ORG: 'forem-key' }),
+      dryRun: false,
+    };
+
+    await expect(adapter.post(ctx as any, {
+      title: 'Release notes',
+      body: 'Article body',
+    }, { host: 'community.codenewbie.org' })).rejects.toThrow('Title has already been taken');
+  });
+});

--- a/packages/social/forem/src/index.ts
+++ b/packages/social/forem/src/index.ts
@@ -1,10 +1,13 @@
-import { defineSocial, oauthSetup } from '@profullstack/sh1pt-core';
+import { defineSocial, oauthSetup, type SocialPost } from '@profullstack/sh1pt-core';
 
 // Forem — the open-source platform DEV Community runs on, used by many
 // self-hosted communities (CodeNewbie, etc.). Same API shape as dev.to,
 // different host. Point this adapter at any Forem instance.
 interface Config {
   host: string;                 // e.g. 'community.codenewbie.org'
+  published?: boolean;          // false = draft
+  canonicalUrl?: string;
+  organizationId?: number;
 }
 
 export default defineSocial<Config>({
@@ -12,16 +15,38 @@ export default defineSocial<Config>({
   label: 'Forem (self-hosted)',
   requires: { maxHashtags: 4, hashtagsInBody: false },
   async connect(ctx, config) {
-    const key = `FOREM_API_KEY_${config.host.replace(/\W/g, '_').toUpperCase()}`;
+    const host = normalizeHost(config.host);
+    const key = secretKeyForHost(host);
     if (!ctx.secret(key)) throw new Error(`${key} not in vault`);
-    return { accountId: config.host };
+    return { accountId: host };
   },
   async post(ctx, post, config) {
     if (!post.title) throw new Error('Forem requires a title');
-    ctx.log(`forem article · ${config.host} · "${post.title}"`);
-    if (ctx.dryRun) return { id: 'dry-run', url: `https://${config.host}/`, platform: 'forem', publishedAt: new Date().toISOString() };
-    // TODO: POST https://${host}/api/articles
-    return { id: `forem_${Date.now()}`, url: `https://${config.host}/`, platform: 'forem', publishedAt: new Date().toISOString() };
+    const host = normalizeHost(config.host);
+    const key = secretKeyForHost(host);
+    const apiKey = ctx.secret(key);
+    if (!apiKey) throw new Error(`${key} not in vault`);
+    ctx.log(`forem article · ${host} · "${post.title}"`);
+    if (ctx.dryRun) return { id: 'dry-run', url: `https://${host}/`, platform: 'forem', publishedAt: new Date().toISOString() };
+
+    const res = await fetch(`https://${host}/api/articles`, {
+      method: 'POST',
+      headers: {
+        'api-key': apiKey,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ article: formatForemArticle(post, config) }),
+    });
+    if (!res.ok) throw new Error(await readForemError(res));
+
+    const article = await res.json() as ForemArticle;
+    if (article.id === undefined) throw new Error('Forem publish response did not include an article id');
+    return {
+      id: String(article.id),
+      url: article.url ?? `https://${host}/`,
+      platform: 'forem',
+      publishedAt: new Date(article.published_at ?? article.created_at ?? Date.now()).toISOString(),
+    };
   },
 
   setup: oauthSetup({
@@ -29,8 +54,47 @@ export default defineSocial<Config>({
     label: "Forem (self-hosted DEV)",
     vendorDocUrl: "https://dev.to/settings/extensions",
     steps: [
-      "On your Forem instance \u2192 Settings \u2192 Extensions \u2192 API Keys \u2192 Generate",
+      "On your Forem instance -> Settings -> Extensions -> API Keys -> Generate",
       "Note: host URL needs to be in your sh1pt.config.ts (e.g. https://my.forem.com)",
     ],
   }),
 });
+
+interface ForemArticle {
+  id?: number | string;
+  url?: string;
+  created_at?: string;
+  published_at?: string | null;
+}
+
+function formatForemArticle(post: SocialPost, config: Config): Record<string, unknown> {
+  const link = post.link ? `\n\n${post.link}` : '';
+  return {
+    title: post.title,
+    body_markdown: `${post.body}${link}`,
+    published: config.published ?? false,
+    tags: (post.hashtags ?? []).slice(0, 4),
+    canonical_url: config.canonicalUrl,
+    organization_id: config.organizationId,
+  };
+}
+
+function normalizeHost(host: string): string {
+  return host.replace(/^https?:\/\//, '').replace(/\/+$/, '');
+}
+
+function secretKeyForHost(host: string): string {
+  return `FOREM_API_KEY_${host.replace(/\W/g, '_').toUpperCase()}`;
+}
+
+async function readForemError(res: Response): Promise<string> {
+  const text = await res.text().catch(() => '');
+  if (!text) return res.statusText;
+  try {
+    const data = JSON.parse(text) as { error?: string; errors?: string[] | string };
+    if (Array.isArray(data.errors)) return data.errors.join('; ');
+    return data.error ?? data.errors ?? text;
+  } catch {
+    return text;
+  }
+}


### PR DESCRIPTION
Summary
- Replace the Forem stub with real article publishing via /api/articles.
- Normalize configured hosts and derive the per-host API key name.
- Parse Forem API errors and article responses instead of returning placeholder URLs.
- Add social contract coverage plus success and failure-path posting tests.

Verification
- pnpm exec vitest run packages/social/forem/src/index.test.ts
- pnpm --filter @profullstack/sh1pt-social-forem typecheck