### PR TITLE
Implement Morph AI adapter

### DIFF
--- a/packages/ai/morph/src/index.ts
+++ b/packages/ai/morph/src/index.ts
@@ -4,25 +4,59 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.morphllm.com';
+
 export default defineAi<Config>({
   id: 'ai-morph',
   label: 'Morph',
   defaultModel: 'morph-v2',
   models: ['morph-v2'],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('MORPH_API_KEY');
-    if (!apiKey) throw new Error('MORPH_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-morph · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-morph integration not yet implemented]', model: 'morph-v2' };
+    if (!apiKey) throw new Error('MORPH_API_KEY not in vault');
+    const model = opts.model ?? 'morph-v2';
+    ctx.log(`morph · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Morph ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'MORPH_API_KEY',
     label: 'Morph',
-    vendorDocUrl: 'https://morphllm.com',
+    vendorDocUrl: 'https://docs.morphllm.com/auth',
     steps: [
-      'Sign in at https://morphllm.com and create an API key',
+      'Sign in to the Morph dashboard and create an API key',
       'Copy the key — usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],


### PR DESCRIPTION
## Summary
- replace the Morph stub with an OpenAI-compatible chat completions integration
- use the documented Morph API base URL and MORPH_API_KEY
- support model overrides, system prompts, max tokens, temperature, extra request fields, dry-run behavior, and usage token mapping

## Verification
- pnpm --filter @profullstack/sh1pt-ai-morph typecheck
- tsx dry-run smoke check for missing-key and dry-run paths

Note: local vitest startup is blocked by a macOS Rollup native package signature loading error before tests execute.