### PR TITLE
feat(social): implement CodeNewbie adapter

### DIFF
--- a/packages/social/codenewbie/src/index.test.ts
+++ b/packages/social/codenewbie/src/index.test.ts
@@ -1,4 +1,81 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { contractTestSocial, fakeConnectContext } from '@profullstack/sh1pt-core/testing';
 import adapter from './index.js';
 
-smokeTest(adapter, { idPrefix: 'social' });
+contractTestSocial(adapter, {
+  sampleConfig: { published: false },
+  samplePost: { title: 'Hello CodeNewbie', body: 'hello from sh1pt contract tests' },
+  requiredSecrets: ['CODENEWBIE_API_KEY'],
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('social-codenewbie posting', () => {
+  it('creates a CodeNewbie article using the Forem API', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        id: 414,
+        url: 'https://community.codenewbie.org/sh1pt/release-notes',
+        published_at: '2026-05-11T20:00:00Z',
+      }),
+    } as Response);
+
+    const ctx = {
+      ...fakeConnectContext({ CODENEWBIE_API_KEY: 'codenewbie-key' }),
+      dryRun: false,
+    };
+
+    const result = await adapter.post(ctx as any, {
+      title: 'Release notes',
+      body: 'Article body',
+      hashtags: ['webdev', 'beginners', 'api', 'typescript', 'ignored'],
+      link: 'https://sh1pt.com',
+    }, { published: true, canonicalUrl: 'https://example.com/source' });
+
+    expect(result).toEqual({
+      id: '414',
+      url: 'https://community.codenewbie.org/sh1pt/release-notes',
+      platform: 'codenewbie',
+      publishedAt: '2026-05-11T20:00:00.000Z',
+    });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://community.codenewbie.org/api/articles');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).headers).toMatchObject({
+      'api-key': 'codenewbie-key',
+      'content-type': 'application/json',
+    });
+    expect(JSON.parse(String((init as RequestInit).body))).toEqual({
+      article: {
+        title: 'Release notes',
+        body_markdown: 'Article body\n\nhttps://sh1pt.com',
+        published: true,
+        tags: ['webdev', 'beginners', 'api', 'typescript'],
+        canonical_url: 'https://example.com/source',
+      },
+    });
+  });
+
+  it('throws CodeNewbie API error messages when article creation fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 422,
+      statusText: 'Unprocessable Entity',
+      text: async () => JSON.stringify({ errors: ['Body markdown is too short'] }),
+    } as Response);
+
+    const ctx = {
+      ...fakeConnectContext({ CODENEWBIE_API_KEY: 'codenewbie-key' }),
+      dryRun: false,
+    };
+
+    await expect(adapter.post(ctx as any, {
+      title: 'Release notes',
+      body: 'Short',
+    }, {})).rejects.toThrow('Body markdown is too short');
+  });
+});

--- a/packages/social/codenewbie/src/index.ts
+++ b/packages/social/codenewbie/src/index.ts
@@ -1,9 +1,15 @@
-import { defineSocial, oauthSetup } from '@profullstack/sh1pt-core';
+import { defineSocial, oauthSetup, type SocialPost } from '@profullstack/sh1pt-core';
 
 // CodeNewbie Community — runs on Forem. Functionally the same API as
 // social-forem pointed at community.codenewbie.org, but kept as its
 // own adapter so the badge + setup flow are explicit.
-interface Config {}
+interface Config {
+  published?: boolean;          // false = draft
+  canonicalUrl?: string;
+}
+
+const CODENEWBIE_API_URL = 'https://community.codenewbie.org/api/articles';
+const CODENEWBIE_HOME = 'https://community.codenewbie.org/';
 
 export default defineSocial<Config>({
   id: 'social-codenewbie',
@@ -13,12 +19,31 @@ export default defineSocial<Config>({
     if (!ctx.secret('CODENEWBIE_API_KEY')) throw new Error('CODENEWBIE_API_KEY not in vault');
     return { accountId: 'codenewbie' };
   },
-  async post(ctx, post) {
+  async post(ctx, post, config) {
     if (!post.title) throw new Error('CodeNewbie requires a title');
+    const apiKey = ctx.secret('CODENEWBIE_API_KEY');
+    if (!apiKey) throw new Error('CODENEWBIE_API_KEY not in vault');
     ctx.log(`codenewbie article · "${post.title}"`);
-    if (ctx.dryRun) return { id: 'dry-run', url: 'https://community.codenewbie.org/', platform: 'codenewbie', publishedAt: new Date().toISOString() };
-    // TODO: POST https://community.codenewbie.org/api/articles
-    return { id: `cn_${Date.now()}`, url: 'https://community.codenewbie.org/', platform: 'codenewbie', publishedAt: new Date().toISOString() };
+    if (ctx.dryRun) return { id: 'dry-run', url: CODENEWBIE_HOME, platform: 'codenewbie', publishedAt: new Date().toISOString() };
+
+    const res = await fetch(CODENEWBIE_API_URL, {
+      method: 'POST',
+      headers: {
+        'api-key': apiKey,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ article: formatCodeNewbieArticle(post, config) }),
+    });
+    if (!res.ok) throw new Error(await readCodeNewbieError(res));
+
+    const article = await res.json() as CodeNewbieArticle;
+    if (article.id === undefined) throw new Error('CodeNewbie publish response did not include an article id');
+    return {
+      id: String(article.id),
+      url: article.url ?? CODENEWBIE_HOME,
+      platform: 'codenewbie',
+      publishedAt: new Date(article.published_at ?? article.created_at ?? Date.now()).toISOString(),
+    };
   },
 
   setup: oauthSetup({
@@ -26,7 +51,37 @@ export default defineSocial<Config>({
     label: "CodeNewbie",
     vendorDocUrl: "https://www.codenewbie.org/",
     steps: [
-      "CodeNewbie runs on Forem \u2014 use a Forem API key from their instance",
+      "CodeNewbie runs on Forem; use a Forem API key from their instance",
     ],
   }),
 });
+
+interface CodeNewbieArticle {
+  id?: number | string;
+  url?: string;
+  created_at?: string;
+  published_at?: string | null;
+}
+
+function formatCodeNewbieArticle(post: SocialPost, config: Config): Record<string, unknown> {
+  const link = post.link ? `\n\n${post.link}` : '';
+  return {
+    title: post.title,
+    body_markdown: `${post.body}${link}`,
+    published: config.published ?? false,
+    tags: (post.hashtags ?? []).slice(0, 4),
+    canonical_url: config.canonicalUrl,
+  };
+}
+
+async function readCodeNewbieError(res: Response): Promise<string> {
+  const text = await res.text().catch(() => '');
+  if (!text) return res.statusText;
+  try {
+    const data = JSON.parse(text) as { error?: string; errors?: string[] | string };
+    if (Array.isArray(data.errors)) return data.errors.join('; ');
+    return data.error ?? data.errors ?? text;
+  } catch {
+    return text;
+  }
+}


### PR DESCRIPTION
Summary
- Replace the CodeNewbie stub with real article publishing through CodeNewbie's Forem API.
- Format article payloads with draft/published mode, tags, canonical URL, and links.
- Parse API errors and returned article metadata instead of returning placeholders.
- Add social contract coverage plus success and failure-path posting tests.

Verification
- pnpm exec vitest run packages/social/codenewbie/src/index.test.ts
- pnpm --filter @profullstack/sh1pt-social-codenewbie typecheck