### PR TITLE
Implement Moonshot chat completions adapter

### DIFF
--- a/packages/ai/moonshot/src/index.test.ts
+++ b/packages/ai/moonshot/src/index.test.ts
@@ -1,4 +1,95 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (
+  secrets: Record<string, string> = { MOONSHOT_API_KEY: 'test-key' },
+  dryRun = false
+) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Moonshot OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx({ MOONSHOT_API_KEY: 'test-key' }, true),
+      'hello',
+      {},
+      {}
+    );
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'kimi-k2.6' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from kimi', reasoning_content: 'brief' } }],
+        model: 'kimi-k2.5',
+        usage: { prompt_tokens: 13, completion_tokens: 8 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx(),
+      'hello',
+      {
+        model: 'kimi-k2.5',
+        system: 'be direct',
+        maxTokens: 64,
+        temperature: 0.2,
+        extra: { thinking: { type: 'disabled' } },
+      },
+      {}
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.moonshot.ai/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'kimi-k2.5',
+      messages: [
+        { role: 'system', content: 'be direct' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 64,
+      temperature: 0.2,
+      thinking: { type: 'disabled' },
+    });
+    expect(result).toEqual({
+      text: 'hi from kimi',
+      model: 'kimi-k2.5',
+      inputTokens: 13,
+      outputTokens: 8,
+    });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'server error'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(
+      /Moonshot 500: server error/
+    );
+  });
+});

--- a/packages/ai/moonshot/src/index.ts
+++ b/packages/ai/moonshot/src/index.ts
@@ -4,27 +4,80 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.moonshot.ai/v1';
+const DEFAULT_MODEL = 'kimi-k2.6';
+
 export default defineAi<Config>({
   id: 'ai-moonshot',
   label: 'Moonshot AI',
-  defaultModel: 'moonshot-v1-8k',
-  models: ['moonshot-v1-8k'],
+  defaultModel: DEFAULT_MODEL,
+  models: [DEFAULT_MODEL, 'kimi-k2.5', 'kimi-k2-thinking', 'kimi-k2-turbo-preview'],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('MOONSHOT_API_KEY');
-    if (!apiKey) throw new Error('MOONSHOT_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-moonshot · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-moonshot integration not yet implemented]', model: 'moonshot-v1-8k' };
+    if (!apiKey) throw new Error('MOONSHOT_API_KEY not in vault');
+    const model = opts.model ?? DEFAULT_MODEL;
+    ctx.log(`moonshot · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: MoonshotMessage[] = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Moonshot ${res.status}: ${(await res.text()).slice(0, 200)}`);
+
+    const data = await res.json() as MoonshotChatResponse;
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'MOONSHOT_API_KEY',
     label: 'Moonshot AI',
-    vendorDocUrl: 'https://platform.moonshot.cn',
+    vendorDocUrl: 'https://platform.kimi.ai/docs/api/chat',
     steps: [
-      'Sign in at https://platform.moonshot.cn and create an API key',
+      'Sign in at https://platform.moonshot.ai/console/api-keys and create an API key',
       'Copy the key — usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],
   }),
 });
+
+type MoonshotRole = 'system' | 'user' | 'assistant' | 'tool';
+
+interface MoonshotMessage {
+  role: MoonshotRole;
+  content: string;
+}
+
+interface MoonshotChatResponse {
+  model: string;
+  choices: Array<{
+    message?: {
+      content?: string;
+      reasoning_content?: string;
+    };
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+  };
+}


### PR DESCRIPTION
## Summary
- replace the Moonshot AI stub with a real Kimi/Moonshot chat completions adapter
- use the documented OpenAI-compatible `https://api.moonshot.ai/v1/chat/completions` endpoint and current Kimi model IDs
- support dry-run behavior, standard generation options, `opts.extra` passthrough for Kimi extensions, token usage mapping, and concise HTTP error excerpts
- add focused tests for dry-run behavior, request payload/auth, token usage mapping, and error handling

## References
- https://platform.kimi.ai/docs/api/overview
- https://platform.kimi.ai/docs/api/chat

## Validation
- `corepack pnpm exec vitest run packages/ai/moonshot/src/index.test.ts`
- `corepack pnpm exec tsc -p packages/ai/moonshot/tsconfig.json --noEmit`
- `git diff --check`