### PR TITLE
Implement Reka chat completions adapter

### DIFF
--- a/packages/ai/reka/src/index.test.ts
+++ b/packages/ai/reka/src/index.test.ts
@@ -1,4 +1,100 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { REKA_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Reka chat completions generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ REKA_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'reka-flash' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps Reka token usage', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: 'chat-1',
+        model: 'reka-edge-2603',
+        choices: [{ message: { role: 'assistant', content: 'hi from reka' } }],
+        usage: { input_tokens: 14, output_tokens: 40 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'reka-edge-2603',
+      system: 'be brief',
+      maxTokens: 32,
+      temperature: 0.2,
+      extra: { top_p: 0.8, top_k: 50 },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.reka.ai/v1/chat/completions');
+    expect(request.headers['X-Api-Key']).toBe('test-key');
+    expect(request.headers['content-type']).toBe('application/json');
+    expect(JSON.parse(request.body)).toEqual({
+      stream: false,
+      model: 'reka-edge-2603',
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 32,
+      temperature: 0.2,
+      top_p: 0.8,
+      top_k: 50,
+    });
+    expect(result).toEqual({
+      text: 'hi from reka',
+      model: 'reka-edge-2603',
+      inputTokens: 14,
+      outputTokens: 40,
+    });
+  });
+
+  it('uses a configured API base URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        model: 'reka-flash',
+        choices: [{ message: { content: 'configured host' } }],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://reka.test' });
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://reka.test/v1/chat/completions');
+    expect(result).toEqual({ text: 'configured host', model: 'reka-flash' });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 422,
+      text: async () => 'unprocessable'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/Reka 422: unprocessable/);
+  });
+});

--- a/packages/ai/reka/src/index.ts
+++ b/packages/ai/reka/src/index.ts
@@ -4,27 +4,80 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.reka.ai';
+const DEFAULT_MODEL = 'reka-flash';
+
 export default defineAi<Config>({
   id: 'ai-reka',
   label: 'Reka AI',
-  defaultModel: 'reka-core',
-  models: ['reka-core'],
+  defaultModel: DEFAULT_MODEL,
+  models: [DEFAULT_MODEL, 'reka-edge', 'reka-edge-2603'],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('REKA_API_KEY');
-    if (!apiKey) throw new Error('REKA_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-reka · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-reka integration not yet implemented]', model: 'reka-core' };
+    if (!apiKey) throw new Error('REKA_API_KEY not in vault');
+    const model = opts.model ?? DEFAULT_MODEL;
+    ctx.log(`reka · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: RekaMessage[] = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'X-Api-Key': apiKey,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        stream: false,
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Reka ${res.status}: ${(await res.text()).slice(0, 200)}`);
+
+    const data = await res.json() as RekaChatResponse;
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.input_tokens,
+      outputTokens: data.usage?.output_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'REKA_API_KEY',
     label: 'Reka AI',
-    vendorDocUrl: 'https://www.reka.ai',
+    vendorDocUrl: 'https://docs.reka.ai/chat/api-reference/create',
     steps: [
-      'Sign in at https://www.reka.ai and create an API key',
+      'Sign in at https://platform.reka.ai and create an API key',
       'Copy the key — usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],
   }),
 });
+
+type RekaRole = 'system' | 'user' | 'assistant' | 'tool';
+
+interface RekaMessage {
+  role: RekaRole;
+  content: string;
+}
+
+interface RekaChatResponse {
+  model: string;
+  choices: Array<{
+    message?: {
+      content?: string;
+    };
+  }>;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+  };
+}


### PR DESCRIPTION
## Summary
- replace the Reka AI stub with the documented `/v1/chat/completions` integration
- update the default model from stale `reka-core` to publicly documented `reka-flash`, with `reka-edge` aliases listed
- send system/user messages, max token and temperature options, plus provider-specific `extra` fields
- normalize assistant text and Reka input/output token usage
- expand tests from smoke-only to dry-run, request-shape, configured-base, usage mapping, and error coverage

## Validation
- `corepack pnpm exec vitest run packages/ai/reka/src/index.test.ts`
- `corepack pnpm exec tsc -p packages/ai/reka/tsconfig.json --noEmit`
- `git diff --check`

## Reference
- Reka chat completions docs: https://docs.reka.ai/chat/api-reference/create
- Reka model docs: https://docs.reka.ai/chat/models