### PR TITLE
Implement Venice chat completions adapter

### DIFF
--- a/packages/ai/venice/src/index.test.ts
+++ b/packages/ai/venice/src/index.test.ts
@@ -1,4 +1,86 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { VENICE_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Venice OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ VENICE_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'zai-org-glm-4.7' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from venice' } }],
+        model: 'deepseek-v3.2',
+        usage: { prompt_tokens: 9, completion_tokens: 5 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'deepseek-v3.2',
+      system: 'be concise',
+      maxTokens: 32,
+      temperature: 0.4,
+      extra: {
+        top_p: 0.8,
+        venice_parameters: { character_slug: 'helper' },
+      },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.venice.ai/api/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'deepseek-v3.2',
+      messages: [
+        { role: 'system', content: 'be concise' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 32,
+      temperature: 0.4,
+      top_p: 0.8,
+      venice_parameters: { character_slug: 'helper' },
+    });
+    expect(result).toEqual({
+      text: 'hi from venice',
+      model: 'deepseek-v3.2',
+      inputTokens: 9,
+      outputTokens: 5,
+    });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 402,
+      text: async () => 'payment required'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(
+      /Venice 402: payment required/
+    );
+  });
+});

--- a/packages/ai/venice/src/index.ts
+++ b/packages/ai/venice/src/index.ts
@@ -4,27 +4,85 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.venice.ai/api/v1';
+const DEFAULT_MODEL = 'zai-org-glm-4.7';
+
 export default defineAi<Config>({
   id: 'ai-venice',
   label: 'Venice AI',
-  defaultModel: 'llama-3.3-70b',
-  models: ['llama-3.3-70b'],
+  defaultModel: DEFAULT_MODEL,
+  models: [
+    DEFAULT_MODEL,
+    'venice-uncensored',
+    'deepseek-v3.2',
+    'qwen3-4b',
+    'mistral-31-24b',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('VENICE_API_KEY');
-    if (!apiKey) throw new Error('VENICE_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-venice · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-venice integration not yet implemented]', model: 'llama-3.3-70b' };
+    if (!apiKey) throw new Error('VENICE_API_KEY not in vault');
+    const model = opts.model ?? DEFAULT_MODEL;
+    ctx.log(`venice · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: VeniceMessage[] = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Venice ${res.status}: ${(await res.text()).slice(0, 200)}`);
+
+    const data = await res.json() as VeniceChatResponse;
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'VENICE_API_KEY',
     label: 'Venice AI',
-    vendorDocUrl: 'https://venice.ai',
+    vendorDocUrl: 'https://docs.venice.ai/api-reference/endpoint/chat/completions',
     steps: [
-      'Sign in at https://venice.ai and create an API key',
+      'Sign in at https://venice.ai/settings/api and create an API key',
       'Copy the key — usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],
   }),
 });
+
+type VeniceRole = 'system' | 'user' | 'assistant' | 'tool' | 'developer';
+
+interface VeniceMessage {
+  role: VeniceRole;
+  content: string;
+}
+
+interface VeniceChatResponse {
+  model: string;
+  choices: Array<{
+    message?: {
+      content?: string;
+    };
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+  };
+}


### PR DESCRIPTION
## Summary
- replace the Venice AI stub with a real OpenAI-compatible chat completions adapter
- use the current Venice `/api/v1/chat/completions` endpoint, documented model IDs, dry-run behavior, standard generation options, and `opts.extra` passthrough for Venice-specific parameters
- add focused tests for dry-run behavior, request payload/auth, token usage mapping, and HTTP error excerpts

## References
- https://docs.venice.ai/api-reference/endpoint/chat/completions
- https://docs.venice.ai/overview/about-venice

## Validation
- `corepack pnpm exec vitest run packages/ai/venice/src/index.test.ts`
- `corepack pnpm exec tsc -p packages/ai/venice/tsconfig.json --noEmit`
- `git diff --check`