### PR TITLE
Implement Cohere v2 chat adapter

### DIFF
--- a/packages/ai/cohere/src/index.test.ts
+++ b/packages/ai/cohere/src/index.test.ts
@@ -1,4 +1,110 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { COHERE_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Cohere v2 chat generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ COHERE_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'command-a-03-2025' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts v2 chat requests and maps token usage', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        model: 'command-r7b-12-2024',
+        message: {
+          content: [
+            { type: 'text', text: 'hi ' },
+            { type: 'text', text: 'from cohere' },
+          ],
+        },
+        usage: {
+          tokens: { input_tokens: 14, output_tokens: 5 },
+          billed_units: { input_tokens: 1, output_tokens: 1 },
+        },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'command-r7b-12-2024',
+      system: 'be brief',
+      maxTokens: 30,
+      temperature: 0.2,
+      extra: { p: 0.8, safety_mode: 'STRICT' },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.cohere.com/v2/chat');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(request.headers['content-type']).toBe('application/json');
+    expect(JSON.parse(request.body)).toEqual({
+      stream: false,
+      model: 'command-r7b-12-2024',
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 30,
+      temperature: 0.2,
+      p: 0.8,
+      safety_mode: 'STRICT',
+    });
+    expect(result).toEqual({
+      text: 'hi from cohere',
+      model: 'command-r7b-12-2024',
+      inputTokens: 14,
+      outputTokens: 5,
+    });
+  });
+
+  it('falls back to billed units when token counts are absent', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        message: { content: 'plain string response' },
+        usage: { billed_units: { input_tokens: 2, output_tokens: 3 } },
+      }),
+    }));
+
+    const result = await adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://cohere.test' });
+
+    expect(result).toEqual({
+      text: 'plain string response',
+      model: 'command-a-03-2025',
+      inputTokens: 2,
+      outputTokens: 3,
+    });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => 'invalid api key'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/Cohere 401: invalid api key/);
+  });
+});

--- a/packages/ai/cohere/src/index.ts
+++ b/packages/ai/cohere/src/index.ts
@@ -4,23 +4,62 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.cohere.com';
+const DEFAULT_MODEL = 'command-a-03-2025';
+
 export default defineAi<Config>({
   id: 'ai-cohere',
   label: 'Cohere',
-  defaultModel: 'command-r-plus',
-  models: ['command-r-plus'],
+  defaultModel: DEFAULT_MODEL,
+  models: [
+    DEFAULT_MODEL,
+    'command-a-reasoning-08-2025',
+    'command-r7b-12-2024',
+    'command-r-plus-08-2024',
+    'command-r-08-2024',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('COHERE_API_KEY');
-    if (!apiKey) throw new Error('COHERE_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-cohere · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-cohere integration not yet implemented]', model: 'command-r-plus' };
+    if (!apiKey) throw new Error('COHERE_API_KEY not in vault');
+    const model = opts.model ?? DEFAULT_MODEL;
+    ctx.log(`cohere · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: CohereMessage[] = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v2/chat`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        stream: false,
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Cohere ${res.status}: ${(await res.text()).slice(0, 200)}`);
+
+    const data = await res.json() as CohereChatResponse;
+    return {
+      text: cohereText(data.message?.content),
+      model: data.model ?? model,
+      inputTokens: data.usage?.tokens?.input_tokens ?? data.usage?.billed_units?.input_tokens,
+      outputTokens: data.usage?.tokens?.output_tokens ?? data.usage?.billed_units?.output_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'COHERE_API_KEY',
     label: 'Cohere',
-    vendorDocUrl: 'https://dashboard.cohere.com',
+    vendorDocUrl: 'https://docs.cohere.com/v2/reference/chat',
     steps: [
       'Sign in at https://dashboard.cohere.com and create an API key',
       'Copy the key — usually shown once',
@@ -28,3 +67,38 @@ export default defineAi<Config>({
     ],
   }),
 });
+
+type CohereRole = 'system' | 'user' | 'assistant' | 'tool';
+
+interface CohereMessage {
+  role: CohereRole;
+  content: string;
+}
+
+interface CohereChatResponse {
+  model?: string;
+  message?: {
+    content?: CohereContent;
+  };
+  usage?: {
+    tokens?: {
+      input_tokens?: number;
+      output_tokens?: number;
+    };
+    billed_units?: {
+      input_tokens?: number;
+      output_tokens?: number;
+    };
+  };
+}
+
+type CohereContent = string | Array<{ type?: string; text?: string }> | undefined;
+
+function cohereText(content: CohereContent): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .filter((part) => part.type === undefined || part.type === 'text')
+    .map((part) => part.text ?? '')
+    .join('');
+}


### PR DESCRIPTION
## Summary
- replace the Cohere AI stub with a real `POST /v2/chat` integration
- update the default model from deprecated `command-r-plus` to current `command-a-03-2025`, with current Command model IDs listed
- send system/user messages, max token and temperature options, plus provider-specific `extra` fields
- normalize text content and token usage from Cohere v2 responses
- expand tests from smoke-only to dry-run, request-shape, usage mapping, billed-unit fallback, and error coverage

## Validation
- `corepack pnpm exec vitest run packages/ai/cohere/src/index.test.ts`
- `corepack pnpm exec tsc -p packages/ai/cohere/tsconfig.json --noEmit`
- `git diff --check`

## Reference
- Cohere v2 Chat docs: https://docs.cohere.com/v2/reference/chat
- Cohere model docs: https://docs.cohere.com/v2/docs/models