### PR TITLE
feat: publish Mastodon social posts

### DIFF
--- a/packages/social/mastodon/src/index.test.ts
+++ b/packages/social/mastodon/src/index.test.ts
@@ -1,4 +1,78 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { contractTestSocial, fakeConnectContext } from '@profullstack/sh1pt-core/testing';
 import adapter from './index.js';
 
-smokeTest(adapter, { idPrefix: 'social' });
+contractTestSocial(adapter, {
+  sampleConfig: { instance: 'mastodon.social' },
+  samplePost: { body: 'hello from sh1pt contract tests' },
+  requiredSecrets: ['MASTODON_TOKEN_MASTODON_SOCIAL'],
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('social-mastodon posting', () => {
+  it('creates statuses on the selected Mastodon instance', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: '109876',
+        url: 'https://mastodon.social/@sh1pt/109876',
+        created_at: '2026-05-12T16:40:00Z',
+      }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ MASTODON_TOKEN_MASTODON_SOCIAL: 'mastodon-token' }),
+      dryRun: false,
+    };
+
+    const result = await adapter.post(ctx as any, {
+      body: 'Release shipped',
+      link: 'https://sh1pt.com',
+    }, {
+      instance: 'mastodon.social',
+      visibility: 'unlisted',
+    });
+
+    expect(result).toEqual({
+      id: '109876',
+      url: 'https://mastodon.social/@sh1pt/109876',
+      platform: 'mastodon',
+      publishedAt: '2026-05-12T16:40:00.000Z',
+    });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://mastodon.social/api/v1/statuses');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).headers).toMatchObject({
+      authorization: 'Bearer mastodon-token',
+      'content-type': 'application/json',
+    });
+    expect(JSON.parse(String((init as RequestInit).body))).toEqual({
+      status: 'Release shipped\nhttps://sh1pt.com',
+      visibility: 'unlisted',
+    });
+  });
+
+  it('surfaces Mastodon API errors', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 422,
+      statusText: 'Unprocessable Entity',
+      json: async () => ({ error: "Validation failed: Text can't be blank" }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ MASTODON_TOKEN_MASTODON_SOCIAL: 'mastodon-token' }),
+      dryRun: false,
+    };
+
+    await expect(adapter.post(ctx as any, {
+      body: 'Release shipped',
+    }, {
+      instance: 'mastodon.social',
+    })).rejects.toThrow('Validation failed');
+  });
+});

--- a/packages/social/mastodon/src/index.ts
+++ b/packages/social/mastodon/src/index.ts
@@ -7,6 +7,14 @@ interface Config {
   visibility?: 'public' | 'unlisted' | 'private' | 'direct';
 }
 
+interface MastodonStatusResponse {
+  id?: string;
+  url?: string;
+  uri?: string;
+  created_at?: string;
+  error?: string;
+}
+
 export default defineSocial<Config>({
   id: 'social-mastodon',
   label: 'Mastodon (Fediverse)',
@@ -18,10 +26,32 @@ export default defineSocial<Config>({
     return { accountId: config.instance };
   },
   async post(ctx, post, config) {
+    const instance = normalizeInstance(config.instance);
+    const token = ctx.secret(tokenSecretKey(instance));
+    if (!token) throw new Error(`Mastodon token for ${instance} not in vault`);
     ctx.log(`mastodon post · ${config.instance} · ${post.body.length} chars`);
     if (ctx.dryRun) return { id: 'dry-run', url: `https://${config.instance}/`, platform: 'mastodon', publishedAt: new Date().toISOString() };
-    // TODO: POST https://${instance}/api/v1/statuses with { status, visibility, media_ids }
-    return { id: `mst_${Date.now()}`, url: `https://${config.instance}/`, platform: 'mastodon', publishedAt: new Date().toISOString() };
+
+    const res = await fetch(`https://${instance}/api/v1/statuses`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        status: formatStatus(post),
+        visibility: config.visibility ?? 'public',
+      }),
+    });
+    const data = await parseStatusResponse(res);
+    if (!res.ok) throw new Error(data.error ?? res.statusText);
+    if (!data.id) throw new Error('Mastodon status response did not include a status id');
+    return {
+      id: data.id,
+      url: data.url ?? data.uri ?? `https://${instance}/`,
+      platform: 'mastodon',
+      publishedAt: new Date(data.created_at ?? Date.now()).toISOString(),
+    };
   },
 
   setup: oauthSetup({
@@ -35,3 +65,23 @@ export default defineSocial<Config>({
     ],
   }),
 });
+
+function tokenSecretKey(instance: string): string {
+  return `MASTODON_TOKEN_${instance.replace(/\./g, '_').toUpperCase()}`;
+}
+
+function normalizeInstance(instance: string): string {
+  return instance.replace(/^https?:\/\//, '').replace(/\/$/, '');
+}
+
+function formatStatus(post: { body: string; link?: string }): string {
+  return post.link ? `${post.body}\n${post.link}` : post.body;
+}
+
+async function parseStatusResponse(res: Response): Promise<MastodonStatusResponse> {
+  try {
+    return await res.json() as MastodonStatusResponse;
+  } catch {
+    return { error: res.statusText };
+  }
+}


### PR DESCRIPTION
## Summary
- replace the Mastodon social adapter stub with a real `POST /api/v1/statuses` request
- use per-instance Mastodon access tokens and normalize instance URLs
- add social contract coverage plus status publish/error tests

## Tests
- `pnpm exec vitest run packages/social/mastodon/src/index.test.ts`
- `pnpm --filter @profullstack/sh1pt-social-mastodon typecheck`
