### PR TITLE
feat(ai): integrate Together AI adapter

### DIFF
--- a/packages/ai/together/src/index.test.ts
+++ b/packages/ai/together/src/index.test.ts
@@ -1,4 +1,80 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { TOGETHER_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Together AI OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ TOGETHER_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'meta-llama/Llama-3.3-70B-Instruct-Turbo' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from together' } }],
+        model: 'meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo',
+        usage: { prompt_tokens: 9, completion_tokens: 4 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo',
+      system: 'be brief',
+      maxTokens: 20,
+      temperature: 0.2,
+      extra: { top_p: 0.9 },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.together.xyz/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo',
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 20,
+      temperature: 0.2,
+      top_p: 0.9,
+    });
+    expect(result).toEqual({
+      text: 'hi from together',
+      model: 'meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo',
+      inputTokens: 9,
+      outputTokens: 4,
+    });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => 'rate limited'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/Together AI 429: rate limited/);
+  });
+});

--- a/packages/ai/together/src/index.ts
+++ b/packages/ai/together/src/index.ts
@@ -4,17 +4,57 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.together.xyz';
+
 export default defineAi<Config>({
   id: 'ai-together',
   label: 'Together AI',
   defaultModel: 'meta-llama/Llama-3.3-70B-Instruct-Turbo',
-  models: ['meta-llama/Llama-3.3-70B-Instruct-Turbo'],
+  models: [
+    'meta-llama/Llama-3.3-70B-Instruct-Turbo',
+    'meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo',
+    'meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo',
+    'deepseek-ai/DeepSeek-R1-Distill-Llama-70B',
+    'Qwen/Qwen2.5-72B-Instruct-Turbo',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('TOGETHER_API_KEY');
-    if (!apiKey) throw new Error('TOGETHER_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-together · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-together integration not yet implemented]', model: 'meta-llama/Llama-3.3-70B-Instruct-Turbo' };
+    if (!apiKey) throw new Error('TOGETHER_API_KEY not in vault');
+    const model = opts.model ?? 'meta-llama/Llama-3.3-70B-Instruct-Turbo';
+    ctx.log(`together · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Together AI ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({


### PR DESCRIPTION
## Summary
- replace the Together AI stub with an OpenAI-compatible chat completions implementation
- add current Together model IDs, dry-run behavior, usage-token mapping, and concise HTTP error messages
- cover the request shape, dry-run short-circuit, and error handling with focused Vitest tests

This implements one of the AI provider adapters requested in #6.

## Validation
- `git diff --check`
- `corepack pnpm exec vitest run packages/ai/together/src/index.test.ts`
- `corepack pnpm exec tsc -p packages/ai/together/tsconfig.json --noEmit`

Note: the repo's full workspace install currently fails before reaching this adapter because `packages/dns/azure` depends on `@sh1pt/core@workspace:*`, while the workspace package is named `@profullstack/sh1pt-core`. I validated this package with root dev tooling and a local link to `packages/core` instead of changing unrelated workspace metadata.
