### PR TITLE
feat: integrate xAI adapter

### DIFF
--- a/packages/ai/xai/src/index.test.ts
+++ b/packages/ai/xai/src/index.test.ts
@@ -1,4 +1,80 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { XAI_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('xAI OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ XAI_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'grok-3' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from xai' } }],
+        model: 'grok-3-mini',
+        usage: { prompt_tokens: 6, completion_tokens: 2 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'grok-3-mini',
+      system: 'be terse',
+      maxTokens: 18,
+      temperature: 0.4,
+      extra: { top_p: 0.85 },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.x.ai/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'grok-3-mini',
+      messages: [
+        { role: 'system', content: 'be terse' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 18,
+      temperature: 0.4,
+      top_p: 0.85,
+    });
+    expect(result).toEqual({
+      text: 'hi from xai',
+      model: 'grok-3-mini',
+      inputTokens: 6,
+      outputTokens: 2,
+    });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: async () => 'forbidden'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/xAI 403: forbidden/);
+  });
+});

--- a/packages/ai/xai/src/index.ts
+++ b/packages/ai/xai/src/index.ts
@@ -4,17 +4,51 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.x.ai';
+
 export default defineAi<Config>({
   id: 'ai-xai',
   label: 'xAI',
   defaultModel: 'grok-3',
-  models: ['grok-3'],
+  models: ['grok-3', 'grok-3-mini', 'grok-2-latest'],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('XAI_API_KEY');
-    if (!apiKey) throw new Error('XAI_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-xai · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-xai integration not yet implemented]', model: 'grok-3' };
+    if (!apiKey) throw new Error('XAI_API_KEY not in vault');
+    const model = opts.model ?? 'grok-3';
+    ctx.log(`xai · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`xAI ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({


### PR DESCRIPTION
## Summary
- replace the xAI stub with an OpenAI-compatible chat completions request
- add the requested xAI model list
- support dry-run short-circuiting, usage token mapping, and status/body excerpts on provider errors

## Verification
- pnpm exec vitest run packages/ai/xai/src/index.test.ts
- pnpm --filter @profullstack/sh1pt-ai-xai typecheck
- git diff --check

Part of #63.