### PR TITLE
Implement Azure OpenAI adapter

### DIFF
--- a/packages/ai/azure/src/index.test.ts
+++ b/packages/ai/azure/src/index.test.ts
@@ -1,4 +1,144 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (
+  secrets: Record<string, string> = { AZURE_OPENAI_API_KEY: 'test-key' },
+  dryRun = false
+) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Azure OpenAI chat completions generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx({ AZURE_OPENAI_API_KEY: 'test-key' }, true),
+      'hello',
+      {},
+      {}
+    );
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'gpt-4o' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts deployment chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from azure' } }],
+        model: 'gpt-4o',
+        usage: { prompt_tokens: 12, completion_tokens: 5 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx(),
+      'hello',
+      {
+        system: 'be useful',
+        maxTokens: 120,
+        temperature: 0.2,
+        extra: { top_p: 0.9 },
+      },
+      {
+        endpoint: 'https://example-resource.openai.azure.com',
+        deployment: 'gpt-4o-prod',
+        apiVersion: '2025-04-01-preview',
+      }
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe(
+      'https://example-resource.openai.azure.com/openai/deployments/gpt-4o-prod/chat/completions?api-version=2025-04-01-preview'
+    );
+    expect(request.headers['api-key']).toBe('test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      messages: [
+        { role: 'system', content: 'be useful' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 120,
+      temperature: 0.2,
+      top_p: 0.9,
+    });
+    expect(result).toEqual({
+      text: 'hi from azure',
+      model: 'gpt-4o',
+      inputTokens: 12,
+      outputTokens: 5,
+    });
+  });
+
+  it('uses the requested model as deployment when config does not override it', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'ok' } }],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', { model: 'gpt-4o-mini' }, {
+      endpoint: 'https://example-resource.openai.azure.com/',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example-resource.openai.azure.com/openai/deployments/gpt-4o-mini/chat/completions?api-version=2024-06-01',
+      expect.any(Object)
+    );
+    expect(result.model).toBe('gpt-4o-mini');
+  });
+
+  it('accepts baseUrl as an endpoint alias', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'ok' } }],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.generate(ctx(), 'hello', {}, {
+      baseUrl: 'https://example-resource.openai.azure.com',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example-resource.openai.azure.com/openai/deployments/gpt-4o/chat/completions?api-version=2024-06-01',
+      expect.any(Object)
+    );
+  });
+
+  it('requires an endpoint for live requests', async () => {
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(
+      /Azure OpenAI endpoint config required/
+    );
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: async () => 'deployment not found'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {
+      endpoint: 'https://example-resource.openai.azure.com',
+    })).rejects.toThrow(/Azure OpenAI 404: deployment not found/);
+  });
+});

--- a/packages/ai/azure/src/index.ts
+++ b/packages/ai/azure/src/index.ts
@@ -1,8 +1,13 @@
 import { defineAi, tokenSetup } from '@profullstack/sh1pt-core';
 
 interface Config {
+  endpoint?: string;
+  deployment?: string;
+  apiVersion?: string;
   baseUrl?: string;
 }
+
+const DEFAULT_API_VERSION = '2024-06-01';
 
 export default defineAi<Config>({
   id: 'ai-azure',
@@ -10,21 +15,65 @@ export default defineAi<Config>({
   defaultModel: 'gpt-4o',
   models: ['gpt-4o'],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('AZURE_OPENAI_API_KEY');
     if (!apiKey) throw new Error('AZURE_OPENAI_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-azure · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-azure integration not yet implemented]', model: 'gpt-4o' };
+    const model = opts.model ?? config.deployment ?? 'gpt-4o';
+    ctx.log(`azure · deployment=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const endpoint = (config.endpoint ?? config.baseUrl)?.replace(/\/$/, '');
+    if (!endpoint) throw new Error('Azure OpenAI endpoint config required');
+    const deployment = config.deployment ?? model;
+    const apiVersion = config.apiVersion ?? DEFAULT_API_VERSION;
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(
+      `${endpoint}/openai/deployments/${encodeURIComponent(deployment)}/chat/completions?api-version=${encodeURIComponent(apiVersion)}`,
+      {
+        method: 'POST',
+        headers: {
+          'api-key': apiKey,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          messages,
+          ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+          ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+          ...opts.extra,
+        }),
+      }
+    );
+    if (!res.ok) throw new Error(`Azure OpenAI ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model?: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model ?? deployment,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'AZURE_OPENAI_API_KEY',
     label: 'Azure OpenAI',
-    vendorDocUrl: 'https://portal.azure.com',
+    vendorDocUrl: 'https://learn.microsoft.com/en-us/azure/ai-services/openai/reference',
     steps: [
-      'Sign in at https://portal.azure.com and create an API key',
-      'Copy the key — usually shown once',
-      'Paste below; sh1pt encrypts it in the vault',
+      'Open the Azure OpenAI resource in portal.azure.com',
+      'Copy the resource endpoint and one API key',
+      'Use a deployed chat model name as the deployment',
+      'Paste below; sh1pt encrypts the API key in the vault',
+    ],
+    fields: [
+      { key: 'endpoint', message: 'Azure OpenAI endpoint, e.g. https://my-resource.openai.azure.com:', required: true },
+      { key: 'deployment', message: 'Azure OpenAI deployment name:' },
+      { key: 'apiVersion', message: 'API version (default 2024-06-01):' },
     ],
   }),
 });


### PR DESCRIPTION
## Summary
- Replace the Azure OpenAI BYOK stub with a real deployment chat completions adapter
- Add endpoint/deployment/api-version setup config, dry-run short-circuiting, message payload construction, usage token mapping, and Azure HTTP error excerpts
- Add focused tests for dry-run, deployment request payloads, model-as-deployment fallback, endpoint aliasing, missing config, and errors

## Validation
- corepack pnpm exec vitest run packages/ai/azure/src/index.test.ts
- corepack pnpm exec tsc -p packages/ai/azure/tsconfig.json --noEmit
- git diff --check