### PR TITLE
Implement CoinPayPortal payment adapter

### DIFF
--- a/packages/payments/coinpay/src/index.test.ts
+++ b/packages/payments/coinpay/src/index.test.ts
@@ -1,7 +1,124 @@
-import { contractTestPayment } from '@profullstack/sh1pt-core/testing';
+import { createHmac } from 'node:crypto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { smokeTest } from '@profullstack/sh1pt-core/testing';
 import payment from './index.js';
 
-contractTestPayment(payment, {
-  sampleConfig: { merchantId: 'm_test', acceptedCoins: ['BTC', 'USDC'] },
-  requiredSecrets: ['COINPAY_API_KEY'],
+smokeTest(payment, { idPrefix: 'payment', requireSupports: true });
+
+describe('payment-coinpay', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates a CoinPayPortal payment request and returns its checkout URL', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        payment: {
+          id: 'pay_123',
+          checkout_url: 'https://coinpayportal.com/pay/pay_123',
+          expires_at: '2026-05-13T08:00:00.000Z',
+        },
+      }),
+    } as Response);
+
+    const session = await payment.createCheckout(ctx({ COINPAY_API_KEY: 'cp_live_test' }), {
+      amount: 2440,
+      currency: 'USD',
+      kind: 'one-time',
+      successUrl: 'https://example.com/success',
+      cancelUrl: 'https://example.com/cancel',
+      customerEmail: 'buyer@example.com',
+      description: 'Launch plan',
+      metadata: { order_id: 'ord_1' },
+    }, {
+      businessId: 'biz_123',
+      acceptedCoins: ['USDC'],
+      currency: 'usdc_sol',
+      apiBaseUrl: 'https://coinpayportal.test/api',
+    });
+
+    expect(session).toEqual({
+      id: 'pay_123',
+      url: 'https://coinpayportal.com/pay/pay_123',
+      expiresAt: '2026-05-13T08:00:00.000Z',
+    });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://coinpayportal.test/api/payments/create');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>).authorization).toBe('Bearer cp_live_test');
+
+    const body = JSON.parse(init.body as string);
+    expect(body).toMatchObject({
+      business_id: 'biz_123',
+      amount_usd: '24.40',
+      currency: 'usdc_sol',
+      payment_method: 'crypto',
+      redirect_url: 'https://example.com/success',
+      cancel_url: 'https://example.com/cancel',
+      description: 'Launch plan',
+      metadata: {
+        order_id: 'ord_1',
+        customer_email: 'buyer@example.com',
+        payment_rail: 'crypto',
+      },
+    });
+  });
+
+  it('verifies CoinPay webhook signatures and normalizes payment events', async () => {
+    const raw = JSON.stringify({
+      id: 'evt_pay_123',
+      type: 'payment.confirmed',
+      data: {
+        payment_id: 'pay_123',
+        status: 'confirmed',
+        amount_usd: '24.40',
+        currency: 'USDC',
+        metadata: { customer_email: 'buyer@example.com' },
+      },
+    });
+    const secret = 'whsec_test';
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const signature = createHmac('sha256', secret)
+      .update(`${timestamp}.${raw}`)
+      .digest('hex');
+
+    const webhook = await payment.verifyWebhook(
+      ctx({ COINPAY_WEBHOOK_SECRET: secret }),
+      raw,
+      `t=${timestamp},v1=${signature}`,
+      {},
+    );
+
+    expect(webhook).toMatchObject({
+      type: 'payment.confirmed',
+      paymentId: 'pay_123',
+      status: 'succeeded',
+      amount: 2440,
+      currency: 'USDC',
+      customerEmail: 'buyer@example.com',
+    });
+  });
+
+  it('rejects invalid CoinPay webhook signatures', async () => {
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    await expect(payment.verifyWebhook(
+      ctx({ COINPAY_WEBHOOK_SECRET: 'whsec_test' }),
+      JSON.stringify({ type: 'payment.confirmed' }),
+      `t=${timestamp},v1=bad`,
+      {},
+    )).rejects.toThrow('Invalid CoinPay webhook signature');
+  });
 });
