### PR TITLE
Implement Phala confidential AI chat adapter

### DIFF
--- a/packages/ai/phala/src/index.test.ts
+++ b/packages/ai/phala/src/index.test.ts
@@ -1,4 +1,115 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (
+  secrets: Record<string, string> = { PHALA_API_KEY: 'test-key' },
+  dryRun = false
+) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Phala confidential AI chat completions generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx({ PHALA_API_KEY: 'test-key' }, true),
+      'hello',
+      {},
+      {}
+    );
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'phala/deepseek-chat-v3-0324' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from phala' } }],
+        model: 'openai/gpt-oss-120b',
+        usage: { prompt_tokens: 22, completion_tokens: 9 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx(),
+      'hello',
+      {
+        model: 'openai/gpt-oss-120b',
+        system: 'be private',
+        maxTokens: 80,
+        temperature: 0.1,
+        extra: { top_p: 0.95 },
+      },
+      {}
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.redpill.ai/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'openai/gpt-oss-120b',
+      messages: [
+        { role: 'system', content: 'be private' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 80,
+      temperature: 0.1,
+      top_p: 0.95,
+    });
+    expect(result).toEqual({
+      text: 'hi from phala',
+      model: 'openai/gpt-oss-120b',
+      inputTokens: 22,
+      outputTokens: 9,
+    });
+  });
+
+  it('uses a configured base URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'ok' } }],
+        model: 'custom-confidential-model',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.generate(ctx(), 'hello', { model: 'custom-confidential-model' }, {
+      baseUrl: 'https://confidential.example/v1',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://confidential.example/v1/chat/completions',
+      expect.any(Object)
+    );
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 402,
+      text: async () => 'insufficient funds'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(
+      /Phala 402: insufficient funds/
+    );
+  });
+});

--- a/packages/ai/phala/src/index.ts
+++ b/packages/ai/phala/src/index.ts
@@ -4,25 +4,65 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.redpill.ai/v1';
+
 export default defineAi<Config>({
   id: 'ai-phala',
   label: 'Phala',
-  defaultModel: 'PHALA_API_KEY',
-  models: ['PHALA_API_KEY'],
+  defaultModel: 'phala/deepseek-chat-v3-0324',
+  models: [
+    'phala/deepseek-chat-v3-0324',
+    'qwen/qwen2.5-vl-72b-instruct',
+    'google/gemma-3-27b-it',
+    'openai/gpt-oss-120b',
+    'meta-llama/llama-3.3-70b-instruct',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
-    const apiKey = ctx.secret('https://phala.network');
-    if (!apiKey) throw new Error('https://phala.network not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-phala · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-phala integration not yet implemented]', model: 'PHALA_API_KEY' };
+  async generate(ctx, prompt, opts, config) {
+    const apiKey = ctx.secret('PHALA_API_KEY');
+    if (!apiKey) throw new Error('PHALA_API_KEY not in vault — run `sh1pt promote ai setup`');
+    const model = opts.model ?? 'phala/deepseek-chat-v3-0324';
+    ctx.log(`phala · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Phala ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
-    secretKey: 'https://phala.network',
+    secretKey: 'PHALA_API_KEY',
     label: 'Phala',
-    vendorDocUrl: '',
+    vendorDocUrl: 'https://docs.phala.com/phala-cloud/confidential-ai/confidential-model/confidential-ai-api',
     steps: [
-      'Sign in at  and create an API key',
+      'Sign in to Phala Cloud, enable Confidential AI API, and create an API key',
       'Copy the key — usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],


### PR DESCRIPTION
## Summary
- Replace the Phala BYOK stub with a real OpenAI-compatible Confidential AI chat completions adapter
- Use PHALA_API_KEY, the documented RedPill/Phala v1 chat endpoint, current Confidential AI model IDs, dry-run short-circuiting, usage token mapping, and response body excerpts on HTTP errors
- Add focused tests for dry-run, request payloads, base URL override, token mapping, and errors

## Validation
- corepack pnpm exec vitest run packages/ai/phala/src/index.test.ts
- corepack pnpm exec tsc -p packages/ai/phala/tsconfig.json --noEmit
- git diff --check