### PR TITLE
feat(ai): integrate Perplexity adapter

### DIFF
--- a/packages/ai/perplexity/src/index.test.ts
+++ b/packages/ai/perplexity/src/index.test.ts
@@ -1,4 +1,80 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { PERPLEXITY_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Perplexity Sonar generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ PERPLEXITY_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'sonar-pro' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts Sonar requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from perplexity' } }],
+        model: 'sonar',
+        usage: { prompt_tokens: 8, completion_tokens: 5 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'sonar',
+      system: 'be brief',
+      maxTokens: 20,
+      temperature: 0.2,
+      extra: { search_recency_filter: 'month' },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.perplexity.ai/v1/sonar');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'sonar',
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 20,
+      temperature: 0.2,
+      search_recency_filter: 'month',
+    });
+    expect(result).toEqual({
+      text: 'hi from perplexity',
+      model: 'sonar',
+      inputTokens: 8,
+      outputTokens: 5,
+    });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => 'rate limited'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/Perplexity 429: rate limited/);
+  });
+});

--- a/packages/ai/perplexity/src/index.ts
+++ b/packages/ai/perplexity/src/index.ts
@@ -4,17 +4,56 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.perplexity.ai';
+
 export default defineAi<Config>({
   id: 'ai-perplexity',
   label: 'Perplexity',
-  defaultModel: 'llama-3.1-sonar-large-128k-online',
-  models: ['llama-3.1-sonar-large-128k-online'],
+  defaultModel: 'sonar-pro',
+  models: [
+    'sonar',
+    'sonar-pro',
+    'sonar-reasoning-pro',
+    'sonar-deep-research',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('PERPLEXITY_API_KEY');
-    if (!apiKey) throw new Error('PERPLEXITY_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-perplexity · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-perplexity integration not yet implemented]', model: 'llama-3.1-sonar-large-128k-online' };
+    if (!apiKey) throw new Error('PERPLEXITY_API_KEY not in vault');
+    const model = opts.model ?? 'sonar-pro';
+    ctx.log(`perplexity · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/sonar`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Perplexity ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({


### PR DESCRIPTION
## Summary
- replace the Perplexity stub with a working Sonar API implementation
- update the deprecated `llama-3.1-sonar-*` default to the current Sonar model family
- map OpenAI-compatible response text and usage tokens, keep dry-run behavior, and pass Perplexity-specific options through `opts.extra`
- cover request shape, dry-run short-circuiting, and HTTP error excerpts with focused Vitest tests

This implements another AI provider adapter for #6.

## Notes
Perplexity's current docs describe Sonar as OpenAI Chat Completions compatible, with `https://api.perplexity.ai` as the base URL and canonical `POST /v1/sonar` for direct API calls. The old `llama-3.1-sonar-*` API model names were deprecated, so this adapter now defaults to `sonar-pro` and includes `sonar`, `sonar-pro`, `sonar-reasoning-pro`, and `sonar-deep-research`.

## Validation
- `git diff --check`
- `corepack pnpm exec vitest run packages/ai/perplexity/src/index.test.ts`
- `corepack pnpm exec tsc -p packages/ai/perplexity/tsconfig.json --noEmit`

As with #76, the repo's full workspace install is currently blocked by the unrelated `packages/dns/azure` dependency on missing workspace package `@sh1pt/core`; I validated this package with root dev tooling and a local link to `packages/core`.
