### PR TITLE
Implement AI21 chat completions adapter

### DIFF
--- a/packages/ai/ai21/src/index.test.ts
+++ b/packages/ai/ai21/src/index.test.ts
@@ -1,4 +1,98 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { AI21_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('AI21 Jamba chat completions generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ AI21_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'jamba-large' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        model: 'jamba-mini',
+        choices: [{ message: { role: 'assistant', content: 'hi from ai21' } }],
+        usage: { prompt_tokens: 12, completion_tokens: 4, total_tokens: 16 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'jamba-mini',
+      system: 'be brief',
+      maxTokens: 24,
+      temperature: 0.2,
+      extra: { top_p: 0.7, n: 1 },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.ai21.com/studio/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(request.headers['content-type']).toBe('application/json');
+    expect(JSON.parse(request.body)).toEqual({
+      stream: false,
+      model: 'jamba-mini',
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 24,
+      temperature: 0.2,
+      top_p: 0.7,
+      n: 1,
+    });
+    expect(result).toEqual({
+      text: 'hi from ai21',
+      model: 'jamba-mini',
+      inputTokens: 12,
+      outputTokens: 4,
+    });
+  });
+
+  it('uses the configured base URL and request model when the response omits model', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'configured host' } }],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://ai21.test' });
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://ai21.test/studio/v1/chat/completions');
+    expect(result).toEqual({ text: 'configured host', model: 'jamba-large' });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => 'unauthorized'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/AI21 401: unauthorized/);
+  });
+});

--- a/packages/ai/ai21/src/index.ts
+++ b/packages/ai/ai21/src/index.ts
@@ -4,23 +4,56 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.ai21.com';
+const DEFAULT_MODEL = 'jamba-large';
+
 export default defineAi<Config>({
   id: 'ai-ai21',
   label: 'AI21',
-  defaultModel: 'jamba-1.5-large',
-  models: ['jamba-1.5-large'],
+  defaultModel: DEFAULT_MODEL,
+  models: ['jamba-large', 'jamba-mini', 'jamba-large-1.7', 'jamba-mini-2'],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('AI21_API_KEY');
-    if (!apiKey) throw new Error('AI21_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-ai21 · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-ai21 integration not yet implemented]', model: 'jamba-1.5-large' };
+    if (!apiKey) throw new Error('AI21_API_KEY not in vault');
+    const model = opts.model ?? DEFAULT_MODEL;
+    ctx.log(`ai21 · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Ai21Message[] = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/studio/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        stream: false,
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`AI21 ${res.status}: ${(await res.text()).slice(0, 200)}`);
+
+    const data = await res.json() as Ai21ChatResponse;
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model ?? model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'AI21_API_KEY',
     label: 'AI21',
-    vendorDocUrl: 'https://studio.ai21.com',
+    vendorDocUrl: 'https://docs.ai21.com/reference/jamba-1-6-api-ref',
     steps: [
       'Sign in at https://studio.ai21.com and create an API key',
       'Copy the key — usually shown once',
@@ -28,3 +61,23 @@ export default defineAi<Config>({
     ],
   }),
 });
+
+type Ai21Role = 'system' | 'user' | 'assistant' | 'tool';
+
+interface Ai21Message {
+  role: Ai21Role;
+  content: string;
+}
+
+interface Ai21ChatResponse {
+  model?: string;
+  choices: Array<{
+    message?: {
+      content?: string;
+    };
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+  };
+}


### PR DESCRIPTION
## Summary
- replace the AI21 stub with the documented `/studio/v1/chat/completions` integration
- update the default model from old `jamba-1.5-large` to current `jamba-large`, with current Jamba aliases listed
- send system/user messages, max token and temperature options, plus provider-specific `extra` fields
- normalize assistant text and prompt/completion token usage from AI21 responses
- expand tests from smoke-only to dry-run, request-shape, configured-base, usage mapping, and error coverage

## Validation
- `corepack pnpm exec vitest run packages/ai/ai21/src/index.test.ts`
- `corepack pnpm exec tsc -p packages/ai/ai21/tsconfig.json --noEmit`
- `git diff --check`

## Reference
- AI21 chat request docs: https://docs.ai21.com/reference/jamba-1-6-api-ref
- AI21 chat response docs: https://docs.ai21.com/reference/jamba-api-response
- Jamba model docs: https://docs.ai21.com/docs/jamba-foundation-models