### PR TITLE
feat: integrate Cerebras AI adapter

### DIFF
--- a/packages/ai/cerebras/src/index.test.ts
+++ b/packages/ai/cerebras/src/index.test.ts
@@ -1,4 +1,80 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { CEREBRAS_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Cerebras OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ CEREBRAS_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'llama-3.3-70b' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from cerebras' } }],
+        model: 'llama3.1-8b',
+        usage: { prompt_tokens: 10, completion_tokens: 4 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'llama3.1-8b',
+      system: 'be brief',
+      maxTokens: 22,
+      temperature: 0.2,
+      extra: { top_p: 0.9 },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.cerebras.ai/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'llama3.1-8b',
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 22,
+      temperature: 0.2,
+      top_p: 0.9,
+    });
+    expect(result).toEqual({
+      text: 'hi from cerebras',
+      model: 'llama3.1-8b',
+      inputTokens: 10,
+      outputTokens: 4,
+    });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'server error'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/Cerebras 500: server error/);
+  });
+});

--- a/packages/ai/cerebras/src/index.ts
+++ b/packages/ai/cerebras/src/index.ts
@@ -4,17 +4,51 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.cerebras.ai';
+
 export default defineAi<Config>({
   id: 'ai-cerebras',
   label: 'Cerebras',
   defaultModel: 'llama-3.3-70b',
-  models: ['llama-3.3-70b'],
+  models: ['llama-3.3-70b', 'llama3.1-8b'],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('CEREBRAS_API_KEY');
-    if (!apiKey) throw new Error('CEREBRAS_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-cerebras · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-cerebras integration not yet implemented]', model: 'llama-3.3-70b' };
+    if (!apiKey) throw new Error('CEREBRAS_API_KEY not in vault');
+    const model = opts.model ?? 'llama-3.3-70b';
+    ctx.log(`cerebras · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Cerebras ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({


### PR DESCRIPTION
## Summary
- replace the Cerebras AI stub with an OpenAI-compatible chat completions request
- add the requested Cerebras model list
- support dry-run short-circuiting, usage token mapping, and status/body excerpts on provider errors

## Verification
- pnpm exec vitest run packages/ai/cerebras/src/index.test.ts
- pnpm --filter @profullstack/sh1pt-ai-cerebras typecheck
- git diff --check

Part of #63.