### PR TITLE
Update uGig social adapter to posts API

### DIFF
--- a/packages/social/ugig/src/index.test.ts
+++ b/packages/social/ugig/src/index.test.ts
@@ -1,4 +1,128 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { contractTestSocial, fakeConnectContext } from '@profullstack/sh1pt-core/testing';
 import adapter from './index.js';
 
-smokeTest(adapter, { idPrefix: 'social' });
+contractTestSocial(adapter, {
+  sampleConfig: {},
+  samplePost: { body: 'hello from sh1pt contract tests' },
+  requiredSecrets: ['UGIG_API_KEY'],
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('social-ugig', () => {
+  it('checks the current uGig profile endpoint with an API key', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ profile: { id: 'profile-1', username: 'sh1pt' } }),
+    } as Response);
+
+    const result = await adapter.connect(fakeConnectContext({ UGIG_API_KEY: 'ugig-key' }) as any, {});
+
+    expect(result).toEqual({ accountId: 'sh1pt' });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://ugig.net/api/profile');
+    expect((init as RequestInit).headers).toMatchObject({ 'X-API-Key': 'ugig-key' });
+  });
+
+  it('creates a community post through the current uGig posts API', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        post: {
+          id: '7db0a088-8639-4054-b960-245b0237b2b3',
+          created_at: '2026-05-13T10:00:00Z',
+        },
+      }),
+    } as Response);
+
+    const ctx = {
+      ...fakeConnectContext({ UGIG_API_KEY: 'ugig-key' }),
+      dryRun: false,
+    };
+
+    const result = await adapter.post(ctx as any, {
+      title: 'Release shipped',
+      body: 'The adapter now uses the documented uGig API.',
+      hashtags: ['#ai', 'typescript', 'automation', 'this-tag-name-is-longer-than-fifty-characters-and-gets-truncated', 'ignored-1', 'ignored-2', 'ignored-3', 'ignored-4', 'ignored-5', 'ignored-6', 'ignored-7'],
+      link: 'https://sh1pt.com',
+    }, {});
+
+    expect(result).toEqual({
+      id: '7db0a088-8639-4054-b960-245b0237b2b3',
+      url: 'https://ugig.net/post/7db0a088-8639-4054-b960-245b0237b2b3',
+      platform: 'ugig',
+      publishedAt: '2026-05-13T10:00:00.000Z',
+    });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://ugig.net/api/posts');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).headers).toMatchObject({
+      'X-API-Key': 'ugig-key',
+      'Content-Type': 'application/json',
+    });
+    expect(JSON.parse(String((init as RequestInit).body))).toEqual({
+      content: 'Release shipped\n\nThe adapter now uses the documented uGig API.',
+      url: 'https://sh1pt.com',
+      post_type: 'link',
+      tags: [
+        'ai',
+        'typescript',
+        'automation',
+        'this-tag-name-is-longer-than-fifty-characters-and-',
+        'ignored-1',
+        'ignored-2',
+        'ignored-3',
+        'ignored-4',
+        'ignored-5',
+        'ignored-6',
+      ],
+    });
+  });
+
+  it('falls back to bearer-token auth for existing UGIG_TOKEN users', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ post: { id: '4ac04e00-a2c6-468b-9316-6d5bcec9c161' } }),
+    } as Response);
+
+    const ctx = {
+      ...fakeConnectContext({ UGIG_TOKEN: 'legacy-token' }),
+      dryRun: false,
+    };
+
+    await adapter.post(ctx as any, { body: 'Legacy token post' }, { postType: 'showcase' });
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect((init as RequestInit).headers).toMatchObject({
+      Authorization: 'Bearer legacy-token',
+    });
+    expect(JSON.parse(String((init as RequestInit).body))).toMatchObject({
+      content: 'Legacy token post',
+      url: null,
+      post_type: 'showcase',
+    });
+  });
+
+  it('surfaces uGig API errors', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      text: async () => JSON.stringify({ error: 'content is required' }),
+    } as Response);
+
+    const ctx = {
+      ...fakeConnectContext({ UGIG_API_KEY: 'ugig-key' }),
+      dryRun: false,
+    };
+
+    await expect(adapter.post(ctx as any, { body: 'bad post' }, {}))
+      .rejects.toThrow('ugig post failed: HTTP 400 - content is required');
+  });
+});

--- a/packages/social/ugig/src/index.ts
+++ b/packages/social/ugig/src/index.ts
@@ -1,103 +1,163 @@
-import { defineSocial, oauthSetup } from '@profullstack/sh1pt-core';
+import { defineSocial, tokenSetup, type SocialPost } from '@profullstack/sh1pt-core';
 
 // ugig.net — Marketplace for AI-assisted professionals.
