### PR TITLE
Implement Cloudflare Workers AI adapter

### DIFF
--- a/packages/ai/cloudflare/src/index.test.ts
+++ b/packages/ai/cloudflare/src/index.test.ts
@@ -1,4 +1,142 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (
+  secrets: Record<string, string> = { CLOUDFLARE_API_TOKEN: 'test-token' },
+  dryRun = false
+) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Cloudflare Workers AI generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx({ CLOUDFLARE_API_TOKEN: 'test-token' }, true),
+      'hello',
+      {},
+      {}
+    );
+
+    expect(result).toEqual({
+      text: '[dry-run]',
+      model: '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts Workers AI run requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        result: {
+          response: 'hi from cloudflare',
+          usage: { prompt_tokens: 25, completion_tokens: 8 },
+        },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx(),
+      'hello',
+      {
+        model: '@cf/meta/llama-3.1-8b-instruct',
+        system: 'be brief',
+        maxTokens: 50,
+        temperature: 0.4,
+        extra: { top_p: 0.8 },
+      },
+      { accountId: 'acct_123' }
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe(
+      'https://api.cloudflare.com/client/v4/accounts/acct_123/ai/run/@cf/meta/llama-3.1-8b-instruct'
+    );
+    expect(request.headers.authorization).toBe('Bearer test-token');
+    expect(JSON.parse(request.body)).toEqual({
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 50,
+      temperature: 0.4,
+      top_p: 0.8,
+    });
+    expect(result).toEqual({
+      text: 'hi from cloudflare',
+      model: '@cf/meta/llama-3.1-8b-instruct',
+      inputTokens: 25,
+      outputTokens: 8,
+    });
+  });
+
+  it('requires an account ID for live requests', async () => {
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(
+      /Cloudflare accountId config required/
+    );
+  });
+
+  it('uses a configured base URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        result: { response: 'ok' },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.generate(ctx(), 'hello', {}, {
+      accountId: 'acct_123',
+      baseUrl: 'https://cloudflare.example/client/v4/',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://cloudflare.example/client/v4/accounts/acct_123/ai/run/@cf/meta/llama-3.3-70b-instruct-fp8-fast',
+      expect.any(Object)
+    );
+  });
+
+  it('includes status and response body excerpt on HTTP errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: async () => 'forbidden'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, { accountId: 'acct_123' })).rejects.toThrow(
+      /Cloudflare Workers AI 403: forbidden/
+    );
+  });
+
+  it('surfaces Cloudflare API error messages from successful HTTP responses', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: false,
+        errors: [{ message: 'model not enabled' }],
+      }),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, { accountId: 'acct_123' })).rejects.toThrow(
+      /Cloudflare Workers AI: model not enabled/
+    );
+  });
+});

--- a/packages/ai/cloudflare/src/index.ts
+++ b/packages/ai/cloudflare/src/index.ts
@@ -1,30 +1,83 @@
 import { defineAi, tokenSetup } from '@profullstack/sh1pt-core';
 
 interface Config {
+  accountId?: string;
   baseUrl?: string;
 }
+
+const DEFAULT_BASE = 'https://api.cloudflare.com/client/v4';
 
 export default defineAi<Config>({
   id: 'ai-cloudflare',
   label: 'Cloudflare Workers AI',
-  defaultModel: '@cf/meta/llama-3.3-70b-instruct',
-  models: ['@cf/meta/llama-3.3-70b-instruct'],
+  defaultModel: '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
+  models: [
+    '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
+    '@cf/meta/llama-3.1-8b-instruct',
+    '@cf/qwen/qwen1.5-14b-chat-awq',
+    '@cf/mistral/mistral-7b-instruct-v0.2-lora',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('CLOUDFLARE_API_TOKEN');
     if (!apiKey) throw new Error('CLOUDFLARE_API_TOKEN not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-cloudflare · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-cloudflare integration not yet implemented]', model: '@cf/meta/llama-3.3-70b-instruct' };
+    const model = opts.model ?? '@cf/meta/llama-3.3-70b-instruct-fp8-fast';
+    ctx.log(`cloudflare · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+    if (!config.accountId) throw new Error('Cloudflare accountId config required');
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const apiBase = (config.baseUrl ?? DEFAULT_BASE).replace(/\/$/, '');
+    const res = await fetch(`${apiBase}/accounts/${config.accountId}/ai/run/${model}`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Cloudflare Workers AI ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      success?: boolean;
+      errors?: Array<{ message?: string }>;
+      result?: {
+        response?: string;
+        usage?: { prompt_tokens?: number; completion_tokens?: number };
+      };
+    };
+    if (data.success === false) {
+      const detail = data.errors?.map((error) => error.message).filter(Boolean).join('; ') || 'request failed';
+      throw new Error(`Cloudflare Workers AI: ${detail}`);
+    }
+    return {
+      text: data.result?.response ?? '',
+      model,
+      inputTokens: data.result?.usage?.prompt_tokens,
+      outputTokens: data.result?.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'CLOUDFLARE_API_TOKEN',
     label: 'Cloudflare Workers AI',
-    vendorDocUrl: 'https://dash.cloudflare.com',
+    vendorDocUrl: 'https://developers.cloudflare.com/workers-ai/get-started/rest-api/',
     steps: [
-      'Sign in at https://dash.cloudflare.com and create an API key',
-      'Copy the key — usually shown once',
-      'Paste below; sh1pt encrypts it in the vault',
+      'Open dash.cloudflare.com → Workers AI → Use REST API',
+      'Create a Workers AI API token and copy the token',
+      'Copy the account ID shown beside the REST API instructions',
+      'Paste below; sh1pt encrypts the token in the vault',
+    ],
+    fields: [
+      { key: 'accountId', message: 'Cloudflare account ID:', required: true },
+      { key: 'baseUrl', message: 'Cloudflare API base URL (optional):' },
     ],
   }),
 });


### PR DESCRIPTION
## Summary
- Replace the Cloudflare Workers AI BYOK stub with a real REST API adapter
- Add accountId setup config, current Workers AI model IDs, dry-run short-circuiting, message payload construction, usage mapping, and Cloudflare API error handling
- Add focused tests for dry-run, request payloads, account ID validation, base URL override, HTTP errors, and Cloudflare success:false errors

## Validation
- corepack pnpm exec vitest run packages/ai/cloudflare/src/index.test.ts
- corepack pnpm exec tsc -p packages/ai/cloudflare/tsconfig.json --noEmit
- git diff --check