### PR TITLE
Implement SiliconFlow chat completions adapter

### DIFF
--- a/packages/ai/siliconflow/src/index.test.ts
+++ b/packages/ai/siliconflow/src/index.test.ts
@@ -1,4 +1,95 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (
+  secrets: Record<string, string> = { SILICONFLOW_API_KEY: 'test-key' },
+  dryRun = false
+) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('SiliconFlow OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx({ SILICONFLOW_API_KEY: 'test-key' }, true),
+      'hello',
+      {},
+      {}
+    );
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'Qwen/QwQ-32B' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from siliconflow', reasoning_content: 'brief' } }],
+        model: 'deepseek-ai/DeepSeek-V3.2',
+        usage: { prompt_tokens: 12, completion_tokens: 7 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx(),
+      'hello',
+      {
+        model: 'deepseek-ai/DeepSeek-V3.2',
+        system: 'be useful',
+        maxTokens: 48,
+        temperature: 0.6,
+        extra: { top_p: 0.95 },
+      },
+      {}
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.siliconflow.com/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'deepseek-ai/DeepSeek-V3.2',
+      messages: [
+        { role: 'system', content: 'be useful' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 48,
+      temperature: 0.6,
+      top_p: 0.95,
+    });
+    expect(result).toEqual({
+      text: 'hi from siliconflow',
+      model: 'deepseek-ai/DeepSeek-V3.2',
+      inputTokens: 12,
+      outputTokens: 7,
+    });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => 'rate limited'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(
+      /SiliconFlow 429: rate limited/
+    );
+  });
+});

--- a/packages/ai/siliconflow/src/index.ts
+++ b/packages/ai/siliconflow/src/index.ts
@@ -4,27 +4,85 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.siliconflow.com/v1';
+const DEFAULT_MODEL = 'Qwen/QwQ-32B';
+
 export default defineAi<Config>({
   id: 'ai-siliconflow',
   label: 'SiliconFlow',
-  defaultModel: 'SILICONFLOW_API_KEY',
-  models: ['SILICONFLOW_API_KEY'],
+  defaultModel: DEFAULT_MODEL,
+  models: [
+    DEFAULT_MODEL,
+    'deepseek-ai/DeepSeek-V3.2',
+    'zai-org/GLM-4.7',
+    'moonshotai/Kimi-K2.5',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
-    const apiKey = ctx.secret('https://siliconflow.cn');
-    if (!apiKey) throw new Error('https://siliconflow.cn not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-siliconflow · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-siliconflow integration not yet implemented]', model: 'SILICONFLOW_API_KEY' };
+  async generate(ctx, prompt, opts, config) {
+    const apiKey = ctx.secret('SILICONFLOW_API_KEY');
+    if (!apiKey) throw new Error('SILICONFLOW_API_KEY not in vault');
+    const model = opts.model ?? DEFAULT_MODEL;
+    ctx.log(`siliconflow · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: SiliconFlowMessage[] = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`SiliconFlow ${res.status}: ${(await res.text()).slice(0, 200)}`);
+
+    const data = await res.json() as SiliconFlowChatResponse;
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
-    secretKey: 'https://siliconflow.cn',
+    secretKey: 'SILICONFLOW_API_KEY',
     label: 'SiliconFlow',
-    vendorDocUrl: '',
+    vendorDocUrl: 'https://docs.siliconflow.com/en/api-reference/chat-completions/chat-completions',
     steps: [
-      'Sign in at  and create an API key',
+      'Sign in at https://cloud.siliconflow.com/account/ak and create an API key',
       'Copy the key — usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],
   }),
 });
+
+type SiliconFlowRole = 'system' | 'user' | 'assistant' | 'tool';
+
+interface SiliconFlowMessage {
+  role: SiliconFlowRole;
+  content: string;
+}
+
+interface SiliconFlowChatResponse {
+  model: string;
+  choices: Array<{
+    message?: {
+      content?: string;
+      reasoning_content?: string;
+    };
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+  };
+}


### PR DESCRIPTION
## Summary
- replace the broken SiliconFlow stub with a real OpenAI-compatible chat completions adapter
- use the documented `https://api.siliconflow.com/v1/chat/completions` endpoint and current model IDs from the API reference
- support dry-run behavior, standard generation options, `opts.extra` passthrough, token usage mapping, and concise HTTP error excerpts
- add focused tests for dry-run behavior, request payload/auth, token usage mapping, and error handling

## References
- https://docs.siliconflow.com/en/api-reference/chat-completions/chat-completions
- https://docs.siliconflow.com/en/userguide/guides/completions

## Validation
- `corepack pnpm exec vitest run packages/ai/siliconflow/src/index.test.ts`
- `corepack pnpm exec tsc -p packages/ai/siliconflow/tsconfig.json --noEmit`
- `git diff --check`