-// Auth: Bearer token from POST /api/auth/login (email + password).
-// "Posting" maps to creating a Prompt in the ugig.net Prompts Marketplace.
+// Auth: API key via X-API-Key, or a legacy Supabase bearer token.
+// Posts map to the public uGig community feed API.
 //
 // API base: https://ugig.net/api
-// Docs:     https://ugig.net  (no public API — reverse-engineered)
+// Docs:     https://ugig.net/openapi.json
 //
 // Rate limits: not publicly documented; avoid bursting > ~10 req/min.
 
 const UGIG_API = 'https://ugig.net/api';
+const UGIG_WEB = 'https://ugig.net';
+const MAX_CONTENT_CHARS = 5_000;
+const MAX_TAGS = 10;
+const MAX_TAG_CHARS = 50;
+
+type UgigPostType = 'text' | 'link' | 'showcase';
 
 interface Config {
   /** ugig.net username for logging/display (e.g. 'nexus_ai') */
   username?: string;
-  /** Default sats price for prompts (0 = free). */
+  /** Override the API base for tests or self-hosted deployments. */
+  apiBaseUrl?: string;
+  /** Default post type; if omitted, link posts are inferred from post.link. */
+  postType?: UgigPostType;
+  /** @deprecated uGig no longer exposes the prompts marketplace endpoint. */
   defaultPriceSats?: number;
-  /** Default category for prompts: 'ai'|'coding'|'writing'|'research'|'other' */
+  /** @deprecated uGig no longer exposes the prompts marketplace endpoint. */
   defaultCategory?: string;
 }
 
 export default defineSocial<Config>({
   id: 'social-ugig',
-  label: 'uGig (Prompts Marketplace)',
-  requires: { maxBodyChars: 10_000, maxHashtags: 10, hashtagsInBody: false },
+  label: 'uGig',
+  requires: { maxBodyChars: MAX_CONTENT_CHARS, maxHashtags: MAX_TAGS, hashtagsInBody: false },
 
   async connect(ctx, config) {
-    const token = ctx.secret('UGIG_TOKEN');
-    if (!token) throw new Error('UGIG_TOKEN not in vault — see setup()');
-
-    const res = await fetch(`${UGIG_API}/profile`, {
-      headers: { Authorization: `Bearer ${token}` },
+    const res = await fetch(`${apiBase(config)}/profile`, {
+      headers: authHeaders(ctx),
     });
-    if (!res.ok) throw new Error(`ugig auth check failed: HTTP ${res.status}`);
-    const data = await res.json() as { profile?: { username?: string } };
+    if (!res.ok) throw new Error(`ugig auth check failed: HTTP ${res.status} - ${await readUgigError(res)}`);
+    const data = await res.json() as { profile?: { username?: string; id?: string } };
     const username = data.profile?.username ?? config.username ?? 'ugig';
     ctx.log(`ugig connected · @${username}`);
     return { accountId: username };
   },
 
   async post(ctx, post, config) {
-    const token = ctx.secret('UGIG_TOKEN');
-    if (!token) throw new Error('UGIG_TOKEN not in vault');
+    const payload = formatUgigPost(post, config);
+    const headers = authHeaders(ctx);
 
-    const title = post.title ?? post.body.slice(0, 80).replace(/\n/g, ' ');
-    const tags = (post.hashtags ?? []).slice(0, 10);
-    const category = config.defaultCategory ?? 'ai';
-    const priceSats = config.defaultPriceSats ?? 0;
-
-    ctx.log(`ugig prompt · "${title}" · ${post.body.length} chars · ${tags.length} tags`);
+    ctx.log(`ugig post · ${payload.post_type} · ${payload.content.length} chars · ${payload.tags.length} tags`);
 
     if (ctx.dryRun) {
-      return { id: 'dry-run', url: 'https://ugig.net/prompts', platform: 'ugig', publishedAt: new Date().toISOString() };
+      return { id: 'dry-run', url: `${UGIG_WEB}/feed`, platform: 'ugig', publishedAt: new Date().toISOString() };
     }
 
-    const payload: Record<string, unknown> = {
-      title,
-      description: post.body.slice(0, 300),
-      content: post.link ? `${post.body}\n\n${post.link}` : post.body,
-      category,
-      tags,
-      price_sats: priceSats,
-      status: 'active',
-    };
-
-    const res = await fetch(`${UGIG_API}/prompts`, {
+    const res = await fetch(`${apiBase(config)}/posts`, {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${token}`,
+        ...headers,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(payload),
     });
 
     if (!res.ok) {
-      const err = await res.text();
-      throw new Error(`ugig post failed: HTTP ${res.status} — ${err}`);
+      throw new Error(`ugig post failed: HTTP ${res.status} - ${await readUgigError(res)}`);
     }
 
-    const data = await res.json() as { listing?: { id?: string; slug?: string } };
-    const listing = data.listing ?? {};
-    const id = listing.id ?? `ugig_${Date.now()}`;
-    const slug = listing.slug ?? id;
-    const url = `https://ugig.net/prompts/${slug}`;
+    const data = await res.json() as { post?: UgigPost };
+    const createdPost = data.post;
+    if (!createdPost?.id) throw new Error('ugig publish response did not include a post id');
 
+    const url = `${UGIG_WEB}/post/${createdPost.id}`;
     ctx.log(`ugig published · ${url}`);
-    return { id, url, platform: 'ugig', publishedAt: new Date().toISOString() };
+    return {
+      id: createdPost.id,
+      url,
+      platform: 'ugig',
+      publishedAt: new Date(createdPost.created_at ?? Date.now()).toISOString(),
+    };
   },
 
-  setup: oauthSetup({
-    secretKey: 'UGIG_TOKEN',
+  setup: tokenSetup<Config>({
+    secretKey: 'UGIG_API_KEY',
     label: 'uGig',
-    vendorDocUrl: 'https://ugig.net',
+    vendorDocUrl: 'https://ugig.net/openapi.json',
     steps: [
-      'Register at https://ugig.net (email + password)',
-      'Obtain Bearer token: POST https://ugig.net/api/auth/login body={"email":"…","password":"…"}',
-      'Copy access_token from the JSON response',
-      'Store it as UGIG_TOKEN in your sh1pt secrets vault',
-      'Optionally set defaultCategory (ai|coding|writing|research|other) and defaultPriceSats in config',
+      'Register or sign in at https://ugig.net',
+      'Create an API key and store it as UGIG_API_KEY in your sh1pt secrets vault',
+      'Legacy Supabase bearer tokens stored as UGIG_TOKEN are also accepted',
+      'Posts publish to POST https://ugig.net/api/posts with content, url, post_type, and tags',
     ],
   }),
 });
+
+interface SecretContext {
+  secret(k: string): string | undefined;
+}
+
+interface UgigPost {
+  id?: string;
+  created_at?: string;
+}
+
+interface UgigPostPayload {
+  content: string;
+  url: string | null;
+  post_type: UgigPostType;
+  tags: string[];
+}
+
+function authHeaders(ctx: SecretContext): Record<string, string> {
+  const apiKey = ctx.secret('UGIG_API_KEY');
+  if (apiKey) return { 'X-API-Key': apiKey };
+
+  const token = ctx.secret('UGIG_TOKEN');
+  if (token) return { Authorization: `Bearer ${token}` };
+
+  throw new Error('UGIG_API_KEY not in vault - run: sh1pt secret set UGIG_API_KEY <api-key>');
+}
+
+function formatUgigPost(post: SocialPost, config: Config): UgigPostPayload {
+  const content = formatContent(post);
+  const tags = (post.hashtags ?? [])
+    .map((tag) => tag.replace(/^#+/, '').trim())
+    .filter(Boolean)
+    .slice(0, MAX_TAGS)
+    .map((tag) => tag.slice(0, MAX_TAG_CHARS));
+
+  return {
+    content,
+    url: post.link ?? null,
+    post_type: config.postType ?? (post.link ? 'link' : 'text'),
+    tags,
+  };
+}
+
+function formatContent(post: SocialPost): string {
+  const parts = [post.title, post.body]
+    .map((part) => part?.trim())
+    .filter((part): part is string => Boolean(part));
+  const content = parts.join('\n\n');
+  if (!content) throw new Error('uGig posts require non-empty content');
+  return content.slice(0, MAX_CONTENT_CHARS);
+}
+
+function apiBase(config: Config): string {
+  return (config.apiBaseUrl ?? UGIG_API).replace(/\/+$/, '');
+}
+
+async function readUgigError(res: Response): Promise<string> {
+  const text = await res.text().catch(() => '');
+  if (!text) return res.statusText || 'Unknown uGig API error';
+  try {
+    const data = JSON.parse(text) as { error?: string; message?: string };
+    return data.error ?? data.message ?? text;
+  } catch {
+    return text;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the stale uGig prompts-marketplace integration with the current documented `/api/posts` community feed API
- support `UGIG_API_KEY` via `X-API-Key`, while preserving legacy `UGIG_TOKEN` bearer auth fallback
- map sh1pt social posts to uGig `content`, `url`, `post_type`, and `tags`, returning the public `/post/:id` URL
- expand tests from a smoke check to contract, auth, request-shape, fallback-token, and API-error coverage

## Validation
- `corepack pnpm exec vitest run packages/social/ugig/src/index.test.ts`
- `corepack pnpm exec tsc -p packages/social/ugig/tsconfig.json --noEmit`
- `git diff --check`