### PR TITLE
Implement Alibaba Cloud chat completions adapter

### DIFF
--- a/packages/ai/alibaba-cloud/src/index.test.ts
+++ b/packages/ai/alibaba-cloud/src/index.test.ts
@@ -1,4 +1,115 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (
+  secrets: Record<string, string> = { DASHSCOPE_API_KEY: 'test-key' },
+  dryRun = false
+) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Alibaba Cloud OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx({ DASHSCOPE_API_KEY: 'test-key' }, true),
+      'hello',
+      {},
+      {}
+    );
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'qwen-plus' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from qwen' } }],
+        model: 'qwen3.5-plus',
+        usage: { prompt_tokens: 16, completion_tokens: 8 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx(),
+      'hello',
+      {
+        model: 'qwen3.5-plus',
+        system: 'be practical',
+        maxTokens: 90,
+        temperature: 0.3,
+        extra: { enable_thinking: false },
+      },
+      {}
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'qwen3.5-plus',
+      messages: [
+        { role: 'system', content: 'be practical' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 90,
+      temperature: 0.3,
+      enable_thinking: false,
+    });
+    expect(result).toEqual({
+      text: 'hi from qwen',
+      model: 'qwen3.5-plus',
+      inputTokens: 16,
+      outputTokens: 8,
+    });
+  });
+
+  it('uses a configured region base URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'ok' } }],
+        model: 'qwen-flash',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.generate(ctx(), 'hello', { model: 'qwen-flash' }, {
+      baseUrl: 'https://dashscope-us.aliyuncs.com/compatible-mode/v1',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://dashscope-us.aliyuncs.com/compatible-mode/v1/chat/completions',
+      expect.any(Object)
+    );
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => 'unauthorized'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(
+      /Alibaba Cloud 401: unauthorized/
+    );
+  });
+});

--- a/packages/ai/alibaba-cloud/src/index.ts
+++ b/packages/ai/alibaba-cloud/src/index.ts
@@ -4,27 +4,88 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1';
+const DEFAULT_MODEL = 'qwen-plus';
+
 export default defineAi<Config>({
   id: 'ai-alibaba-cloud',
-  label: 'Alibaba Cloud Int.',
-  defaultModel: 'qwen-max',
-  models: ['qwen-max'],
+  label: 'Alibaba Cloud Model Studio',
+  defaultModel: DEFAULT_MODEL,
+  models: [
+    DEFAULT_MODEL,
+    'qwen3.5-plus',
+    'qwen3.5-flash',
+    'qwen3-max',
+    'qwen-flash',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('DASHSCOPE_API_KEY');
-    if (!apiKey) throw new Error('DASHSCOPE_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-alibaba-cloud · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-alibaba-cloud integration not yet implemented]', model: 'qwen-max' };
+    if (!apiKey) throw new Error('DASHSCOPE_API_KEY not in vault');
+    const model = opts.model ?? DEFAULT_MODEL;
+    ctx.log(`alibaba-cloud · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: AlibabaCloudMessage[] = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`Alibaba Cloud ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    }
+
+    const data = await res.json() as AlibabaCloudChatResponse;
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'DASHSCOPE_API_KEY',
-    label: 'Alibaba Cloud Int.',
-    vendorDocUrl: 'https://dashscope-intl.console.aliyun.com',
+    label: 'Alibaba Cloud Model Studio',
+    vendorDocUrl: 'https://www.alibabacloud.com/help/en/model-studio/first-api-call-to-qwen',
     steps: [
-      'Sign in at https://dashscope-intl.console.aliyun.com and create an API key',
-      'Copy the key — usually shown once',
+      'Sign in to Alibaba Cloud Model Studio and create a DashScope API key',
+      'Use the deployment region that matches your key; the default base URL uses Singapore',
+      'Copy the key - usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],
   }),
 });
+
+type AlibabaCloudRole = 'system' | 'user' | 'assistant' | 'tool';
+
+interface AlibabaCloudMessage {
+  role: AlibabaCloudRole;
+  content: string;
+}
+
+interface AlibabaCloudChatResponse {
+  model: string;
+  choices: Array<{
+    message?: {
+      content?: string;
+    };
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+  };
+}


### PR DESCRIPTION
## Summary
- replace the Alibaba Cloud stub with the documented DashScope OpenAI-compatible chat completions API
- default to the Singapore compatible-mode endpoint, while keeping `baseUrl` override support for US/China/EU regional keys
- add current Qwen model IDs, standard generation options, `opts.extra` passthrough, usage mapping, dry-run behavior, and HTTP error excerpts

Docs used:
- https://www.alibabacloud.com/help/en/model-studio/first-api-call-to-qwen
- https://www.alibabacloud.com/help/en/model-studio/models

## Validation
- `corepack pnpm exec vitest run packages/ai/alibaba-cloud/src/index.test.ts`
- `corepack pnpm exec tsc -p packages/ai/alibaba-cloud/tsconfig.json --noEmit`
- `git diff --check`