### PR TITLE
feat(ai): integrate SambaNova adapter

### DIFF
--- a/packages/ai/sambanova/src/index.test.ts
+++ b/packages/ai/sambanova/src/index.test.ts
@@ -1,4 +1,80 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { SAMBANOVA_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('SambaNova OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ SAMBANOVA_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'Meta-Llama-3.3-70B-Instruct' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from sambanova' } }],
+        model: 'DeepSeek-R1',
+        usage: { prompt_tokens: 12, completion_tokens: 7 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'DeepSeek-R1',
+      system: 'be brief',
+      maxTokens: 20,
+      temperature: 0.2,
+      extra: { top_p: 0.9 },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.sambanova.ai/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'DeepSeek-R1',
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 20,
+      temperature: 0.2,
+      top_p: 0.9,
+    });
+    expect(result).toEqual({
+      text: 'hi from sambanova',
+      model: 'DeepSeek-R1',
+      inputTokens: 12,
+      outputTokens: 7,
+    });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => 'rate limited'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/SambaNova 429: rate limited/);
+  });
+});

--- a/packages/ai/sambanova/src/index.ts
+++ b/packages/ai/sambanova/src/index.ts
@@ -4,17 +4,55 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.sambanova.ai/v1';
+
 export default defineAi<Config>({
   id: 'ai-sambanova',
   label: 'SambaNova',
   defaultModel: 'Meta-Llama-3.3-70B-Instruct',
-  models: ['Meta-Llama-3.3-70B-Instruct'],
+  models: [
+    'Meta-Llama-3.3-70B-Instruct',
+    'DeepSeek-R1',
+    'Llama-4-Maverick-17B-128E-Instruct',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('SAMBANOVA_API_KEY');
-    if (!apiKey) throw new Error('SAMBANOVA_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-sambanova · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-sambanova integration not yet implemented]', model: 'Meta-Llama-3.3-70B-Instruct' };
+    if (!apiKey) throw new Error('SAMBANOVA_API_KEY not in vault');
+    const model = opts.model ?? 'Meta-Llama-3.3-70B-Instruct';
+    ctx.log(`sambanova · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`SambaNova ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({


### PR DESCRIPTION
## Summary
- replace the SambaNova stub with a working OpenAI-compatible chat completions implementation
- use SambaNova's documented API base URL, `https://api.sambanova.ai/v1`
- preserve dry-run behavior, map usage tokens, pass provider-specific options through `opts.extra`, and surface concise HTTP error excerpts
- cover request shape, dry-run short-circuiting, and error handling with focused Vitest tests

This implements another AI provider adapter for #6.

## Notes
SambaNova documents OpenAI client compatibility and the direct chat-completions endpoint at `https://api.sambanova.ai/v1/chat/completions`; this adapter keeps `baseUrl` override support.

## Validation
- `git diff --check`
- `corepack pnpm exec vitest run packages/ai/sambanova/src/index.test.ts`
- `corepack pnpm exec tsc -p packages/ai/sambanova/tsconfig.json --noEmit`

The full workspace install remains blocked by the unrelated `packages/dns/azure` dependency on missing workspace package `@sh1pt/core`; this package was validated with root dev tooling and a local link to `packages/core`.
