### PR TITLE
feat: integrate DeepSeek AI adapter

### DIFF
--- a/packages/ai/deepseek/src/index.test.ts
+++ b/packages/ai/deepseek/src/index.test.ts
@@ -1,4 +1,80 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { DEEPSEEK_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('DeepSeek OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ DEEPSEEK_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'deepseek-chat' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from deepseek' } }],
+        model: 'deepseek-reasoner',
+        usage: { prompt_tokens: 9, completion_tokens: 5 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'deepseek-reasoner',
+      system: 'be concise',
+      maxTokens: 30,
+      temperature: 0.1,
+      extra: { top_p: 0.8 },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.deepseek.com/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'deepseek-reasoner',
+      messages: [
+        { role: 'system', content: 'be concise' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 30,
+      temperature: 0.1,
+      top_p: 0.8,
+    });
+    expect(result).toEqual({
+      text: 'hi from deepseek',
+      model: 'deepseek-reasoner',
+      inputTokens: 9,
+      outputTokens: 5,
+    });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => 'invalid api key'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/DeepSeek 401: invalid api key/);
+  });
+});

--- a/packages/ai/deepseek/src/index.ts
+++ b/packages/ai/deepseek/src/index.ts
@@ -4,17 +4,51 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.deepseek.com';
+
 export default defineAi<Config>({
   id: 'ai-deepseek',
   label: 'DeepSeek',
   defaultModel: 'deepseek-chat',
-  models: ['deepseek-chat'],
+  models: ['deepseek-chat', 'deepseek-reasoner'],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('DEEPSEEK_API_KEY');
-    if (!apiKey) throw new Error('DEEPSEEK_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-deepseek · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-deepseek integration not yet implemented]', model: 'deepseek-chat' };
+    if (!apiKey) throw new Error('DEEPSEEK_API_KEY not in vault');
+    const model = opts.model ?? 'deepseek-chat';
+    ctx.log(`deepseek · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`DeepSeek ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({


### PR DESCRIPTION
## Summary
- replace the DeepSeek AI stub with an OpenAI-compatible chat completions request
- add the requested DeepSeek model list: deepseek-chat and deepseek-reasoner
- support dry-run short-circuiting, usage token mapping, and status/body excerpts on provider errors

## Verification
- pnpm exec vitest run packages/ai/deepseek/src/index.test.ts
- pnpm --filter @profullstack/sh1pt-ai-deepseek typecheck
- git diff --check

Part of #63.