### PR TITLE
Generate Scoop manifests

### DIFF
--- a/packages/targets/pkg-scoop/src/index.test.ts
+++ b/packages/targets/pkg-scoop/src/index.test.ts
@@ -1,4 +1,76 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'pkg', requireKind: true });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Scoop manifest generation', () => {
+  it('writes a multi-architecture Scoop manifest from release config', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-scoop-'));
+    tempDirs.push(outDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      version: 'v1.2.3',
+    }) as any, {
+      appName: 'myapp',
+      downloadRepo: 'acme/myapp',
+      description: 'Example command line app',
+      homepage: 'https://example.com/myapp',
+      license: 'MIT',
+      bin: ['myapp.exe'],
+      shortcuts: [['myapp.exe', 'My App']],
+      checkver: 'github',
+      autoupdate: {
+        url: 'https://github.com/acme/myapp/releases/download/v$version/myapp-$version-$arch.zip',
+      },
+      architecture: [
+        {
+          name: '64bit',
+          sha256: 'a'.repeat(64),
+        },
+        {
+          name: 'arm64',
+          url: 'https://downloads.example.com/myapp-{version}-windows-arm64.zip',
+          sha256: 'b'.repeat(64),
+          extractDir: 'myapp',
+        },
+      ],
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'myapp.json'));
+
+    const manifest = JSON.parse(await readFile(join(outDir, 'myapp.json'), 'utf-8'));
+    expect(manifest.version).toBe('1.2.3');
+    expect(manifest.description).toBe('Example command line app');
+    expect(manifest.homepage).toBe('https://example.com/myapp');
+    expect(manifest.license).toBe('MIT');
+    expect(manifest.architecture['64bit'].url).toBe('https://github.com/acme/myapp/releases/download/v1.2.3/myapp-1.2.3-64bit.zip');
+    expect(manifest.architecture['64bit'].hash).toBe('a'.repeat(64));
+    expect(manifest.architecture['64bit'].bin).toEqual(['myapp.exe']);
+    expect(manifest.architecture['64bit'].shortcuts).toEqual([['myapp.exe', 'My App']]);
+    expect(manifest.architecture.arm64.url).toBe('https://downloads.example.com/myapp-1.2.3-windows-arm64.zip');
+    expect(manifest.architecture.arm64.hash).toBe('b'.repeat(64));
+    expect(manifest.architecture.arm64.extract_dir).toBe('myapp');
+    expect(manifest.checkver).toBe('github');
+    expect(manifest.autoupdate.url).toBe('https://github.com/acme/myapp/releases/download/v$version/myapp-$version-$arch.zip');
+  });
+
+  it('keeps dry-run shipping side-effect free', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      appName: 'myapp',
+    })).resolves.toEqual({ id: 'dry-run' });
+  });
+});