+
+function ctx(secrets: Record<string, string>) {
+  return {
+    secret(key: string) {
+      return secrets[key];
+    },
+    log: vi.fn(),
+  };
+}

--- a/packages/payments/coinpay/src/index.test.ts
+++ b/packages/payments/coinpay/src/index.test.ts
@@ -11,17 +11,22 @@ describe('payment-coinpay', () => {
   });
 
   it('creates a CoinPayPortal payment request and returns its checkout URL', async () => {
-    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: true,
-      json: async () => ({
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(jsonResponse({
+        success: true,
+        coins: [
+          { symbol: 'BTC', is_active: true, has_wallet: true },
+          { symbol: 'USDC_SOL', is_active: true, has_wallet: true },
+        ],
+      }))
+      .mockResolvedValueOnce(jsonResponse({
         success: true,
         payment: {
           id: 'pay_123',
           checkout_url: 'https://coinpayportal.com/pay/pay_123',
           expires_at: '2026-05-13T08:00:00.000Z',
         },
-      }),
-    } as Response);
+      }));
 
     const session = await payment.createCheckout(ctx({ COINPAY_API_KEY: 'cp_live_test' }), {
       amount: 2440,
@@ -45,8 +50,15 @@ describe('payment-coinpay', () => {
       expiresAt: '2026-05-13T08:00:00.000Z',
     });
 
-    expect(fetchMock).toHaveBeenCalledOnce();
-    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const [supportedUrl, supportedInit] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(supportedUrl.origin + supportedUrl.pathname).toBe('https://coinpayportal.test/api/supported-coins');
+    expect(supportedUrl.searchParams.get('business_id')).toBe('biz_123');
+    expect(supportedUrl.searchParams.get('active_only')).toBe('true');
+    expect(supportedInit.method).toBe('GET');
+
+    const [url, init] = fetchMock.mock.calls[1] as [string, RequestInit];
     expect(url).toBe('https://coinpayportal.test/api/payments/create');
     expect(init.method).toBe('POST');
     expect((init.headers as Record<string, string>).authorization).toBe('Bearer cp_live_test');
@@ -66,6 +78,60 @@ describe('payment-coinpay', () => {
         payment_rail: 'crypto',
       },
     });
+  });
+
+  it('uses the business supported coins endpoint when no currency is configured', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(jsonResponse({
+        success: true,
+        coins: [
+          { symbol: 'SOL', is_active: true, has_wallet: true },
+        ],
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        success: true,
+        payment: {
+          id: 'pay_sol',
+          checkout_url: 'https://coinpayportal.com/pay/pay_sol',
+        },
+      }));
+
+    await payment.createCheckout(ctx({ COINPAY_API_KEY: 'cp_live_test' }), {
+      amount: 500,
+      currency: 'USD',
+      kind: 'one-time',
+      successUrl: 'https://example.com/success',
+      cancelUrl: 'https://example.com/cancel',
+    }, {
+      businessId: 'biz_123',
+      apiBaseUrl: 'https://coinpayportal.test/api',
+    });
+
+    const [, init] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      currency: 'sol',
+    });
+  });
+
+  it('rejects configured currencies that are not enabled for the business', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(jsonResponse({
+      success: true,
+      coins: [
+        { symbol: 'SOL', is_active: true, has_wallet: true },
+      ],
+    }));
+
+    await expect(payment.createCheckout(ctx({ COINPAY_API_KEY: 'cp_live_test' }), {
+      amount: 500,
+      currency: 'USD',
+      kind: 'one-time',
+      successUrl: 'https://example.com/success',
+      cancelUrl: 'https://example.com/cancel',
+    }, {
+      businessId: 'biz_123',
+      currency: 'usdc_sol',
+      apiBaseUrl: 'https://coinpayportal.test/api',
+    })).rejects.toThrow('does not support configured currency usdc_sol');
   });
 
   it('verifies CoinPay webhook signatures and normalizes payment events', async () => {
@@ -121,4 +187,11 @@ function ctx(secrets: Record<string, string>) {
     },
     log: vi.fn(),
   };
+}
+
+function jsonResponse(json: unknown): Response {
+  return {
+    ok: true,
+    json: async () => json,
+  } as Response;
 }

