### PR TITLE
Implement AtlasCloud AI adapter

### DIFF
--- a/packages/ai/atlascloud/src/index.ts
+++ b/packages/ai/atlascloud/src/index.ts
@@ -4,25 +4,59 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.atlascloud.ai';
+
 export default defineAi<Config>({
   id: 'ai-atlascloud',
   label: 'AtlasCloud',
-  defaultModel: 'ATLASCLOUD_API_KEY',
-  models: ['ATLASCLOUD_API_KEY'],
+  defaultModel: 'deepseek-v3',
+  models: ['deepseek-v3'],
 
-  async generate(ctx, prompt, _opts, _config) {
-    const apiKey = ctx.secret('https://atlascloud.ai');
-    if (!apiKey) throw new Error('https://atlascloud.ai not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-atlascloud · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-atlascloud integration not yet implemented]', model: 'ATLASCLOUD_API_KEY' };
+  async generate(ctx, prompt, opts, config) {
+    const apiKey = ctx.secret('ATLASCLOUD_API_KEY');
+    if (!apiKey) throw new Error('ATLASCLOUD_API_KEY not in vault');
+    const model = opts.model ?? 'deepseek-v3';
+    ctx.log(`atlascloud · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`AtlasCloud ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
-    secretKey: 'https://atlascloud.ai',
+    secretKey: 'ATLASCLOUD_API_KEY',
     label: 'AtlasCloud',
-    vendorDocUrl: '',
+    vendorDocUrl: 'https://www.atlascloud.ai/docs/en/models/llm',
     steps: [
-      'Sign in at  and create an API key',
+      'Sign in at https://www.atlascloud.ai and create an API key',
       'Copy the key — usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],


### PR DESCRIPTION
## Summary
- replace the AtlasCloud stub with an OpenAI-compatible chat completions integration
- use ATLASCLOUD_API_KEY and the documented AtlasCloud LLM base URL
- support model overrides, system prompts, max tokens, temperature, extra request fields, dry-run behavior, and usage token mapping

## Verification
- pnpm --filter @profullstack/sh1pt-ai-atlascloud typecheck
- tsx dry-run smoke check for missing-key and dry-run paths

Note: local vitest startup is blocked by a macOS Rollup native package signature loading error before tests execute.