### PR TITLE
Implement Homebrew formula generation

### DIFF
--- a/packages/targets/pkg-homebrew/src/index.test.ts
+++ b/packages/targets/pkg-homebrew/src/index.test.ts
@@ -1,4 +1,76 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'pkg', requireKind: true });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Homebrew formula generation', () => {
+  it('writes a platform-aware formula for binary releases', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-homebrew-'));
+    tempDirs.push(outDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      version: '1.2.3',
+    }) as any, {
+      tap: 'acme/homebrew-tools',
+      formulaName: 'my-tool',
+      desc: 'Acme command-line tool',
+      homepage: 'https://example.com/my-tool',
+      license: 'MIT',
+      binaryName: 'my-tool',
+      binaries: [
+        {
+          platform: 'darwin-arm64',
+          url: 'https://downloads.example.com/my-tool-1.2.3-darwin-arm64.tar.gz',
+          sha256: 'a'.repeat(64),
+        },
+        {
+          platform: 'linux-x64',
+          url: 'https://downloads.example.com/my-tool-1.2.3-linux-x64.tar.gz',
+          sha256: 'b'.repeat(64),
+        },
+      ],
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'my-tool.rb'));
+    const formula = await readFile(result.artifact, 'utf-8');
+
+    expect(formula).toContain('class MyTool < Formula');
+    expect(formula).toContain('desc "Acme command-line tool"');
+    expect(formula).toContain('version "1.2.3"');
+    expect(formula).toContain('license "MIT"');
+    expect(formula).toContain('on_macos do');
+    expect(formula).toContain('if Hardware::CPU.arm?');
+    expect(formula).toContain('on_linux do');
+    expect(formula).toContain('if Hardware::CPU.intel?');
+    expect(formula).toContain('bin.install "my-tool"');
+    expect(formula).toContain('system "#{bin}/my-tool", "--version"');
+  });
+
+  it('keeps dry-run shipping side-effect free', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      tap: 'acme/homebrew-tools',
+      formulaName: 'my-tool',
+      binaries: [
+        {
+          platform: 'darwin-x64',
+          url: 'https://downloads.example.com/my-tool-1.2.3-darwin-x64.tar.gz',
+          sha256: 'c'.repeat(64),
+        },
+      ],
+    })).resolves.toEqual({ id: 'dry-run' });
+  });
+});

--- a/packages/targets/pkg-homebrew/src/index.ts
+++ b/packages/targets/pkg-homebrew/src/index.ts
@@ -1,9 +1,97 @@
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 interface Config {
   tap: string;               // e.g. "myorg/homebrew-tap"
   formulaName: string;       // e.g. "sh1pt"
   binaries: { url: string; sha256: string; platform: 'darwin-x64' | 'darwin-arm64' | 'linux-x64' | 'linux-arm64' }[];
+  desc?: string;
+  homepage?: string;
+  license?: string;
+  binaryName?: string;
+  testArgs?: string[];
+}
+
+type Binary = Config['binaries'][number];
+type Os = 'darwin' | 'linux';
+
+function rubyString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function formulaClassName(formulaName: string): string {
+  const parts = formulaName.split(/[^A-Za-z0-9]+/).filter(Boolean);
+  const name = parts
+    .map((part) => {
+      const normalized = part[0]!.toUpperCase() + part.slice(1);
+      return /^\d/.test(normalized) ? `V${normalized}` : normalized;
+    })
+    .join('');
+  return name || 'Sh1ptFormula';
+}
+
+function osFor(platform: Binary['platform']): Os {
+  return platform.startsWith('darwin') ? 'darwin' : 'linux';
+}
+
+function cpuPredicate(platform: Binary['platform']): string {
+  return platform.endsWith('arm64') ? 'arm?' : 'intel?';
+}
+
+function renderPlatformBlocks(binaries: Binary[]): string {
+  const blocks: string[] = [];
+
+  for (const os of ['darwin', 'linux'] as const) {
+    const osBinaries = binaries.filter((binary) => osFor(binary.platform) === os);
+    if (osBinaries.length === 0) continue;
+
+    blocks.push(`  on_${os === 'darwin' ? 'macos' : 'linux'} do`);
+    for (const binary of osBinaries) {
+      blocks.push(`    if Hardware::CPU.${cpuPredicate(binary.platform)}`);
+      blocks.push(`      url ${rubyString(binary.url)}`);
+      blocks.push(`      sha256 ${rubyString(binary.sha256)}`);
+      blocks.push('    end');
+    }
+    blocks.push('  end');
+    blocks.push('');
+  }
+
+  return blocks.join('\n').trimEnd();
+}
+
+function renderFormula(config: Config, version: string): string {
+  if (!config.binaries?.length) {
+    throw new Error('Homebrew formula requires at least one binary download');
+  }
+
+  const binaryName = config.binaryName ?? config.formulaName;
+  const testArgs = config.testArgs ?? ['--version'];
+  const lines = [
+    `class ${formulaClassName(config.formulaName)} < Formula`,
+    `  desc ${rubyString(config.desc ?? `${config.formulaName} command-line release`)}`,
+    `  homepage ${rubyString(config.homepage ?? `https://github.com/${config.tap}`)}`,
+    `  version ${rubyString(version)}`,
+  ];
+
+  if (config.license) {
+    lines.push(`  license ${rubyString(config.license)}`);
+  }
+
+  lines.push('');
+  lines.push(renderPlatformBlocks(config.binaries));
+  lines.push('');
+  lines.push('  def install');
+  lines.push(`    bin.install ${rubyString(binaryName)}`);
+  lines.push('  end');
+  lines.push('');
+  lines.push('  test do');
+  lines.push(`    system "#{bin}/${binaryName}", ${testArgs.map(rubyString).join(', ')}`);
+  lines.push('  end');
+  lines.push('end');
+  lines.push('');
+
+  return lines.join('\n');
 }
 
 export default defineTarget<Config>({
@@ -11,9 +99,12 @@ export default defineTarget<Config>({
   kind: 'package-manager',
   label: 'Homebrew',
   async build(ctx, config) {
+    const formula = renderFormula(config, ctx.version);
+    const formulaPath = join(ctx.outDir, `${config.formulaName}.rb`);
     ctx.log(`render Formula/${config.formulaName}.rb`);
-    // TODO: render ruby formula from template + ctx.version + config.binaries
-    return { artifact: `${ctx.outDir}/${config.formulaName}.rb` };
+    await mkdir(ctx.outDir, { recursive: true });
+    await writeFile(formulaPath, formula, 'utf-8');
+    return { artifact: formulaPath };
   },
   async ship(ctx, config) {
     ctx.log(`open PR against ${config.tap} bumping ${config.formulaName} → ${ctx.version}`);


### PR DESCRIPTION
## Summary
- Replace the Homebrew target placeholder build with real Formula Ruby generation
- Support macOS/Linux x64 and arm64 binary blocks, optional formula metadata, binary install name, and test arguments
- Add focused coverage for generated formula content and dry-run shipping

## Validation
- pnpm vitest run packages/targets/pkg-homebrew/src/index.test.ts
- pnpm --filter @profullstack/sh1pt-target-pkg-homebrew typecheck
- pnpm --filter @profullstack/sh1pt-target-pkg-homebrew build
- git diff --check