### PR TITLE
feat(ai): integrate DeepInfra adapter

### DIFF
--- a/packages/ai/deepinfra/src/index.test.ts
+++ b/packages/ai/deepinfra/src/index.test.ts
@@ -1,4 +1,80 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { DEEPINFRA_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('DeepInfra OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ DEEPINFRA_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'deepseek-ai/DeepSeek-V3' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from deepinfra' } }],
+        model: 'deepseek-ai/DeepSeek-R1',
+        usage: { prompt_tokens: 11, completion_tokens: 6 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'deepseek-ai/DeepSeek-R1',
+      system: 'be brief',
+      maxTokens: 20,
+      temperature: 0.2,
+      extra: { reasoning_effort: 'low' },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.deepinfra.com/v1/openai/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'deepseek-ai/DeepSeek-R1',
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 20,
+      temperature: 0.2,
+      reasoning_effort: 'low',
+    });
+    expect(result).toEqual({
+      text: 'hi from deepinfra',
+      model: 'deepseek-ai/DeepSeek-R1',
+      inputTokens: 11,
+      outputTokens: 6,
+    });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => 'rate limited'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/DeepInfra 429: rate limited/);
+  });
+});

--- a/packages/ai/deepinfra/src/index.ts
+++ b/packages/ai/deepinfra/src/index.ts
@@ -4,17 +4,56 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.deepinfra.com/v1/openai';
+
 export default defineAi<Config>({
   id: 'ai-deepinfra',
   label: 'DeepInfra',
-  defaultModel: 'meta-llama/Meta-Llama-3.1-70B-Instruct',
-  models: ['meta-llama/Meta-Llama-3.1-70B-Instruct'],
+  defaultModel: 'deepseek-ai/DeepSeek-V3',
+  models: [
+    'deepseek-ai/DeepSeek-V3',
+    'deepseek-ai/DeepSeek-R1',
+    'meta-llama/Meta-Llama-3.1-70B-Instruct',
+    'Qwen/Qwen3-30B-A3B',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('DEEPINFRA_API_KEY');
-    if (!apiKey) throw new Error('DEEPINFRA_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-deepinfra · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-deepinfra integration not yet implemented]', model: 'meta-llama/Meta-Llama-3.1-70B-Instruct' };
+    if (!apiKey) throw new Error('DEEPINFRA_API_KEY not in vault');
+    const model = opts.model ?? 'deepseek-ai/DeepSeek-V3';
+    ctx.log(`deepinfra · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`DeepInfra ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({


### PR DESCRIPTION
## Summary
- replace the DeepInfra stub with a working OpenAI-compatible chat completions implementation
- update the default model to DeepInfra's documented `deepseek-ai/DeepSeek-V3` sample model and include a small current model list
- preserve dry-run behavior, map usage tokens, pass provider-specific options through `opts.extra`, and surface concise HTTP error excerpts
- cover request shape, dry-run short-circuiting, and error handling with focused Vitest tests

This implements another AI provider adapter for #6.

## Notes
DeepInfra documents an OpenAI-compatible base URL at `https://api.deepinfra.com/v1/openai`; this adapter posts to `/chat/completions` under that base and keeps `baseUrl` override support.

## Validation
- `git diff --check`
- `corepack pnpm exec vitest run packages/ai/deepinfra/src/index.test.ts`
- `corepack pnpm exec tsc -p packages/ai/deepinfra/tsconfig.json --noEmit`

As with the other adapter PRs, the repo's full workspace install is currently blocked by the unrelated `packages/dns/azure` dependency on missing workspace package `@sh1pt/core`; I validated this package with root dev tooling and a local link to `packages/core`.