--- a/packages/payments/coinpay/src/index.ts
+++ b/packages/payments/coinpay/src/index.ts
@@ -1,14 +1,14 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import { definePayment, tokenSetup, type CheckoutRequest, type CheckoutSession, type Webhook } from '@profullstack/sh1pt-core';
 
-// CoinPayPortal — default crypto-accepting payment provider in sh1pt.
-// Accepts BTC / ETH / USDC / SOL, settles to the merchant wallet, and
-// signs all webhook events with X-CoinPay-Signature.
+// CoinPayPortal - default crypto-accepting payment provider in sh1pt.
+// Uses the business configured coin list from CoinPayPortal and signs all
+// webhook events with X-CoinPay-Signature.
 interface Config {
   businessId?: string;
   merchantId?: string;               // Back-compat alias for businessId.
-  acceptedCoins?: string[];          // e.g. ['BTC','USDC']
-  currency?: string;                 // CoinPay currency code, e.g. btc, eth, sol, usdc_sol.
+  acceptedCoins?: string[];          // Preferred business-enabled coins, e.g. ['USDC','SOL'].
+  currency?: string;                 // CoinPay currency code, e.g. sol, usdc_sol.
   paymentMethod?: 'crypto' | 'card' | 'both';
   apiBaseUrl?: string;
   checkoutBaseUrl?: string;
@@ -27,7 +27,7 @@ export default definePayment<Config>({
   async connect(ctx, config) {
     if (!ctx.secret('COINPAY_API_KEY')) throw new Error('COINPAY_API_KEY not in vault');
     const businessId = resolveBusinessId(config);
-    ctx.log(`coinpay connected · coins=${config.acceptedCoins?.join(',') ?? 'BTC,ETH,USDC,SOL'}`);
+    ctx.log(`coinpay connected · business=${businessId ?? 'api-key default'}`);
     return { accountId: businessId ?? 'coinpay' };
   },
 
@@ -40,11 +40,13 @@ export default definePayment<Config>({
     if (!apiKey) throw new Error('COINPAY_API_KEY not in vault');
 
     ctx.log(`coinpay checkout · ${req.amount} ${req.currency} · ${req.kind}`);
+    const supportedCurrencies = await fetchSupportedCurrencies(config, apiKey);
+    const paymentCurrency = resolvePaymentCurrency(config, supportedCurrencies);
     const response = await coinpayRequest<CoinPayCreatePaymentResponse>(
       config,
       '/payments/create',
       apiKey,
-      buildPaymentBody(req, config),
+      buildPaymentBody(req, config, paymentCurrency),
     );
 
     return checkoutSessionFromPayment(response, config);
@@ -74,11 +76,11 @@ export default definePayment<Config>({
   }),
 });
 
-function buildPaymentBody(req: CheckoutRequest, config: Config): Record<string, unknown> {
+function buildPaymentBody(req: CheckoutRequest, config: Config, paymentCurrency: string): Record<string, unknown> {
   const body: Record<string, unknown> = {
     business_id: resolveBusinessId(config),
     amount_usd: toUsdDecimal(req.amount, req.currency),
-    currency: resolvePaymentCurrency(req, config),
+    currency: paymentCurrency,
     payment_method: config.paymentMethod ?? 'crypto',
     redirect_url: req.successUrl,
     cancel_url: req.cancelUrl,
@@ -94,6 +96,39 @@ function buildPaymentBody(req: CheckoutRequest, config: Config): Record<string, 
   };
 
   return stripUndefined(body);
+}
+
+async function fetchSupportedCurrencies(config: Config, apiKey: string): Promise<string[]> {
+  const businessId = resolveBusinessId(config);
+  const query: Record<string, string> = { active_only: 'true' };
+  if (businessId) query.business_id = businessId;
+  const response = await coinpayGet<CoinPaySupportedCoinsResponse>(
+    config,
+    '/supported-coins',
+    apiKey,
+    query,
+  );
+  return supportedCurrenciesFromResponse(response);
+}
+
+async function coinpayGet<T>(
+  config: Config,
+  path: string,
+  apiKey: string,
+  query: Record<string, string>,
+): Promise<T> {
+  const url = new URL(`${apiBaseUrl(config)}${path}`);
+  for (const [key, value] of Object.entries(query)) url.searchParams.set(key, value);
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      accept: 'application/json',
+    },
+  });
+
+  return readCoinPayJson<T>(response);
 }
 
 async function coinpayRequest<T>(
@@ -198,12 +233,32 @@ function normalizeStatus(status: string | undefined): Webhook['status'] | undefi
   return undefined;
 }
 
-function resolvePaymentCurrency(req: CheckoutRequest, config: Config): string {
-  if (config.currency) return config.currency.toLowerCase();
-  const requested = req.currency.toUpperCase();
-  if (CRYPTO_CURRENCY_MAP[requested]) return CRYPTO_CURRENCY_MAP[requested];
-  const [firstAccepted] = config.acceptedCoins ?? [];
-  return CRYPTO_CURRENCY_MAP[firstAccepted?.toUpperCase() ?? ''] ?? 'usdc_sol';
+function resolvePaymentCurrency(config: Config, supportedCurrencies: string[]): string {
+  if (!supportedCurrencies.length) {
+    throw new Error('CoinPayPortal business has no active supported coins');
+  }
+
+  if (config.currency) {
+    const configured = normalizeCurrency(config.currency);
+    if (!supportedCurrencies.includes(configured)) {
+      throw new Error(`CoinPayPortal business does not support configured currency ${configured}`);
+    }
+    return configured;
+  }
+
+  for (const preference of config.acceptedCoins ?? []) {
+    const preferred = normalizeCurrency(preference);
+    const match = supportedCurrencies.find((currency) => matchesCoinPreference(currency, preferred));
+    if (match) return match;
+  }
+
+  if (config.acceptedCoins?.length) {
+    throw new Error(`CoinPayPortal business does not support preferred coins: ${config.acceptedCoins.join(', ')}`);
+  }
+
+  const fallback = supportedCurrencies[0];
+  if (!fallback) throw new Error('CoinPayPortal business has no active supported coins');
+  return fallback;
 }
 
 function toUsdDecimal(amount: number, currency: string): string {
@@ -241,15 +296,28 @@ function stripUndefined<T>(value: T): T {
   return value;
 }
 
-const CRYPTO_CURRENCY_MAP: Record<string, string> = {
-  BTC: 'btc',
-  ETH: 'eth',
-  SOL: 'sol',
-  USDC: 'usdc_sol',
-  USDC_SOL: 'usdc_sol',
-  USDC_POL: 'usdc_pol',
-  USDC_ETH: 'usdc_eth',
-};
+function supportedCurrenciesFromResponse(response: CoinPaySupportedCoinsResponse): string[] {
+  const coins = coinsFromResponse(response);
+  return coins
+    .filter((coin) => coin.is_active !== false && coin.active !== false && coin.has_wallet !== false)
+    .map((coin) => coin.currency ?? coin.symbol ?? coin.code)
+    .filter((symbol): symbol is string => typeof symbol === 'string' && symbol.trim().length > 0)
+    .map(normalizeCurrency);
+}
+
+function coinsFromResponse(response: CoinPaySupportedCoinsResponse): CoinPaySupportedCoin[] {
+  if (response.coins) return response.coins;
+  if (Array.isArray(response.data)) return response.data;
+  return response.data?.coins ?? [];
+}
+
+function normalizeCurrency(value: string): string {
+  return value.trim().toLowerCase().replace(/-/g, '_');
+}
+
+function matchesCoinPreference(currency: string, preferred: string): boolean {
+  return currency === preferred || currency.startsWith(`${preferred}_`);
+}
 
 interface CoinPayErrorResponse {
   success?: boolean;
@@ -274,6 +342,22 @@ type CoinPayCreatePaymentResponse = CoinPayPayment & {
   payment?: CoinPayPayment;
   data?: CoinPayPayment & { payment?: CoinPayPayment };
 };
+
+interface CoinPaySupportedCoin {
+  symbol?: string;
+  currency?: string;
+  code?: string;
+  is_active?: boolean;
+  active?: boolean;
+  has_wallet?: boolean;
+}
+
+interface CoinPaySupportedCoinsResponse {
+  success?: boolean;
+  ok?: boolean;
+  coins?: CoinPaySupportedCoin[];
+  data?: CoinPaySupportedCoin[] | { coins?: CoinPaySupportedCoin[] };
+}
 
 interface CoinPayWebhookEvent {
   id?: string;

--- a/packages/payments/coinpay/src/index.ts
+++ b/packages/payments/coinpay/src/index.ts
@@ -1,64 +1,290 @@
-import { definePayment, tokenSetup, type CheckoutSession, type Webhook } from '@profullstack/sh1pt-core';
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { definePayment, tokenSetup, type CheckoutRequest, type CheckoutSession, type Webhook } from '@profullstack/sh1pt-core';
 
-// CoinPay — default crypto-accepting payment provider in sh1pt. Accepts
-// BTC / ETH / USDC / SOL, settles to the merchant wallet or fiat on ramp.
-// Webhook signature is HMAC-SHA256 of raw body using the webhook secret.
+// CoinPayPortal — default crypto-accepting payment provider in sh1pt.
+// Accepts BTC / ETH / USDC / SOL, settles to the merchant wallet, and
+// signs all webhook events with X-CoinPay-Signature.
 interface Config {
-  merchantId?: string;
-  acceptedCoins?: string[];          // e.g. ['BTC','ETH','USDC','SOL']
-  settlementMode?: 'crypto' | 'fiat'; // keep as crypto, or auto-convert
-  webhookSecret?: string;            // read from vault if not set here
+  businessId?: string;
+  merchantId?: string;               // Back-compat alias for businessId.
+  acceptedCoins?: string[];          // e.g. ['BTC','USDC']
+  currency?: string;                 // CoinPay currency code, e.g. btc, eth, sol, usdc_sol.
+  paymentMethod?: 'crypto' | 'card' | 'both';
+  apiBaseUrl?: string;
+  checkoutBaseUrl?: string;
+  webhookSecret?: string;            // Read from vault if not set here.
+  webhookToleranceSeconds?: number;
 }
 
-const API = 'https://api.coinpay.com/v1';
+const DEFAULT_API_BASE = 'https://coinpayportal.com/api';
+const DEFAULT_CHECKOUT_BASE = 'https://coinpayportal.com';
 
 export default definePayment<Config>({
   id: 'payment-coinpay',
-  label: 'CoinPay (crypto — default)',
-  supports: ['crypto', 'one-time', 'subscription', 'crowdfund'],
+  label: 'CoinPayPortal (crypto — default)',
+  supports: ['crypto', 'one-time', 'crowdfund'],
 
   async connect(ctx, config) {
     if (!ctx.secret('COINPAY_API_KEY')) throw new Error('COINPAY_API_KEY not in vault');
+    const businessId = resolveBusinessId(config);
     ctx.log(`coinpay connected · coins=${config.acceptedCoins?.join(',') ?? 'BTC,ETH,USDC,SOL'}`);
-    return { accountId: config.merchantId ?? 'coinpay' };
+    return { accountId: businessId ?? 'coinpay' };
   },
 
-  async createCheckout(ctx, req) {
+  async createCheckout(ctx, req, config) {
+    if (req.kind === 'subscription') {
+      throw new Error('CoinPayPortal does not expose merchant recurring subscriptions through /api/payments/create');
+    }
+
+    const apiKey = ctx.secret('COINPAY_API_KEY');
+    if (!apiKey) throw new Error('COINPAY_API_KEY not in vault');
+
     ctx.log(`coinpay checkout · ${req.amount} ${req.currency} · ${req.kind}`);
-    // TODO: POST ${API}/checkouts with { amount, currency, accepted_coins,
-    // success_url, cancel_url, metadata, settlement_mode }
-    return {
-      id: `cp_${Date.now()}`,
-      url: `https://pay.coinpay.com/checkout/stub?amount=${req.amount}&currency=${req.currency}`,
-    } satisfies CheckoutSession;
+    const response = await coinpayRequest<CoinPayCreatePaymentResponse>(
+      config,
+      '/payments/create',
+      apiKey,
+      buildPaymentBody(req, config),
+    );
+
+    return checkoutSessionFromPayment(response, config);
   },
 
-  async verifyWebhook(_ctx, rawBody, signature): Promise<Webhook> {
-    // TODO: HMAC-SHA256(rawBody, COINPAY_WEBHOOK_SECRET) === signature
-    const payload = JSON.parse(rawBody);
-    return {
-      type: payload.type ?? 'unknown',
-      payload,
-      paymentId: payload.id,
-      status: payload.status,
-      amount: payload.amount,
-      currency: payload.currency,
-      customerEmail: payload.customer_email,
-    };
+  async verifyWebhook(ctx, rawBody, signature, config): Promise<Webhook> {
+    const secret = config.webhookSecret ?? ctx.secret('COINPAY_WEBHOOK_SECRET');
+    if (!secret) throw new Error('COINPAY_WEBHOOK_SECRET not in vault');
+    verifyCoinPaySignature(rawBody, signature, secret, config.webhookToleranceSeconds);
+
+    return normalizeWebhook(JSON.parse(rawBody) as CoinPayWebhookEvent);
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'COINPAY_API_KEY',
     label: 'CoinPay',
-    vendorDocUrl: 'https://coinpay.io/merchant/api',
+    vendorDocUrl: 'https://coinpayportal.com/docs',
     steps: [
-      'Open coinpay.io → Merchant dashboard → API Keys',
-      'Create an API key for your merchant account',
+      'Open CoinPayPortal → Business dashboard → API Keys',
+      'Create an API key for your business',
       'Copy the API key + webhook secret',
     ],
     fields: [
       { key: 'COINPAY_WEBHOOK_SECRET', message: 'Paste the webhook signing secret:', secret: true },
-      { key: 'merchantId', message: 'Merchant ID:' },
+      { key: 'businessId', message: 'Business ID:' },
     ],
   }),
 });
+
+function buildPaymentBody(req: CheckoutRequest, config: Config): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    business_id: resolveBusinessId(config),
+    amount_usd: toUsdDecimal(req.amount, req.currency),
+    currency: resolvePaymentCurrency(req, config),
+    payment_method: config.paymentMethod ?? 'crypto',
+    redirect_url: req.successUrl,
+    cancel_url: req.cancelUrl,
+    description: req.description,
+    metadata: {
+      ...req.metadata,
+      customer_id: req.customerId,
+      customer_email: req.customerEmail,
+      connected_account_id: req.connectedAccountId,
+      platform_fee_bps: req.platformFeeBps?.toString(),
+      payment_rail: config.paymentMethod ?? 'crypto',
+    },
+  };
+
+  return stripUndefined(body);
+}
+
+async function coinpayRequest<T>(
+  config: Config,
+  path: string,
+  apiKey: string,
+  body: Record<string, unknown>,
+): Promise<T> {
+  const response = await fetch(`${apiBaseUrl(config)}${path}`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      'content-type': 'application/json',
+      accept: 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  return readCoinPayJson<T>(response);
+}
+
+async function readCoinPayJson<T>(response: Response): Promise<T> {
+  const json = await response.json().catch(() => ({})) as CoinPayErrorResponse & T;
+  if (!response.ok || json.success === false || json.ok === false) {
+    const error = typeof json.error === 'string' ? json.error : json.error?.message;
+    throw new Error(error ?? json.message ?? `CoinPay API error ${response.status}`);
+  }
+  return json as T;
+}
+
+function checkoutSessionFromPayment(response: CoinPayCreatePaymentResponse, config: Config): CheckoutSession {
+  const payment = response.payment ?? response.data?.payment ?? response.data ?? response;
+  const id = payment.id ?? payment.payment_id;
+  if (!id) throw new Error('CoinPay payment response did not include id');
+
+  const url = payment.checkout_url
+    ?? payment.payment_url
+    ?? payment.url
+    ?? payment.stripe_checkout_url
+    ?? `${checkoutBaseUrl(config)}/pay/${id}`;
+
+  return {
+    id,
+    url,
+    expiresAt: payment.expires_at,
+  };
+}
+
+function verifyCoinPaySignature(
+  rawBody: string,
+  signatureHeader: string,
+  secret: string,
+  toleranceSeconds = 300,
+): void {
+  const parts = Object.fromEntries(signatureHeader.split(',').map((part) => {
+    const [key, ...value] = part.trim().split('=');
+    return [key, value.join('=')];
+  }));
+  const timestamp = parts.t;
+  const signature = parts.v1;
+  if (!timestamp || !signature) throw new Error('CoinPay signature missing t or v1');
+
+  const timestampSeconds = Number(timestamp);
+  if (!Number.isFinite(timestampSeconds)) throw new Error('CoinPay signature timestamp is invalid');
+  if (toleranceSeconds > 0) {
+    const age = Math.floor(Date.now() / 1000) - timestampSeconds;
+    if (Math.abs(age) > toleranceSeconds) throw new Error('CoinPay webhook signature timestamp outside tolerance');
+  }
+
+  const expected = createHmac('sha256', secret)
+    .update(`${timestamp}.${rawBody}`)
+    .digest('hex');
+  const actualBuffer = Buffer.from(signature, 'hex');
+  const expectedBuffer = Buffer.from(expected, 'hex');
+  if (actualBuffer.length !== expectedBuffer.length || !timingSafeEqual(actualBuffer, expectedBuffer)) {
+    throw new Error('Invalid CoinPay webhook signature');
+  }
+}
+
+function normalizeWebhook(event: CoinPayWebhookEvent): Webhook {
+  const data = event.data ?? {};
+  return {
+    type: event.type ?? 'unknown',
+    payload: event,
+    paymentId: data.payment_id ?? event.id,
+    status: normalizeStatus(data.status ?? event.type),
+    amount: usdDecimalToMinor(data.amount_usd),
+    currency: data.currency?.toUpperCase(),
+    customerEmail: data.metadata?.customer_email,
+  };
+}
+
+function normalizeStatus(status: string | undefined): Webhook['status'] | undefined {
+  if (!status) return undefined;
+  if (['confirmed', 'forwarded', 'succeeded', 'paid', 'payment.confirmed', 'payment.forwarded'].includes(status)) {
+    return 'succeeded';
+  }
+  if (['pending', 'awaiting_payment', 'processing', 'created'].includes(status)) return 'pending';
+  if (['expired', 'failed', 'cancelled', 'canceled', 'payment.expired'].includes(status)) return 'failed';
+  if (status === 'refunded') return 'refunded';
+  if (status === 'disputed') return 'disputed';
+  return undefined;
+}
+
+function resolvePaymentCurrency(req: CheckoutRequest, config: Config): string {
+  if (config.currency) return config.currency.toLowerCase();
+  const requested = req.currency.toUpperCase();
+  if (CRYPTO_CURRENCY_MAP[requested]) return CRYPTO_CURRENCY_MAP[requested];
+  const [firstAccepted] = config.acceptedCoins ?? [];
+  return CRYPTO_CURRENCY_MAP[firstAccepted?.toUpperCase() ?? ''] ?? 'usdc_sol';
+}
+
+function toUsdDecimal(amount: number, currency: string): string {
+  if (currency.toUpperCase() !== 'USD') {
+    throw new Error('CoinPayPortal payment creation requires req.currency to be USD for amount_usd');
+  }
+  return (amount / 100).toFixed(2);
+}
+
+function usdDecimalToMinor(value: string | number | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? Math.round(parsed * 100) : undefined;
+}
+
+function resolveBusinessId(config: Config): string | undefined {
+  return config.businessId ?? config.merchantId;
+}
+
+function apiBaseUrl(config: Config): string {
+  return (config.apiBaseUrl ?? DEFAULT_API_BASE).replace(/\/+$/, '');
+}
+
+function checkoutBaseUrl(config: Config): string {
+  return (config.checkoutBaseUrl ?? DEFAULT_CHECKOUT_BASE).replace(/\/+$/, '');
+}
+
+function stripUndefined<T>(value: T): T {
+  if (Array.isArray(value)) return value.map(stripUndefined) as T;
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).filter(([, entry]) => entry !== undefined).map(([key, entry]) => [key, stripUndefined(entry)]),
+    ) as T;
+  }
+  return value;
+}
+
+const CRYPTO_CURRENCY_MAP: Record<string, string> = {
+  BTC: 'btc',
+  ETH: 'eth',
+  SOL: 'sol',
+  USDC: 'usdc_sol',
+  USDC_SOL: 'usdc_sol',
+  USDC_POL: 'usdc_pol',
+  USDC_ETH: 'usdc_eth',
+};
+
+interface CoinPayErrorResponse {
+  success?: boolean;
+  ok?: boolean;
+  message?: string;
+  error?: { message?: string } | string;
+}
+
+interface CoinPayPayment {
+  id?: string;
+  payment_id?: string;
+  checkout_url?: string;
+  payment_url?: string;
+  url?: string;
+  stripe_checkout_url?: string;
+  expires_at?: string;
+}
+
+type CoinPayCreatePaymentResponse = CoinPayPayment & {
+  success?: boolean;
+  ok?: boolean;
+  payment?: CoinPayPayment;
+  data?: CoinPayPayment & { payment?: CoinPayPayment };
+};
+
+interface CoinPayWebhookEvent {
+  id?: string;
+  type?: string;
+  data?: {
+    payment_id?: string;
+    status?: string;
+    amount_usd?: string | number;
+    currency?: string;
+    metadata?: {
+      customer_email?: string;
+    };
+  };
+}


### PR DESCRIPTION


Summary\n- replace the CoinPay payment stub with a CoinPayPortal REST-backed checkout implementation\n- create payments through /api/payments/create with business ID, USD amount, selected crypto rail/currency, redirect URLs, and metadata\n- verify X-CoinPay-Signature HMAC webhooks and normalize payment.confirmed/payment.forwarded/payment.expired payloads\n\n## Validation\n- corepack pnpm exec vitest run packages/payments/coinpay/src/index.test.ts\n- corepack pnpm exec tsc -p packages/payments/coinpay/tsconfig.json --noEmit\n- git diff --check\n\n## Notes\n- keeps merchantId as a backwards-compatible alias for businessId\n- uses CoinPayPortal docs for payment creation and webhook signature semantics\n