### PR TITLE
Generate Slack app manifests

### DIFF
--- a/packages/targets/chat-slack/src/index.test.ts
+++ b/packages/targets/chat-slack/src/index.test.ts
@@ -1,4 +1,73 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'chat', requireKind: true });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Slack app manifest generation', () => {
+  it('writes a Slack manifest from app config', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-slack-'));
+    tempDirs.push(outDir);
+
+    const result = await adapter.build(fakeBuildContext({ outDir }) as any, {
+      appId: 'A123456',
+      clientId: '123.456',
+      distribution: 'directory',
+      requestUrl: 'https://example.com/slack/events',
+      name: 'Ship Bot',
+      description: 'Release assistant for Slack',
+      botDisplayName: 'shipbot',
+      botEvents: ['app_mention', 'message.im'],
+      slashCommands: [
+        {
+          command: '/ship',
+          url: 'https://example.com/slack/commands',
+          description: 'Trigger a release workflow',
+        },
+      ],
+      scopes: {
+        bot: ['commands', 'chat:write'],
+        user: ['users:read'],
+      },
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'slack-manifest.yaml'));
+    const manifest = await readFile(result.artifact, 'utf-8');
+
+    expect(manifest).toContain('display_information:');
+    expect(manifest).toContain('  name: "Ship Bot"');
+    expect(manifest).toContain('  description: "Release assistant for Slack"');
+    expect(manifest).toContain('oauth_config:');
+    expect(manifest).toContain('  client_id: "123.456"');
+    expect(manifest).toContain('      - "commands"');
+    expect(manifest).toContain('      - "users:read"');
+    expect(manifest).toContain('  slash_commands:');
+    expect(manifest).toContain('    - command: "/ship"');
+    expect(manifest).toContain('      url: "https://example.com/slack/commands"');
+    expect(manifest).toContain('    request_url: "https://example.com/slack/events"');
+    expect(manifest).toContain('      - "app_mention"');
+    expect(manifest).toContain('  org_deploy_enabled: true');
+  });
+
+  it('keeps dry-run shipping side-effect free', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      appId: 'A123456',
+      clientId: '123.456',
+      distribution: 'workspace',
+      requestUrl: 'https://example.com/slack/events',
+      scopes: { bot: ['chat:write'] },
+    })).resolves.toEqual({ id: 'dry-run' });
+  });
+});

--- a/packages/targets/chat-slack/src/index.ts
+++ b/packages/targets/chat-slack/src/index.ts
@@ -1,4 +1,6 @@
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 // Slack apps — bots, slash commands, workflows, Block Kit surfaces.
 // Two distribution tiers:
@@ -9,8 +11,86 @@ interface Config {
   clientId: string;
   distribution: 'workspace' | 'directory';
   requestUrl: string;                // events + interactivity endpoint
+  name?: string;
+  description?: string;
+  botDisplayName?: string;
+  botEvents?: string[];
   slashCommands?: { command: string; url: string; description: string }[];
   scopes: { bot?: string[]; user?: string[] };
+}
+
+function yamlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function renderList(values: string[], indent: string): string[] {
+  return values.map((value) => `${indent}- ${yamlString(value)}`);
+}
+
+function renderSlashCommands(commands: NonNullable<Config['slashCommands']>): string[] {
+  return commands.flatMap((command) => [
+    '    - command: ' + yamlString(command.command),
+    '      url: ' + yamlString(command.url),
+    '      description: ' + yamlString(command.description),
+  ]);
+}
+
+function renderSlackManifest(config: Config): string {
+  const appName = config.name ?? config.appId;
+  const botDisplayName = config.botDisplayName ?? appName;
+  const botScopes = config.scopes.bot ?? [];
+  const userScopes = config.scopes.user ?? [];
+  const botEvents = config.botEvents ?? [];
+  const lines = [
+    'display_information:',
+    `  name: ${yamlString(appName)}`,
+  ];
+
+  if (config.description) {
+    lines.push(`  description: ${yamlString(config.description)}`);
+  }
+
+  lines.push('features:');
+  lines.push('  bot_user:');
+  lines.push(`    display_name: ${yamlString(botDisplayName)}`);
+  lines.push('    always_online: false');
+
+  if (config.slashCommands?.length) {
+    lines.push('  slash_commands:');
+    lines.push(...renderSlashCommands(config.slashCommands));
+  }
+
+  lines.push('oauth_config:');
+  lines.push(`  client_id: ${yamlString(config.clientId)}`);
+  lines.push('  scopes:');
+
+  if (botScopes.length) {
+    lines.push('    bot:');
+    lines.push(...renderList(botScopes, '      '));
+  }
+
+  if (userScopes.length) {
+    lines.push('    user:');
+    lines.push(...renderList(userScopes, '      '));
+  }
+
+  lines.push('settings:');
+  lines.push('  event_subscriptions:');
+  lines.push(`    request_url: ${yamlString(config.requestUrl)}`);
+
+  if (botEvents.length) {
+    lines.push('    bot_events:');
+    lines.push(...renderList(botEvents, '      '));
+  }
+
+  lines.push('  interactivity:');
+  lines.push('    is_enabled: true');
+  lines.push(`    request_url: ${yamlString(config.requestUrl)}`);
+  lines.push(`  org_deploy_enabled: ${config.distribution === 'directory' ? 'true' : 'false'}`);
+  lines.push('  socket_mode_enabled: false');
+  lines.push('  token_rotation_enabled: false');
+  lines.push('');
+  return lines.join('\n');
 }
 
 export default defineTarget<Config>({
@@ -18,9 +98,11 @@ export default defineTarget<Config>({
   kind: 'chat',
   label: 'Slack App Directory',
   async build(ctx, config) {
+    const manifestPath = join(ctx.outDir, 'slack-manifest.yaml');
     ctx.log(`render slack app manifest · appId=${config.appId}`);
-    // TODO: render Slack App Manifest (YAML/JSON) from config → ctx.outDir
-    return { artifact: `${ctx.outDir}/slack-manifest.yaml` };
+    await mkdir(ctx.outDir, { recursive: true });
+    await writeFile(manifestPath, renderSlackManifest(config), 'utf-8');
+    return { artifact: manifestPath };
   },
   async ship(ctx, config) {
     const dest = config.distribution === 'directory' ? 'App Directory (review queue)' : 'workspace (no review)';


### PR DESCRIPTION
## Summary
- Replace the Slack chat target placeholder build with generated Slack app manifest YAML
- Add config for app display metadata, bot display name, bot events, slash commands, and bot/user OAuth scopes
- Write event subscription and interactivity request URLs plus distribution-sensitive org deploy settings
- Add focused coverage for generated manifest content and dry-run shipping

## Validation
- corepack pnpm exec vitest run packages/targets/chat-slack/src/index.test.ts
- corepack pnpm exec tsc -p packages/targets/chat-slack/tsconfig.json --noEmit
- corepack pnpm --filter @profullstack/sh1pt-target-chat-slack build
- git diff --check