### PR TITLE
feat: integrate Groq AI adapter

### DIFF
--- a/packages/ai/groq/src/index.test.ts
+++ b/packages/ai/groq/src/index.test.ts
@@ -1,4 +1,80 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { GROQ_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Groq OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ GROQ_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'llama-3.3-70b-versatile' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from groq' } }],
+        model: 'llama-3.1-8b-instant',
+        usage: { prompt_tokens: 7, completion_tokens: 3 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'llama-3.1-8b-instant',
+      system: 'be brief',
+      maxTokens: 20,
+      temperature: 0.2,
+      extra: { top_p: 0.9 },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.groq.com/openai/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'llama-3.1-8b-instant',
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 20,
+      temperature: 0.2,
+      top_p: 0.9,
+    });
+    expect(result).toEqual({
+      text: 'hi from groq',
+      model: 'llama-3.1-8b-instant',
+      inputTokens: 7,
+      outputTokens: 3,
+    });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => 'rate limited'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/Groq 429: rate limited/);
+  });
+});

--- a/packages/ai/groq/src/index.ts
+++ b/packages/ai/groq/src/index.ts
@@ -4,17 +4,56 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.groq.com/openai';
+
 export default defineAi<Config>({
   id: 'ai-groq',
   label: 'Groq',
   defaultModel: 'llama-3.3-70b-versatile',
-  models: ['llama-3.3-70b-versatile'],
+  models: [
+    'llama-3.3-70b-versatile',
+    'llama-3.1-8b-instant',
+    'mixtral-8x7b-32768',
+    'deepseek-r1-distill-llama-70b',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('GROQ_API_KEY');
-    if (!apiKey) throw new Error('GROQ_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-groq · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-groq integration not yet implemented]', model: 'llama-3.3-70b-versatile' };
+    if (!apiKey) throw new Error('GROQ_API_KEY not in vault');
+    const model = opts.model ?? 'llama-3.3-70b-versatile';
+    ctx.log(`groq · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Groq ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({


### PR DESCRIPTION
## Summary
- replace the Groq AI stub with an OpenAI-compatible chat completions request
- add the requested Groq model list and default model
- support dry-run short-circuiting, usage token mapping, and status/body excerpts on provider errors

## Verification
- pnpm exec vitest run packages/ai/groq/src/index.test.ts
- pnpm --filter @profullstack/sh1pt-ai-groq typecheck
- git diff --check

Part of #63.