### PR TITLE
Implement MiniMax chat completions adapter

### DIFF
--- a/packages/ai/minimax/src/index.test.ts
+++ b/packages/ai/minimax/src/index.test.ts
@@ -1,4 +1,95 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (
+  secrets: Record<string, string> = { MINIMAX_API_KEY: 'test-key' },
+  dryRun = false
+) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('MiniMax OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx({ MINIMAX_API_KEY: 'test-key' }, true),
+      'hello',
+      {},
+      {}
+    );
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'MiniMax-M2.7' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: '<think>brief</think>hi from minimax' } }],
+        model: 'MiniMax-M2.1',
+        usage: { prompt_tokens: 14, completion_tokens: 9 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx(),
+      'hello',
+      {
+        model: 'MiniMax-M2.1',
+        system: 'be practical',
+        maxTokens: 80,
+        temperature: 1,
+        extra: { reasoning_split: true },
+      },
+      {}
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.minimax.io/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'MiniMax-M2.1',
+      messages: [
+        { role: 'system', content: 'be practical' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 80,
+      temperature: 1,
+      reasoning_split: true,
+    });
+    expect(result).toEqual({
+      text: '<think>brief</think>hi from minimax',
+      model: 'MiniMax-M2.1',
+      inputTokens: 14,
+      outputTokens: 9,
+    });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: async () => 'bad request'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(
+      /MiniMax 400: bad request/
+    );
+  });
+});

--- a/packages/ai/minimax/src/index.ts
+++ b/packages/ai/minimax/src/index.ts
@@ -4,27 +4,86 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.minimax.io/v1';
+const DEFAULT_MODEL = 'MiniMax-M2.7';
+
 export default defineAi<Config>({
   id: 'ai-minimax',
   label: 'MiniMax',
-  defaultModel: 'abab6.5-chat',
-  models: ['abab6.5-chat'],
+  defaultModel: DEFAULT_MODEL,
+  models: [
+    DEFAULT_MODEL,
+    'MiniMax-M2.7-highspeed',
+    'MiniMax-M2.5',
+    'MiniMax-M2.1',
+    'MiniMax-M2',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('MINIMAX_API_KEY');
-    if (!apiKey) throw new Error('MINIMAX_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-minimax · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-minimax integration not yet implemented]', model: 'abab6.5-chat' };
+    if (!apiKey) throw new Error('MINIMAX_API_KEY not in vault');
+    const model = opts.model ?? DEFAULT_MODEL;
+    ctx.log(`minimax · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: MiniMaxMessage[] = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`MiniMax ${res.status}: ${(await res.text()).slice(0, 200)}`);
+
+    const data = await res.json() as MiniMaxChatResponse;
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'MINIMAX_API_KEY',
     label: 'MiniMax',
-    vendorDocUrl: 'https://www.minimaxi.com',
+    vendorDocUrl: 'https://platform.minimax.io/docs/api-reference/text-openai-api',
     steps: [
-      'Sign in at https://www.minimaxi.com and create an API key',
+      'Sign in at https://platform.minimax.io and create an API key',
       'Copy the key — usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],
   }),
 });
+
+type MiniMaxRole = 'system' | 'user' | 'assistant' | 'tool';
+
+interface MiniMaxMessage {
+  role: MiniMaxRole;
+  content: string;
+}
+
+interface MiniMaxChatResponse {
+  model: string;
+  choices: Array<{
+    message?: {
+      content?: string;
+      reasoning_details?: unknown;
+    };
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+  };
+}


### PR DESCRIPTION
## Summary
- replace the MiniMax stub with a real OpenAI-compatible chat completions adapter
- use the documented MiniMax OpenAI-compatible base URL and current M2 model IDs
- support dry-run behavior, standard generation options, `opts.extra` passthrough for MiniMax options such as `reasoning_split`, token usage mapping, and concise HTTP error excerpts
- add focused tests for dry-run behavior, request payload/auth, token usage mapping, and error handling

## References
- https://platform.minimax.io/docs/api-reference/text-openai-api
- https://platform.minimax.io/docs/api-reference/api-overview

## Validation
- `corepack pnpm exec vitest run packages/ai/minimax/src/index.test.ts`
- `corepack pnpm exec tsc -p packages/ai/minimax/tsconfig.json --noEmit`
- `git diff --check`