### PR TITLE
feat: publish Bluesky social posts

### DIFF
--- a/packages/social/bluesky/src/index.test.ts
+++ b/packages/social/bluesky/src/index.test.ts
@@ -1,8 +1,95 @@
-import { contractTestSocial } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { contractTestSocial, fakeConnectContext } from '@profullstack/sh1pt-core/testing';
 import social from './index.js';
 
 contractTestSocial(social, {
   sampleConfig: { handle: 'test.bsky.social' },
   samplePost: { body: 'hello from sh1pt contract tests' },
   requiredSecrets: ['BLUESKY_APP_PASSWORD'],
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('social-bluesky posting', () => {
+  it('creates a session and publishes a feed post record', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          did: 'did:plc:abc123',
+          accessJwt: 'jwt-token',
+        }),
+      } as any)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          uri: 'at://did:plc:abc123/app.bsky.feed.post/3kabc',
+          cid: 'bafyreicid',
+        }),
+      } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ BLUESKY_APP_PASSWORD: 'app-password' }),
+      dryRun: false,
+    };
+
+    const result = await social.post(ctx as any, {
+      body: 'Release shipped',
+      link: 'https://sh1pt.com',
+    }, {
+      handle: 'sh1pt.bsky.social',
+    });
+
+    expect(result).toEqual({
+      id: 'at://did:plc:abc123/app.bsky.feed.post/3kabc',
+      url: 'https://bsky.app/profile/sh1pt.bsky.social/post/3kabc',
+      platform: 'bluesky',
+      publishedAt: expect.any(String),
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://bsky.social/xrpc/com.atproto.server.createSession');
+    expect(JSON.parse(String((fetchMock.mock.calls[0]?.[1] as RequestInit).body))).toEqual({
+      identifier: 'sh1pt.bsky.social',
+      password: 'app-password',
+    });
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('https://bsky.social/xrpc/com.atproto.repo.createRecord');
+    expect((fetchMock.mock.calls[1]?.[1] as RequestInit).headers).toMatchObject({
+      authorization: 'Bearer jwt-token',
+      'content-type': 'application/json',
+    });
+    const recordPayload = JSON.parse(String((fetchMock.mock.calls[1]?.[1] as RequestInit).body));
+    expect(recordPayload).toMatchObject({
+      repo: 'did:plc:abc123',
+      collection: 'app.bsky.feed.post',
+      record: {
+        $type: 'app.bsky.feed.post',
+        text: 'Release shipped\nhttps://sh1pt.com',
+      },
+    });
+    expect(recordPayload.record.createdAt).toEqual(expect.any(String));
+  });
+
+  it('surfaces Bluesky API errors', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      json: async () => ({ error: 'AuthenticationRequired', message: 'Invalid identifier or password' }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ BLUESKY_APP_PASSWORD: 'bad-password' }),
+      dryRun: false,
+    };
+
+    await expect(social.post(ctx as any, {
+      body: 'Release shipped',
+    }, {
+      handle: 'sh1pt.bsky.social',
+    })).rejects.toThrow('Invalid identifier or password');
+  });
 });

--- a/packages/social/bluesky/src/index.ts
+++ b/packages/social/bluesky/src/index.ts
@@ -1,4 +1,4 @@
-import { defineSocial, oauthSetup } from '@profullstack/sh1pt-core';
+import { defineSocial, oauthSetup, type SocialPost } from '@profullstack/sh1pt-core';
 
 // Bluesky — AT Protocol. Auth via app password (Settings → App Passwords
 // in the Bluesky app; do NOT use the main account password). Endpoint:
@@ -6,6 +6,21 @@ import { defineSocial, oauthSetup } from '@profullstack/sh1pt-core';
 interface Config {
   handle: string;              // e.g. 'alice.bsky.social'
   pds?: string;                // default 'https://bsky.social'
+}
+
+interface BlueskyErrorResponse {
+  error?: string;
+  message?: string;
+}
+
+interface CreateSessionResponse extends BlueskyErrorResponse {
+  did?: string;
+  accessJwt?: string;
+}
+
+interface CreateRecordResponse extends BlueskyErrorResponse {
+  uri?: string;
+  cid?: string;
 }
 
 export default defineSocial<Config>({
@@ -17,10 +32,23 @@ export default defineSocial<Config>({
     return { accountId: config.handle };
   },
   async post(ctx, post, config) {
+    const appPassword = ctx.secret('BLUESKY_APP_PASSWORD');
+    if (!appPassword) throw new Error('BLUESKY_APP_PASSWORD not in vault (create in Settings → App Passwords)');
+    const pds = normalizePds(config.pds);
     ctx.log(`bluesky post · @${config.handle} · ${post.body.length} chars`);
     if (ctx.dryRun) return { id: 'dry-run', url: `https://bsky.app/profile/${config.handle}`, platform: 'bluesky', publishedAt: new Date().toISOString() };
-    // TODO: AT Proto flow — createSession → uploadBlob (per media) → createRecord app.bsky.feed.post
-    return { id: `bsky_${Date.now()}`, url: `https://bsky.app/profile/${config.handle}`, platform: 'bluesky', publishedAt: new Date().toISOString() };
+
+    const session = await createSession(pds, config.handle, appPassword);
+    if (!session.did || !session.accessJwt) throw new Error('Bluesky createSession response did not include did and accessJwt');
+    const record = await createPostRecord(pds, session.did, session.accessJwt, post);
+    if (!record.uri) throw new Error('Bluesky createRecord response did not include a record URI');
+
+    return {
+      id: record.uri,
+      url: postUrl(config.handle, record.uri),
+      platform: 'bluesky',
+      publishedAt: new Date().toISOString(),
+    };
   },
 
   setup: oauthSetup({
@@ -34,3 +62,58 @@ export default defineSocial<Config>({
     ],
   }),
 });
+
+function normalizePds(pds = 'https://bsky.social'): string {
+  return pds.replace(/\/$/, '');
+}
+
+function formatPostText(post: SocialPost): string {
+  const link = post.link ? `\n${post.link}` : '';
+  return `${post.body}${link}`.slice(0, 300);
+}
+
+async function createSession(pds: string, identifier: string, password: string): Promise<CreateSessionResponse> {
+  const res = await fetch(`${pds}/xrpc/com.atproto.server.createSession`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ identifier, password }),
+  });
+  const data = await readJson<CreateSessionResponse>(res);
+  if (!res.ok) throw new Error(data.message ?? data.error ?? res.statusText);
+  return data;
+}
+
+async function createPostRecord(pds: string, repo: string, accessJwt: string, post: SocialPost): Promise<CreateRecordResponse> {
+  const res = await fetch(`${pds}/xrpc/com.atproto.repo.createRecord`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${accessJwt}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      repo,
+      collection: 'app.bsky.feed.post',
+      record: {
+        $type: 'app.bsky.feed.post',
+        text: formatPostText(post),
+        createdAt: new Date().toISOString(),
+      },
+    }),
+  });
+  const data = await readJson<CreateRecordResponse>(res);
+  if (!res.ok) throw new Error(data.message ?? data.error ?? res.statusText);
+  return data;
+}
+
+async function readJson<T extends BlueskyErrorResponse>(res: Response): Promise<T> {
+  try {
+    return await res.json() as T;
+  } catch {
+    return { error: res.statusText } as T;
+  }
+}
+
+function postUrl(handle: string, uri: string): string {
+  const rkey = uri.split('/').pop();
+  return rkey ? `https://bsky.app/profile/${handle}/post/${rkey}` : `https://bsky.app/profile/${handle}`;
+}


### PR DESCRIPTION
## Summary
- replace the Bluesky social adapter stub with the AT Protocol createSession/createRecord flow
- publish `app.bsky.feed.post` records and return canonical bsky.app post URLs
- add social contract coverage plus publish/error tests

## Tests
- `pnpm exec vitest run packages/social/bluesky/src/index.test.ts`
- `pnpm --filter @profullstack/sh1pt-social-bluesky typecheck`
