### PR TITLE
Implement GMICloud AI adapter

### DIFF
--- a/packages/ai/gmicloud/src/index.ts
+++ b/packages/ai/gmicloud/src/index.ts
@@ -4,25 +4,59 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.gmi-serving.com';
+
 export default defineAi<Config>({
   id: 'ai-gmicloud',
   label: 'GMICloud',
-  defaultModel: 'GMICLOUD_API_KEY',
-  models: ['GMICLOUD_API_KEY'],
+  defaultModel: 'deepseek-ai/DeepSeek-R1',
+  models: ['deepseek-ai/DeepSeek-R1'],
 
-  async generate(ctx, prompt, _opts, _config) {
-    const apiKey = ctx.secret('https://gmicloud.ai');
-    if (!apiKey) throw new Error('https://gmicloud.ai not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-gmicloud · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-gmicloud integration not yet implemented]', model: 'GMICLOUD_API_KEY' };
+  async generate(ctx, prompt, opts, config) {
+    const apiKey = ctx.secret('GMI_API_KEY');
+    if (!apiKey) throw new Error('GMI_API_KEY not in vault');
+    const model = opts.model ?? 'deepseek-ai/DeepSeek-R1';
+    ctx.log(`gmicloud · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`GMICloud ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
-    secretKey: 'https://gmicloud.ai',
+    secretKey: 'GMI_API_KEY',
     label: 'GMICloud',
-    vendorDocUrl: '',
+    vendorDocUrl: 'https://docs.gmicloud.ai/inference-engine/api-reference',
     steps: [
-      'Sign in at  and create an API key',
+      'Sign in at https://www.gmicloud.ai and create an API key',
       'Copy the key — usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],


### PR DESCRIPTION
## Summary
- replace the GMICloud stub with an OpenAI-compatible chat completions integration
- use GMI_API_KEY and the documented GMI serving API base URL
- support model overrides, system prompts, max tokens, temperature, extra request fields, dry-run behavior, and usage token mapping

## Verification
- pnpm --filter @profullstack/sh1pt-ai-gmicloud typecheck
- tsx dry-run smoke check for missing-key and dry-run paths

Note: local vitest startup is blocked by a macOS Rollup native package signature loading error before tests execute.