### PR TITLE
Implement Featherless chat completions adapter

### DIFF
--- a/packages/ai/featherless/src/index.test.ts
+++ b/packages/ai/featherless/src/index.test.ts
@@ -1,4 +1,98 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (
+  secrets: Record<string, string> = { FEATHERLESS_API_KEY: 'test-key' },
+  dryRun = false
+) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Featherless OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx({ FEATHERLESS_API_KEY: 'test-key' }, true),
+      'hello',
+      {},
+      {}
+    );
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'Qwen/Qwen2.5-7B-Instruct' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from featherless' } }],
+        model: 'GalrionSoftworks/Margnum-12B-v1',
+        usage: { prompt_tokens: 11, completion_tokens: 6 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx(),
+      'hello',
+      {
+        model: 'GalrionSoftworks/Margnum-12B-v1',
+        system: 'be helpful',
+        maxTokens: 40,
+        temperature: 0.5,
+        extra: { top_p: 0.9, min_p: 0.05 },
+      },
+      {}
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.featherless.ai/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(request.headers['HTTP-Referer']).toBe('https://github.com/profullstack/sh1pt');
+    expect(request.headers['X-Title']).toBe('sh1pt');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'GalrionSoftworks/Margnum-12B-v1',
+      messages: [
+        { role: 'system', content: 'be helpful' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 40,
+      temperature: 0.5,
+      top_p: 0.9,
+      min_p: 0.05,
+    });
+    expect(result).toEqual({
+      text: 'hi from featherless',
+      model: 'GalrionSoftworks/Margnum-12B-v1',
+      inputTokens: 11,
+      outputTokens: 6,
+    });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => 'unauthorized'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(
+      /Featherless 401: unauthorized/
+    );
+  });
+});

--- a/packages/ai/featherless/src/index.ts
+++ b/packages/ai/featherless/src/index.ts
@@ -4,27 +4,81 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.featherless.ai/v1';
+const DEFAULT_MODEL = 'Qwen/Qwen2.5-7B-Instruct';
+
 export default defineAi<Config>({
   id: 'ai-featherless',
   label: 'Featherless',
-  defaultModel: 'FEATHERLESS_API_KEY',
-  models: ['FEATHERLESS_API_KEY'],
+  defaultModel: DEFAULT_MODEL,
+  models: [DEFAULT_MODEL, 'GalrionSoftworks/Margnum-12B-v1'],
 
-  async generate(ctx, prompt, _opts, _config) {
-    const apiKey = ctx.secret('https://featherless.ai');
-    if (!apiKey) throw new Error('https://featherless.ai not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-featherless · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-featherless integration not yet implemented]', model: 'FEATHERLESS_API_KEY' };
+  async generate(ctx, prompt, opts, config) {
+    const apiKey = ctx.secret('FEATHERLESS_API_KEY');
+    if (!apiKey) throw new Error('FEATHERLESS_API_KEY not in vault');
+    const model = opts.model ?? DEFAULT_MODEL;
+    ctx.log(`featherless · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: FeatherlessMessage[] = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+        'HTTP-Referer': 'https://github.com/profullstack/sh1pt',
+        'X-Title': 'sh1pt',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Featherless ${res.status}: ${(await res.text()).slice(0, 200)}`);
+
+    const data = await res.json() as FeatherlessChatResponse;
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
-    secretKey: 'https://featherless.ai',
+    secretKey: 'FEATHERLESS_API_KEY',
     label: 'Featherless',
-    vendorDocUrl: '',
+    vendorDocUrl: 'https://featherless.ai/docs/completions',
     steps: [
-      'Sign in at  and create an API key',
+      'Sign in at https://featherless.ai/account/api-keys and create an API key',
       'Copy the key — usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],
   }),
 });
+
+type FeatherlessRole = 'system' | 'user' | 'assistant' | 'tool';
+
+interface FeatherlessMessage {
+  role: FeatherlessRole;
+  content: string;
+}
+
+interface FeatherlessChatResponse {
+  model: string;
+  choices: Array<{
+    message?: {
+      content?: string;
+    };
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+  };
+}


### PR DESCRIPTION
## Summary
- replace the broken Featherless stub with a real OpenAI-compatible chat completions adapter
- use the documented `https://api.featherless.ai/v1/chat/completions` endpoint, documented example model IDs, dry-run behavior, standard generation options, and `opts.extra` passthrough for sampler parameters
- send Featherless-requested `HTTP-Referer` and `X-Title` application headers
- add focused tests for dry-run behavior, request payload/auth/attribution headers, token usage mapping, and HTTP error excerpts

## References
- https://featherless.ai/docs/completions
- https://featherless.ai/docs/quickstart-guide
- https://featherless.ai/docs/api-overview-and-common-options

## Validation
- `corepack pnpm exec vitest run packages/ai/featherless/src/index.test.ts`
- `corepack pnpm exec tsc -p packages/ai/featherless/tsconfig.json --noEmit`
- `git diff --check`