### PR TITLE
Implement Z.ai chat completions adapter

### DIFF
--- a/packages/ai/zai/src/index.test.ts
+++ b/packages/ai/zai/src/index.test.ts
@@ -1,4 +1,116 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (
+  secrets: Record<string, string> = { ZAI_API_KEY: 'test-key' },
+  dryRun = false
+) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Z.ai chat completions generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx({ ZAI_API_KEY: 'test-key' }, true),
+      'hello',
+      {},
+      {}
+    );
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'glm-5.1' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from glm' } }],
+        model: 'glm-4.7',
+        usage: { prompt_tokens: 12, completion_tokens: 7 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx(),
+      'hello',
+      {
+        model: 'glm-4.7',
+        system: 'be practical',
+        maxTokens: 120,
+        temperature: 0.8,
+        extra: { thinking: { type: 'disabled' } },
+      },
+      {}
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.z.ai/api/paas/v4/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'glm-4.7',
+      messages: [
+        { role: 'system', content: 'be practical' },
+        { role: 'user', content: 'hello' },
+      ],
+      stream: false,
+      max_tokens: 120,
+      temperature: 0.8,
+      thinking: { type: 'disabled' },
+    });
+    expect(result).toEqual({
+      text: 'hi from glm',
+      model: 'glm-4.7',
+      inputTokens: 12,
+      outputTokens: 7,
+    });
+  });
+
+  it('uses a configured base URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'ok' } }],
+        model: 'glm-4.5-air',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.generate(ctx(), 'hello', { model: 'glm-4.5-air' }, {
+      baseUrl: 'https://example.test/api/paas/v4',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.test/api/paas/v4/chat/completions',
+      expect.any(Object)
+    );
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => 'rate limited'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(
+      /Z.ai 429: rate limited/
+    );
+  });
+});

--- a/packages/ai/zai/src/index.ts
+++ b/packages/ai/zai/src/index.ts
@@ -4,27 +4,92 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.z.ai/api/paas/v4';
+const DEFAULT_MODEL = 'glm-5.1';
+
 export default defineAi<Config>({
   id: 'ai-zai',
   label: 'Z.ai',
-  defaultModel: 'glm-4.5',
-  models: ['glm-4.5'],
+  defaultModel: DEFAULT_MODEL,
+  models: [
+    DEFAULT_MODEL,
+    'glm-5-turbo',
+    'glm-5',
+    'glm-4.7',
+    'glm-4.7-flash',
+    'glm-4.6',
+    'glm-4.5',
+    'glm-4.5-air',
+    'glm-4.5-flash',
+    'glm-4-32b-0414-128k',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('ZAI_API_KEY');
-    if (!apiKey) throw new Error('ZAI_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-zai · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-zai integration not yet implemented]', model: 'glm-4.5' };
+    if (!apiKey) throw new Error('ZAI_API_KEY not in vault');
+    const model = opts.model ?? DEFAULT_MODEL;
+    ctx.log(`zai · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: ZaiMessage[] = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        stream: false,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Z.ai ${res.status}: ${(await res.text()).slice(0, 200)}`);
+
+    const data = await res.json() as ZaiChatResponse;
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'ZAI_API_KEY',
     label: 'Z.ai',
-    vendorDocUrl: 'https://z.ai',
+    vendorDocUrl: 'https://docs.z.ai/api-reference/llm/chat-completion',
     steps: [
       'Sign in at https://z.ai and create an API key',
-      'Copy the key — usually shown once',
+      'Copy the key - usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],
   }),
 });
+
+type ZaiRole = 'system' | 'user' | 'assistant' | 'tool';
+
+interface ZaiMessage {
+  role: ZaiRole;
+  content: string;
+}
+
+interface ZaiChatResponse {
+  model: string;
+  choices: Array<{
+    message?: {
+      content?: string;
+      reasoning_content?: string;
+    };
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+  };
+}


### PR DESCRIPTION
## Summary
- replace the Z.ai stub with the documented `/api/paas/v4/chat/completions` integration
- update defaults to current GLM-5.1-era model IDs while preserving GLM-4.5 family options
- add dry-run behavior, standard generation options, `opts.extra` passthrough for Z.ai fields such as `thinking`, usage mapping, and concise HTTP error handling

Docs used:
- https://docs.z.ai/api-reference/llm/chat-completion
- https://docs.z.ai/guides/llm/glm-4.5

## Validation
- `corepack pnpm exec vitest run packages/ai/zai/src/index.test.ts`
- `corepack pnpm exec tsc -p packages/ai/zai/tsconfig.json --noEmit`
- `git diff --check`