### PR TITLE
Implement Nebius chat completions adapter

### DIFF
--- a/packages/ai/nebius/src/index.test.ts
+++ b/packages/ai/nebius/src/index.test.ts
@@ -1,4 +1,100 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { NEBIUS_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Nebius Token Factory chat completions generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ NEBIUS_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'meta-llama/Llama-3.3-70B-Instruct' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        model: 'deepseek-ai/DeepSeek-R1-0528',
+        choices: [{ message: { role: 'assistant', content: 'hi from nebius' } }],
+        usage: { prompt_tokens: 13, completion_tokens: 5, total_tokens: 18 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'deepseek-ai/DeepSeek-R1-0528',
+      system: 'be brief',
+      maxTokens: 28,
+      temperature: 0.3,
+      extra: { top_p: 0.8, service_tier: 'auto' },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.tokenfactory.nebius.com/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(request.headers['content-type']).toBe('application/json');
+    expect(JSON.parse(request.body)).toEqual({
+      stream: false,
+      model: 'deepseek-ai/DeepSeek-R1-0528',
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 28,
+      temperature: 0.3,
+      top_p: 0.8,
+      service_tier: 'auto',
+    });
+    expect(result).toEqual({
+      text: 'hi from nebius',
+      model: 'deepseek-ai/DeepSeek-R1-0528',
+      inputTokens: 13,
+      outputTokens: 5,
+    });
+  });
+
+  it('supports text-style choices from compatible Nebius responses', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        model: 'meta-llama/Llama-3.3-70B-Instruct',
+        choices: [{ text: 'text choice response' }],
+      }),
+    }));
+
+    const result = await adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://nebius.test' });
+
+    expect(result).toEqual({
+      text: 'text choice response',
+      model: 'meta-llama/Llama-3.3-70B-Instruct',
+    });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 422,
+      text: async () => 'invalid request'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/Nebius 422: invalid request/);
+  });
+});

--- a/packages/ai/nebius/src/index.ts
+++ b/packages/ai/nebius/src/index.ts
@@ -4,27 +4,86 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.tokenfactory.nebius.com';
+const DEFAULT_MODEL = 'meta-llama/Llama-3.3-70B-Instruct';
+
 export default defineAi<Config>({
   id: 'ai-nebius',
   label: 'Nebius Token Factory',
-  defaultModel: 'meta-llama/Llama-3.3-70B-Instruct',
-  models: ['meta-llama/Llama-3.3-70B-Instruct'],
+  defaultModel: DEFAULT_MODEL,
+  models: [
+    DEFAULT_MODEL,
+    'meta-llama/Meta-Llama-3.1-70B-Instruct',
+    'deepseek-ai/DeepSeek-R1-0528',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('NEBIUS_API_KEY');
-    if (!apiKey) throw new Error('NEBIUS_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-nebius · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-nebius integration not yet implemented]', model: 'meta-llama/Llama-3.3-70B-Instruct' };
+    if (!apiKey) throw new Error('NEBIUS_API_KEY not in vault');
+    const model = opts.model ?? DEFAULT_MODEL;
+    ctx.log(`nebius · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: NebiusMessage[] = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        stream: false,
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Nebius ${res.status}: ${(await res.text()).slice(0, 200)}`);
+
+    const data = await res.json() as NebiusChatResponse;
+    const choice = data.choices[0];
+    return {
+      text: choice?.message?.content ?? choice?.text ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'NEBIUS_API_KEY',
     label: 'Nebius Token Factory',
-    vendorDocUrl: 'https://studio.nebius.ai',
+    vendorDocUrl: 'https://docs.tokenfactory.nebius.com/api-reference/inference/create-chat-completion',
     steps: [
-      'Sign in at https://studio.nebius.ai and create an API key',
+      'Sign in at https://tokenfactory.nebius.com and create an API key',
       'Copy the key — usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],
   }),
 });
+
+type NebiusRole = 'system' | 'user' | 'assistant' | 'tool';
+
+interface NebiusMessage {
+  role: NebiusRole;
+  content: string;
+}
+
+interface NebiusChatResponse {
+  model: string;
+  choices: Array<{
+    message?: {
+      content?: string;
+    };
+    text?: string;
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+  };
+}


### PR DESCRIPTION
## Summary
- replace the Nebius AI stub with the documented Token Factory `/v1/chat/completions` integration
- use the current Token Factory API base and preserve the existing Llama 3.3 default model
- send system/user messages, max token and temperature options, plus provider-specific `extra` fields
- normalize assistant-message and text-style choices plus prompt/completion token usage
- expand tests from smoke-only to dry-run, request-shape, text-choice fallback, usage mapping, and error coverage

## Validation
- `corepack pnpm exec vitest run packages/ai/nebius/src/index.test.ts`
- `corepack pnpm exec tsc -p packages/ai/nebius/tsconfig.json --noEmit`
- `git diff --check`

## Reference
- Nebius chat completions docs: https://docs.tokenfactory.nebius.com/api-reference/inference/create-chat-completion
- Nebius quickstart: https://docs.tokenfactory.nebius.com/quickstart