### PR TITLE
Implement StepFun chat completions adapter

### DIFF
--- a/packages/ai/stepfun/src/index.test.ts
+++ b/packages/ai/stepfun/src/index.test.ts
@@ -1,4 +1,115 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (
+  secrets: Record<string, string> = { STEPFUN_API_KEY: 'test-key' },
+  dryRun = false
+) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('StepFun OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx({ STEPFUN_API_KEY: 'test-key' }, true),
+      'hello',
+      {},
+      {}
+    );
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'step-3.5-flash' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from stepfun' } }],
+        model: 'step-3.5-flash-2603',
+        usage: { prompt_tokens: 18, completion_tokens: 10 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx(),
+      'hello',
+      {
+        model: 'step-3.5-flash-2603',
+        system: 'be practical',
+        maxTokens: 100,
+        temperature: 0.5,
+        extra: { reasoning_format: { type: 'deepseek-style' } },
+      },
+      {}
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.stepfun.ai/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'step-3.5-flash-2603',
+      messages: [
+        { role: 'system', content: 'be practical' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 100,
+      temperature: 0.5,
+      reasoning_format: { type: 'deepseek-style' },
+    });
+    expect(result).toEqual({
+      text: 'hi from stepfun',
+      model: 'step-3.5-flash-2603',
+      inputTokens: 18,
+      outputTokens: 10,
+    });
+  });
+
+  it('uses a configured Step Plan base URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'ok' } }],
+        model: 'step-3.5-flash',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.generate(ctx(), 'hello', {}, {
+      baseUrl: 'https://api.stepfun.ai/step_plan/v1',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.stepfun.ai/step_plan/v1/chat/completions',
+      expect.any(Object)
+    );
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: async () => 'forbidden'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(
+      /StepFun 403: forbidden/
+    );
+  });
+});

--- a/packages/ai/stepfun/src/index.ts
+++ b/packages/ai/stepfun/src/index.ts
@@ -4,27 +4,90 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.stepfun.ai/v1';
+const DEFAULT_MODEL = 'step-3.5-flash';
+
 export default defineAi<Config>({
   id: 'ai-stepfun',
   label: 'StepFun',
-  defaultModel: 'step-2-16k',
-  models: ['step-2-16k'],
+  defaultModel: DEFAULT_MODEL,
+  models: [
+    DEFAULT_MODEL,
+    'step-3.5-flash-2603',
+    'step-3',
+    'step-2-mini',
+    'step-2-16k',
+    'step-2-16k-exp',
+    'step-1-8k',
+    'step-1-32k',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('STEPFUN_API_KEY');
-    if (!apiKey) throw new Error('STEPFUN_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-stepfun · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-stepfun integration not yet implemented]', model: 'step-2-16k' };
+    if (!apiKey) throw new Error('STEPFUN_API_KEY not in vault');
+    const model = opts.model ?? DEFAULT_MODEL;
+    ctx.log(`stepfun · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: StepFunMessage[] = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`StepFun ${res.status}: ${(await res.text()).slice(0, 200)}`);
+
+    const data = await res.json() as StepFunChatResponse;
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'STEPFUN_API_KEY',
     label: 'StepFun',
-    vendorDocUrl: 'https://platform.stepfun.com',
+    vendorDocUrl: 'https://platform.stepfun.ai/docs/en/api-reference/chat/chat-completion-create',
     steps: [
-      'Sign in at https://platform.stepfun.com and create an API key',
-      'Copy the key — usually shown once',
+      'Sign in at https://platform.stepfun.ai and create an API key',
+      'Copy the key - usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],
   }),
 });
+
+type StepFunRole = 'system' | 'user' | 'assistant' | 'tool';
+
+interface StepFunMessage {
+  role: StepFunRole;
+  content: string;
+}
+
+interface StepFunChatResponse {
+  model: string;
+  choices: Array<{
+    message?: {
+      content?: string;
+      reasoning?: string;
+      reasoning_content?: string;
+    };
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+  };
+}


### PR DESCRIPTION
## Summary
- replace the StepFun stub with the documented OpenAI-compatible chat completions API
- update defaults to the current recommended `step-3.5-flash` model family and keep older text models available
- add dry-run behavior, standard generation options, `opts.extra` passthrough for StepFun fields such as `reasoning_format`, usage mapping, and concise HTTP error handling

Docs used:
- https://platform.stepfun.ai/docs/en/api-reference/chat/chat-completion-create
- https://platform.stepfun.ai/docs/en/guides/models/overview
- https://platform.stepfun.ai/docs/en/guides/developer/openai

## Validation
- `corepack pnpm exec vitest run packages/ai/stepfun/src/index.test.ts`
- `corepack pnpm exec tsc -p packages/ai/stepfun/tsconfig.json --noEmit`
- `git diff --check`