### PR TITLE
Implement Baseten chat completions adapter

### DIFF
--- a/packages/ai/baseten/src/index.test.ts
+++ b/packages/ai/baseten/src/index.test.ts
@@ -1,4 +1,115 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (
+  secrets: Record<string, string> = { BASETEN_API_KEY: 'test-key' },
+  dryRun = false
+) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Baseten chat completions generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx({ BASETEN_API_KEY: 'test-key' }, true),
+      'hello',
+      {},
+      {}
+    );
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'deepseek-ai/DeepSeek-V3.1' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests with Api-Key auth and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from baseten' } }],
+        model: 'deepseek-ai/DeepSeek-V3-0324',
+        usage: { prompt_tokens: 20, completion_tokens: 11 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx(),
+      'hello',
+      {
+        model: 'deepseek-ai/DeepSeek-V3-0324',
+        system: 'be practical',
+        maxTokens: 100,
+        temperature: 0.2,
+        extra: { top_p: 0.9 },
+      },
+      {}
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://inference.baseten.co/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Api-Key test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'deepseek-ai/DeepSeek-V3-0324',
+      messages: [
+        { role: 'system', content: 'be practical' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 100,
+      temperature: 0.2,
+      top_p: 0.9,
+    });
+    expect(result).toEqual({
+      text: 'hi from baseten',
+      model: 'deepseek-ai/DeepSeek-V3-0324',
+      inputTokens: 20,
+      outputTokens: 11,
+    });
+  });
+
+  it('uses a configured self-deployed model base URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'ok' } }],
+        model: 'custom-model',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.generate(ctx(), 'hello', { model: 'custom-model' }, {
+      baseUrl: 'https://model-abc123.api.baseten.co/v1',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://model-abc123.api.baseten.co/v1/chat/completions',
+      expect.any(Object)
+    );
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => 'unauthorized'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(
+      /Baseten 401: unauthorized/
+    );
+  });
+});

--- a/packages/ai/baseten/src/index.ts
+++ b/packages/ai/baseten/src/index.ts
@@ -4,27 +4,83 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://inference.baseten.co/v1';
+const DEFAULT_MODEL = 'deepseek-ai/DeepSeek-V3.1';
+
 export default defineAi<Config>({
   id: 'ai-baseten',
   label: 'Baseten',
-  defaultModel: 'BASETEN_API_KEY',
-  models: ['BASETEN_API_KEY'],
+  defaultModel: DEFAULT_MODEL,
+  models: [
+    DEFAULT_MODEL,
+    'deepseek-ai/DeepSeek-V3-0324',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
-    const apiKey = ctx.secret('https://www.baseten.co');
-    if (!apiKey) throw new Error('https://www.baseten.co not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-baseten · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-baseten integration not yet implemented]', model: 'BASETEN_API_KEY' };
+  async generate(ctx, prompt, opts, config) {
+    const apiKey = ctx.secret('BASETEN_API_KEY');
+    if (!apiKey) throw new Error('BASETEN_API_KEY not in vault');
+    const model = opts.model ?? DEFAULT_MODEL;
+    ctx.log(`baseten · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: BasetenMessage[] = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Api-Key ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Baseten ${res.status}: ${(await res.text()).slice(0, 200)}`);
+
+    const data = await res.json() as BasetenChatResponse;
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
-    secretKey: 'https://www.baseten.co',
+    secretKey: 'BASETEN_API_KEY',
     label: 'Baseten',
-    vendorDocUrl: '',
+    vendorDocUrl: 'https://docs.baseten.co/reference/inference-api/chat-completions',
     steps: [
-      'Sign in at  and create an API key',
-      'Copy the key — usually shown once',
+      'Sign in at https://www.baseten.co and create an API key',
+      'Enable the Model API or configure a deployed model endpoint if needed',
+      'Copy the key - usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],
   }),
 });
+
+type BasetenRole = 'system' | 'user' | 'assistant' | 'tool';
+
+interface BasetenMessage {
+  role: BasetenRole;
+  content: string;
+}
+
+interface BasetenChatResponse {
+  model: string;
+  choices: Array<{
+    message?: {
+      content?: string;
+    };
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+  };
+}


### PR DESCRIPTION
## Summary
- replace the Baseten stub with its documented OpenAI-compatible chat completions endpoint
- fix the secret key to `BASETEN_API_KEY` and use Baseten's required `Authorization: Api-Key ...` scheme
- add model API defaults, self-deployed `baseUrl` override support, standard generation options, `opts.extra` passthrough, usage mapping, dry-run behavior, and concise HTTP error handling

Docs used:
- https://docs.baseten.co/reference/inference-api/chat-completions
- https://docs.baseten.co/inference/model-apis/overview

## Validation
- `corepack pnpm exec vitest run packages/ai/baseten/src/index.test.ts`
- `corepack pnpm exec tsc -p packages/ai/baseten/tsconfig.json --noEmit`
- `git diff --check`