--- a/packages/targets/pkg-scoop/src/index.ts
+++ b/packages/targets/pkg-scoop/src/index.ts
@@ -1,9 +1,92 @@
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+type ScoopArch = '64bit' | '32bit' | 'arm64';
+type ScoopShortcuts = [string, string][];
+
+interface ArchitectureConfig {
+  name: ScoopArch;
+  url?: string;
+  sha256?: string;
+  bin?: string | string[];
+  shortcuts?: ScoopShortcuts;
+  extractDir?: string;
+}
 
 interface Config {
   appName: string;          // e.g. "myapp"
   bucketRepo?: string;      // GitHub repo for your scoop bucket, e.g. "myorg/scoop-bucket"
   urlTemplate?: string;     // download URL template with {{version}}
+  downloadRepo?: string;    // GitHub release repo, e.g. "myorg/myapp"
+  sha256?: string;
+  description?: string;
+  homepage?: string;
+  license?: string;
+  bin?: string | string[];
+  shortcuts?: ScoopShortcuts;
+  architecture?: ArchitectureConfig[];
+  checkver?: string | Record<string, unknown>;
+  autoupdate?: {
+    url?: string;
+    hash?: { url: string };
+  };
+}
+
+function scoopVersion(version: string): string {
+  return version.replace(/^v/, '');
+}
+
+function templateValue(value: string, config: Config, version: string, arch: ScoopArch): string {
+  return value
+    .replaceAll('{{version}}', version)
+    .replaceAll('{version}', version)
+    .replaceAll('{{appName}}', config.appName)
+    .replaceAll('{appName}', config.appName)
+    .replaceAll('{{arch}}', arch)
+    .replaceAll('{arch}', arch);
+}
+
+function defaultUrlTemplate(config: Config): string {
+  const repo = config.downloadRepo ?? config.bucketRepo ?? `profullstack/${config.appName}`;
+  return `https://github.com/${repo}/releases/download/v{{version}}/${config.appName}-{{version}}-{{arch}}.zip`;
+}
+
+function architectureUrl(ctx: { version: string }, config: Config, arch: ArchitectureConfig): string {
+  return templateValue(arch.url ?? config.urlTemplate ?? defaultUrlTemplate(config), config, scoopVersion(ctx.version), arch.name);
+}
+
+function renderManifest(ctx: { version: string }, config: Config): string {
+  const version = scoopVersion(ctx.version);
+  const architectures = config.architecture ?? [{ name: '64bit' as const }];
+  const manifest: Record<string, unknown> = {
+    version,
+    description: config.description ?? `${config.appName} release`,
+    homepage: config.homepage ?? 'https://sh1pt.com',
+    license: config.license ?? 'MIT',
+    architecture: Object.fromEntries(architectures.map((arch) => {
+      const entry: Record<string, unknown> = {
+        url: architectureUrl(ctx, config, arch),
+        hash: arch.sha256 ?? config.sha256 ?? 'skip',
+      };
+      if (arch.extractDir) entry.extract_dir = arch.extractDir;
+      if (arch.bin ?? config.bin) entry.bin = arch.bin ?? config.bin;
+      if (arch.shortcuts ?? config.shortcuts) entry.shortcuts = arch.shortcuts ?? config.shortcuts;
+      return [arch.name, entry];
+    })),
+  };
+
+  if (config.checkver) manifest.checkver = config.checkver;
+  if (config.autoupdate) {
+    manifest.autoupdate = {
+      ...config.autoupdate,
+      ...(config.autoupdate.url ? {
+        url: templateValue(config.autoupdate.url, config, '$version', '64bit'),
+      } : {}),
+    };
+  }
+
+  return `${JSON.stringify(manifest, null, 2)}\n`;
 }
 
 export default defineTarget<Config>({
@@ -11,9 +94,11 @@ export default defineTarget<Config>({
   kind: 'package-manager',
   label: 'Scoop bucket',
   async build(ctx, config) {
+    const manifestPath = join(ctx.outDir, `${config.appName}.json`);
     ctx.log(`generate scoop manifest ${config.appName}.json for v${ctx.version}`);
-    // TODO: render JSON manifest with url, hash, bin, shortcuts
-    return { artifact: `${ctx.outDir}/${config.appName}.json` };
+    await mkdir(ctx.outDir, { recursive: true });
+    await writeFile(manifestPath, renderManifest(ctx, config), 'utf-8');
+    return { artifact: manifestPath };
   },
   async ship(ctx, config) {
     const bucket = config.bucketRepo ?? 'profullstack/scoop-bucket';


### PR DESCRIPTION
## Summary
- render real Scoop JSON manifests for the pkg-scoop target
- support release URL templates, per-architecture URLs and hashes, bin entries, shortcuts, checkver, and autoupdate metadata
- add focused tests for manifest generation and dry-run shipping

## Validation
- corepack pnpm exec vitest run packages/targets/pkg-scoop/src/index.test.ts
- corepack pnpm exec tsc -p packages/targets/pkg-scoop/tsconfig.json --noEmit
- corepack pnpm --filter @profullstack/sh1pt-target-pkg-scoop build
- git diff --check