### PR TITLE
Implement Friendli AI adapter

### DIFF
--- a/packages/ai/friendli/src/index.ts
+++ b/packages/ai/friendli/src/index.ts
@@ -4,25 +4,59 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.friendli.ai/serverless';
+
 export default defineAi<Config>({
   id: 'ai-friendli',
   label: 'Friendli',
-  defaultModel: 'FRIENDLI_TOKEN',
-  models: ['FRIENDLI_TOKEN'],
+  defaultModel: 'meta-llama/Llama-3.1-8B-Instruct',
+  models: ['meta-llama/Llama-3.1-8B-Instruct'],
 
-  async generate(ctx, prompt, _opts, _config) {
-    const apiKey = ctx.secret('https://friendli.ai');
-    if (!apiKey) throw new Error('https://friendli.ai not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-friendli · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-friendli integration not yet implemented]', model: 'FRIENDLI_TOKEN' };
+  async generate(ctx, prompt, opts, config) {
+    const apiKey = ctx.secret('FRIENDLI_TOKEN');
+    if (!apiKey) throw new Error('FRIENDLI_TOKEN not in vault');
+    const model = opts.model ?? 'meta-llama/Llama-3.1-8B-Instruct';
+    ctx.log(`friendli · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Friendli ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
-    secretKey: 'https://friendli.ai',
+    secretKey: 'FRIENDLI_TOKEN',
     label: 'Friendli',
-    vendorDocUrl: '',
+    vendorDocUrl: 'https://friendli.ai/docs/openapi/model-apis/chat-completions',
     steps: [
-      'Sign in at  and create an API key',
+      'Sign in to Friendli Suite and create a personal API token',
       'Copy the key — usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],


### PR DESCRIPTION
## Summary
- replace the Friendli stub with a Serverless OpenAI-compatible chat completions integration
- use FRIENDLI_TOKEN and the documented serverless chat completions endpoint
- support model overrides, system prompts, max tokens, temperature, extra request fields, dry-run behavior, and usage token mapping

## Verification
- pnpm --filter @profullstack/sh1pt-ai-friendli typecheck
- tsx dry-run smoke check for missing-key and dry-run paths

Note: local vitest startup is blocked by a macOS Rollup native package signature loading error before tests execute.