### PR TITLE
Implement Inception chat completions adapter

### DIFF
--- a/packages/ai/inception/src/index.test.ts
+++ b/packages/ai/inception/src/index.test.ts
@@ -1,4 +1,114 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (
+  secrets: Record<string, string> = { INCEPTION_API_KEY: 'test-key' },
+  dryRun = false
+) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Inception chat completions generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx({ INCEPTION_API_KEY: 'test-key' }, true),
+      'hello',
+      {},
+      {}
+    );
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'mercury-2' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from inception' } }],
+        model: 'mercury-2',
+        usage: { prompt_tokens: 14, completion_tokens: 6 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx(),
+      'hello',
+      {
+        system: 'be direct',
+        maxTokens: 100,
+        temperature: 0.3,
+        extra: { reasoning_effort: 'low' },
+      },
+      {}
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.inceptionlabs.ai/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'mercury-2',
+      messages: [
+        { role: 'system', content: 'be direct' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 100,
+      temperature: 0.3,
+      reasoning_effort: 'low',
+    });
+    expect(result).toEqual({
+      text: 'hi from inception',
+      model: 'mercury-2',
+      inputTokens: 14,
+      outputTokens: 6,
+    });
+  });
+
+  it('uses a configured base URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'ok' } }],
+        model: 'mercury-2',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.generate(ctx(), 'hello', {}, {
+      baseUrl: 'https://inception.example/v1',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://inception.example/v1/chat/completions',
+      expect.any(Object)
+    );
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => 'unauthorized'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(
+      /Inception 401: unauthorized/
+    );
+  });
+});

--- a/packages/ai/inception/src/index.ts
+++ b/packages/ai/inception/src/index.ts
@@ -4,25 +4,59 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.inceptionlabs.ai/v1';
+
 export default defineAi<Config>({
   id: 'ai-inception',
   label: 'Inception',
-  defaultModel: 'mercury',
-  models: ['mercury'],
+  defaultModel: 'mercury-2',
+  models: ['mercury-2'],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('INCEPTION_API_KEY');
     if (!apiKey) throw new Error('INCEPTION_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-inception · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-inception integration not yet implemented]', model: 'mercury' };
+    const model = opts.model ?? 'mercury-2';
+    ctx.log(`inception · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Inception ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'INCEPTION_API_KEY',
     label: 'Inception',
-    vendorDocUrl: 'https://www.inceptionlabs.ai',
+    vendorDocUrl: 'https://docs.inceptionlabs.ai/capabilities/chat-completions',
     steps: [
-      'Sign in at https://www.inceptionlabs.ai and create an API key',
+      'Sign in at https://platform.inceptionlabs.ai and create an API key',
       'Copy the key — usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],


### PR DESCRIPTION
## Summary
- Replace the Inception BYOK stub with a real Mercury 2 chat completions adapter
- Use INCEPTION_API_KEY, the documented Inception v1 chat endpoint, dry-run short-circuiting, usage token mapping, and response body excerpts on HTTP errors
- Add focused tests for dry-run, request payloads, base URL override, token mapping, and errors

## Validation
- corepack pnpm exec vitest run packages/ai/inception/src/index.test.ts
- corepack pnpm exec tsc -p packages/ai/inception/tsconfig.json --noEmit
- git diff --check