### PR TITLE
Implement Parasail chat completions adapter

### DIFF
--- a/packages/ai/parasail/src/index.test.ts
+++ b/packages/ai/parasail/src/index.test.ts
@@ -1,4 +1,115 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (
+  secrets: Record<string, string> = { PARASAIL_API_KEY: 'test-key' },
+  dryRun = false
+) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Parasail chat completions generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx({ PARASAIL_API_KEY: 'test-key' }, true),
+      'hello',
+      {},
+      {}
+    );
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'parasail-llama-33-70b-fp8' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from parasail' } }],
+        model: 'parasail-qwen3-32b',
+        usage: { prompt_tokens: 18, completion_tokens: 7 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx(),
+      'hello',
+      {
+        model: 'parasail-qwen3-32b',
+        system: 'be concise',
+        maxTokens: 64,
+        temperature: 0.2,
+        extra: { top_p: 0.9 },
+      },
+      {}
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.parasail.io/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'parasail-qwen3-32b',
+      messages: [
+        { role: 'system', content: 'be concise' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 64,
+      temperature: 0.2,
+      top_p: 0.9,
+    });
+    expect(result).toEqual({
+      text: 'hi from parasail',
+      model: 'parasail-qwen3-32b',
+      inputTokens: 18,
+      outputTokens: 7,
+    });
+  });
+
+  it('uses a configured base URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'ok' } }],
+        model: 'custom-model',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.generate(ctx(), 'hello', { model: 'custom-model' }, {
+      baseUrl: 'https://custom.parasail.example/v1',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://custom.parasail.example/v1/chat/completions',
+      expect.any(Object)
+    );
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => 'rate limited'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(
+      /Parasail 429: rate limited/
+    );
+  });
+});

--- a/packages/ai/parasail/src/index.ts
+++ b/packages/ai/parasail/src/index.ts
@@ -4,25 +4,65 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.parasail.io/v1';
+
 export default defineAi<Config>({
   id: 'ai-parasail',
   label: 'Parasail',
-  defaultModel: 'PARASAIL_API_KEY',
-  models: ['PARASAIL_API_KEY'],
+  defaultModel: 'parasail-llama-33-70b-fp8',
+  models: [
+    'parasail-llama-33-70b-fp8',
+    'parasail-llama-4-scout-instruct',
+    'parasail-llama-4-maverick-instruct-fp8',
+    'parasail-qwen3-32b',
+    'parasail-mistral-devstral-small',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
-    const apiKey = ctx.secret('https://parasail.io');
-    if (!apiKey) throw new Error('https://parasail.io not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-parasail · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-parasail integration not yet implemented]', model: 'PARASAIL_API_KEY' };
+  async generate(ctx, prompt, opts, config) {
+    const apiKey = ctx.secret('PARASAIL_API_KEY');
+    if (!apiKey) throw new Error('PARASAIL_API_KEY not in vault — run `sh1pt promote ai setup`');
+    const model = opts.model ?? 'parasail-llama-33-70b-fp8';
+    ctx.log(`parasail · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Parasail ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
-    secretKey: 'https://parasail.io',
+    secretKey: 'PARASAIL_API_KEY',
     label: 'Parasail',
-    vendorDocUrl: '',
+    vendorDocUrl: 'https://docs.parasail.io/parasail-docs/cookbooks/chat-completions',
     steps: [
-      'Sign in at  and create an API key',
+      'Sign in at https://parasail.io and create an API key',
       'Copy the key — usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],


### PR DESCRIPTION
## Summary
- Replace the Parasail BYOK stub with a real OpenAI-compatible chat completions adapter
- Use PARASAIL_API_KEY, current Parasail model IDs, dry-run short-circuiting, usage token mapping, and response body excerpts on HTTP errors
- Add focused tests for dry-run, request payloads, base URL override, token mapping, and errors

## Validation
- corepack pnpm exec vitest run packages/ai/parasail/src/index.test.ts
- corepack pnpm exec tsc -p packages/ai/parasail/tsconfig.json --noEmit
- git diff --check