### PR TITLE
Generate snapcraft manifest

### DIFF
--- a/packages/targets/pkg-snap/src/index.test.ts
+++ b/packages/targets/pkg-snap/src/index.test.ts
@@ -1,4 +1,63 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'pkg', requireKind: true });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('snapcraft manifest generation', () => {
+  it('writes a snapcraft.yaml scaffold from release config', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-snap-'));
+    tempDirs.push(outDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      projectDir: '/repo/myapp',
+      version: '1.2.3',
+      channel: 'stable',
+    }) as any, {
+      snapName: 'myapp',
+      summary: 'My app CLI',
+      description: 'My app ships useful commands.\nPackaged through sh1pt.',
+      command: 'bin/myapp',
+      base: 'core24',
+      confinement: 'strict',
+      architectures: ['amd64', 'arm64'],
+      plugs: ['network', 'home'],
+      stagePackages: ['ca-certificates'],
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'snap', 'snapcraft.yaml'));
+    const manifest = await readFile(result.artifact, 'utf-8');
+
+    expect(manifest).toContain('name: "myapp"');
+    expect(manifest).toContain('base: "core24"');
+    expect(manifest).toContain('version: "1.2.3"');
+    expect(manifest).toContain('grade: "stable"');
+    expect(manifest).toContain('confinement: "strict"');
+    expect(manifest).toContain('build-on: "amd64"');
+    expect(manifest).toContain('build-for: "arm64"');
+    expect(manifest).toContain('command: "bin/myapp"');
+    expect(manifest).toContain('      - "network"');
+    expect(manifest).toContain('plugin: "dump"');
+    expect(manifest).toContain('source: "/repo/myapp"');
+    expect(manifest).toContain('      - "ca-certificates"');
+  });
+
+  it('keeps dry-run shipping side-effect free', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      snapName: 'myapp',
+    })).resolves.toEqual({ id: 'dry-run' });
+  });
+});

--- a/packages/targets/pkg-snap/src/index.ts
+++ b/packages/targets/pkg-snap/src/index.ts
@@ -1,4 +1,6 @@
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 interface Config {
   snapName: string;          // e.g. "myapp"
@@ -7,6 +9,74 @@ interface Config {
   base?: 'core22' | 'core24' | 'bare';
   architectures?: ('amd64' | 'arm64' | 'armhf' | 'i386' | 'riscv64' | 's390x')[];
   channel?: 'stable' | 'candidate' | 'beta' | 'edge';
+  summary?: string;
+  description?: string;
+  command?: string;
+  source?: string;
+  plugin?: 'dump' | 'npm' | 'make' | 'nil' | string;
+  plugs?: string[];
+  stagePackages?: string[];
+}
+
+function yamlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function renderList(values: string[], indent: string): string[] {
+  return values.map((value) => `${indent}- ${yamlString(value)}`);
+}
+
+function renderDescription(description: string): string[] {
+  return [
+    'description: |',
+    ...description.split('\n').map((line) => `  ${line}`),
+  ];
+}
+
+function renderSnapcraftYaml(ctx: { projectDir: string; version: string; channel: string }, config: Config): string {
+  const grade = config.grade ?? (ctx.channel === 'stable' ? 'stable' : 'devel');
+  const confinement = config.confinement ?? 'strict';
+  const base = config.base ?? 'core22';
+  const arches = config.architectures ?? ['amd64', 'arm64'];
+  const command = config.command ?? `bin/${config.snapName}`;
+  const source = config.source ?? ctx.projectDir;
+  const plugin = config.plugin ?? 'dump';
+  const description = config.description ?? `${config.snapName} packaged by sh1pt.`;
+  const lines = [
+    `name: ${yamlString(config.snapName)}`,
+    `base: ${yamlString(base)}`,
+    `version: ${yamlString(ctx.version)}`,
+    `summary: ${yamlString(config.summary ?? `${config.snapName} release`)}`,
+    ...renderDescription(description),
+    `grade: ${yamlString(grade)}`,
+    `confinement: ${yamlString(confinement)}`,
+    'architectures:',
+    ...arches.flatMap((arch) => [
+      `  - build-on: ${yamlString(arch)}`,
+      `    build-for: ${yamlString(arch)}`,
+    ]),
+    'apps:',
+    `  ${config.snapName}:`,
+    `    command: ${yamlString(command)}`,
+  ];
+
+  if (config.plugs?.length) {
+    lines.push('    plugs:');
+    lines.push(...renderList(config.plugs, '      '));
+  }
+
+  lines.push('parts:');
+  lines.push(`  ${config.snapName}:`);
+  lines.push(`    plugin: ${yamlString(plugin)}`);
+  lines.push(`    source: ${yamlString(source)}`);
+
+  if (config.stagePackages?.length) {
+    lines.push('    stage-packages:');
+    lines.push(...renderList(config.stagePackages, '      '));
+  }
+
+  lines.push('');
+  return lines.join('\n');
 }
 
 export default defineTarget<Config>({
@@ -18,11 +88,13 @@ export default defineTarget<Config>({
     const confinement = config.confinement ?? 'strict';
     const base = config.base ?? 'core22';
     const arches = config.architectures ?? ['amd64', 'arm64'];
+    const manifestPath = join(ctx.outDir, 'snap', 'snapcraft.yaml');
     ctx.log(`render snapcraft.yaml for ${config.snapName} v${ctx.version} (${grade}/${confinement})`);
     ctx.log(`architectures: ${arches.join(', ')} | base: ${base}`);
-    // TODO: render snapcraft.yaml from template using ctx.projectDir metadata
+    await mkdir(join(ctx.outDir, 'snap'), { recursive: true });
+    await writeFile(manifestPath, renderSnapcraftYaml(ctx, config), 'utf-8');
     // TODO: run `snapcraft --destructive-mode` or `snapcraft remote-build`
-    return { artifact: `${ctx.outDir}/${config.snapName}_${ctx.version}_multi.snap` };
+    return { artifact: manifestPath };
   },
   async ship(ctx, config) {
     const trackChannel = config.channel ?? (ctx.channel === 'stable' ? 'stable' : 'edge');


### PR DESCRIPTION
## Summary
- Replace the Snapcraft target placeholder build with generated snapcraft.yaml output
- Support release metadata, base/grade/confinement, target architectures, app command/plugs, and part source/stage packages
- Add focused tests for generated manifest content and dry-run shipping

## Validation
- pnpm vitest run packages/targets/pkg-snap/src/index.test.ts
- pnpm --filter @profullstack/sh1pt-target-pkg-snap typecheck
- pnpm --filter @profullstack/sh1pt-target-pkg-snap build
- git diff --check