### PR TITLE
feat: submit Reddit social posts

### DIFF
--- a/packages/social/reddit/src/index.test.ts
+++ b/packages/social/reddit/src/index.test.ts
@@ -1,4 +1,93 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { contractTestSocial, fakeConnectContext } from '@profullstack/sh1pt-core/testing';
 import adapter from './index.js';
 
-smokeTest(adapter, { idPrefix: 'social' });
+contractTestSocial(adapter, {
+  sampleConfig: { subreddit: 'sh1pt' },
+  samplePost: { title: 'Release shipped', body: 'hello from sh1pt contract tests' },
+  requiredSecrets: ['REDDIT_ACCESS_TOKEN'],
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('social-reddit posting', () => {
+  it('submits text posts to Reddit with an OAuth bearer token', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        json: {
+          data: {
+            id: 'abc123',
+            url: 'https://www.reddit.com/r/sh1pt/comments/abc123/release_shipped/',
+          },
+          errors: [],
+        },
+      }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ REDDIT_ACCESS_TOKEN: 'reddit-token' }),
+      dryRun: false,
+    };
+
+    const result = await adapter.post(ctx as any, {
+      title: 'Release shipped',
+      body: 'Article body',
+    }, {
+      subreddit: 'sh1pt',
+      kind: 'self',
+      flairId: 'flair_1',
+    });
+
+    expect(result).toEqual({
+      id: 'abc123',
+      url: 'https://www.reddit.com/r/sh1pt/comments/abc123/release_shipped/',
+      platform: 'reddit',
+      publishedAt: expect.any(String),
+    });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://oauth.reddit.com/api/submit');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).headers).toMatchObject({
+      authorization: 'Bearer reddit-token',
+      'content-type': 'application/x-www-form-urlencoded',
+    });
+    const body = new URLSearchParams(String((init as RequestInit).body));
+    expect(Object.fromEntries(body)).toMatchObject({
+      api_type: 'json',
+      flair_id: 'flair_1',
+      kind: 'self',
+      sr: 'sh1pt',
+      text: 'Article body',
+      title: 'Release shipped',
+    });
+  });
+
+  it('surfaces Reddit submit errors', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        json: {
+          data: {},
+          errors: [['RATELIMIT', 'you are doing that too much', 'ratelimit']],
+        },
+      }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ REDDIT_ACCESS_TOKEN: 'reddit-token' }),
+      dryRun: false,
+    };
+
+    await expect(adapter.post(ctx as any, {
+      title: 'Release shipped',
+      body: 'Article body',
+    }, {
+      subreddit: 'sh1pt',
+    })).rejects.toThrow('RATELIMIT: you are doing that too much');
+  });
+});

--- a/packages/social/reddit/src/index.ts
+++ b/packages/social/reddit/src/index.ts
@@ -9,21 +9,49 @@ interface Config {
   flairId?: string;
 }
 
+interface RedditSubmitResponse {
+  json?: {
+    data?: {
+      id?: string;
+      url?: string;
+    };
+    errors?: Array<[string, string, string?]>;
+  };
+}
+
 export default defineSocial<Config>({
   id: 'social-reddit',
   label: 'Reddit',
   requires: { maxBodyChars: 40_000, maxHashtags: 0 },   // Reddit doesn't use hashtags
   async connect(ctx) {
     if (!ctx.secret('REDDIT_ACCESS_TOKEN') && !ctx.secret('REDDIT_REFRESH_TOKEN')) {
-      throw new Error('Reddit needs REDDIT_ACCESS_TOKEN or REDDIT_REFRESH_TOKEN in vault');
+      throw new Error('REDDIT_ACCESS_TOKEN or REDDIT_REFRESH_TOKEN not in vault — run: sh1pt secret set REDDIT_ACCESS_TOKEN <access-token>');
     }
     return { accountId: 'reddit' };
   },
   async post(ctx, post, config) {
+    if (!post.title) throw new Error('Reddit requires a title');
+    const token = ctx.secret('REDDIT_ACCESS_TOKEN');
+    if (!token) throw new Error('REDDIT_ACCESS_TOKEN not in vault — run: sh1pt secret set REDDIT_ACCESS_TOKEN <access-token>');
     ctx.log(`reddit submit · r/${config.subreddit} · kind=${config.kind ?? 'self'}`);
     if (ctx.dryRun) return { id: 'dry-run', url: `https://reddit.com/r/${config.subreddit}`, platform: 'reddit', publishedAt: new Date().toISOString() };
-    // TODO: POST /api/submit with { sr, kind, title, text|url, flair_id }
-    return { id: `rd_${Date.now()}`, url: `https://reddit.com/r/${config.subreddit}`, platform: 'reddit', publishedAt: new Date().toISOString() };
+
+    const res = await fetch('https://oauth.reddit.com/api/submit', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body: formatSubmitBody(post, config),
+    });
+    const data = await parseSubmitResponse(res);
+    if (!res.ok) throw new Error(data.json?.errors?.[0]?.[1] ?? res.statusText);
+    const redditError = data.json?.errors?.[0];
+    if (redditError) throw new Error(`${redditError[0]}: ${redditError[1]}`);
+
+    const submitted = data.json?.data;
+    if (!submitted?.id || !submitted.url) throw new Error('Reddit submit response did not include a post id and URL');
+    return { id: submitted.id, url: submitted.url, platform: 'reddit', publishedAt: new Date().toISOString() };
   },
 
   setup: oauthSetup({
@@ -54,3 +82,28 @@ export default defineSocial<Config>({
       : {}),
   }),
 });
+
+function formatSubmitBody(post: { title?: string; body: string; link?: string }, config: Config): URLSearchParams {
+  const kind = config.kind ?? (post.link ? 'link' : 'self');
+  const body = new URLSearchParams({
+    api_type: 'json',
+    kind,
+    sr: config.subreddit,
+    title: post.title ?? '',
+  });
+  if (config.flairId) body.set('flair_id', config.flairId);
+  if (kind === 'link') {
+    body.set('url', post.link ?? post.body);
+  } else {
+    body.set('text', post.body.slice(0, 40_000));
+  }
+  return body;
+}
+
+async function parseSubmitResponse(res: Response): Promise<RedditSubmitResponse> {
+  try {
+    return await res.json() as RedditSubmitResponse;
+  } catch {
+    return { json: { errors: [['HTTP_ERROR', res.statusText]] } };
+  }
+}


### PR DESCRIPTION
## Summary
- replace the Reddit social adapter stub with a real OAuth `/api/submit` request
- support self/link submit payloads, flair IDs, Reddit API errors, and missing response validation
- upgrade the Reddit adapter from smoke-only coverage to the social contract plus submit/error tests

## Tests
- `pnpm exec vitest run packages/social/reddit/src/index.test.ts`
- `pnpm --filter @profullstack/sh1pt-social-reddit typecheck`
