### PR TITLE
Generate Nix package expressions

### DIFF
--- a/packages/targets/pkg-nix/src/index.test.ts
+++ b/packages/targets/pkg-nix/src/index.test.ts
@@ -1,4 +1,73 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'pkg', requireKind: true });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('nix package expression generation', () => {
+  it('writes a default.nix with source, build inputs, install phase, and meta', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-nix-'));
+    tempDirs.push(outDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      version: 'v1.2.3',
+    }) as any, {
+      pname: 'myapp',
+      sourceRepo: 'acme/myapp',
+      rev: 'release-1.2.3',
+      sha256: 'sha256-abc123',
+      description: 'Example command line app',
+      homepage: 'https://example.com/myapp',
+      license: 'licenses.asl20',
+      platforms: 'platforms.linux',
+      mainProgram: 'myapp',
+      maintainerHandle: 'photon101',
+      nativeBuildInputs: ['pkg-config', 'makeWrapper'],
+      buildInputs: ['openssl', 'zlib'],
+      installPhase: [
+        'runHook preInstall',
+        'install -Dm755 myapp $out/bin/myapp',
+        'runHook postInstall',
+      ].join('\n'),
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'default.nix'));
+
+    const expression = await readFile(join(outDir, 'default.nix'), 'utf-8');
+    expect(expression).toContain('{ lib, stdenv, fetchFromGitHub }:');
+    expect(expression).toContain('pname = "myapp";');
+    expect(expression).toContain('version = "1.2.3";');
+    expect(expression).toContain('owner = "acme";');
+    expect(expression).toContain('repo = "myapp";');
+    expect(expression).toContain('rev = "release-1.2.3";');
+    expect(expression).toContain('hash = "sha256-abc123";');
+    expect(expression).toContain('nativeBuildInputs = [ pkg-config makeWrapper ];');
+    expect(expression).toContain('buildInputs = [ openssl zlib ];');
+    expect(expression).toContain('install -Dm755 myapp $out/bin/myapp');
+    expect(expression).toContain('description = "Example command line app";');
+    expect(expression).toContain('homepage = "https://example.com/myapp";');
+    expect(expression).toContain('license = licenses.asl20;');
+    expect(expression).toContain('platforms = platforms.linux;');
+    expect(expression).toContain('mainProgram = "myapp";');
+    expect(expression).toContain('maintainers = with maintainers; [ photon101 ];');
+  });
+
+  it('keeps dry-run shipping side-effect free', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      pname: 'myapp',
+    })).resolves.toEqual({ id: 'dry-run' });
+  });
+});

--- a/packages/targets/pkg-nix/src/index.ts
+++ b/packages/targets/pkg-nix/src/index.ts
@@ -1,10 +1,98 @@
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 interface Config {
   pname: string;             // e.g. "myapp"
   nixpkgsRepo?: string;      // GitHub repo, defaults to NixOS/nixpkgs
   attrPath?: string;         // e.g. "nodePackages.myapp"
   maintainerHandle?: string; // your nixpkgs GitHub handle
+  sourceRepo?: string;       // GitHub source repo, e.g. "myorg/myapp"
+  rev?: string;
+  sha256?: string;
+  description?: string;
+  homepage?: string;
+  license?: string;          // e.g. "licenses.mit"
+  platforms?: string;        // e.g. "platforms.unix"
+  mainProgram?: string;
+  buildInputs?: string[];
+  nativeBuildInputs?: string[];
+  installPhase?: string;
+}
+
+function nixVersion(version: string): string {
+  return version.replace(/^v/, '');
+}
+
+function nixString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function parseRepo(sourceRepo: string | undefined, pname: string): { owner: string; repo: string } {
+  const [owner, repo] = (sourceRepo ?? `profullstack/${pname}`).split('/');
+  return {
+    owner: owner || 'profullstack',
+    repo: repo || pname,
+  };
+}
+
+function nixList(values: string[] | undefined): string {
+  return values?.length ? `[ ${values.join(' ')} ]` : '[ ]';
+}
+
+function nixIndentedString(value: string): string {
+  return value.replaceAll("''", "'''").replaceAll('${', "''${");
+}
+
+function defaultInstallPhase(config: Config): string {
+  const mainProgram = config.mainProgram ?? config.pname;
+  return [
+    'runHook preInstall',
+    `mkdir -p $out/share/${config.pname}`,
+    `cp -R . $out/share/${config.pname}/`,
+    'mkdir -p $out/bin',
+    `ln -s $out/share/${config.pname}/${mainProgram} $out/bin/${mainProgram} || true`,
+    'runHook postInstall',
+  ].join('\n');
+}
+
+function renderDefaultNix(ctx: { version: string }, config: Config): string {
+  const version = nixVersion(ctx.version);
+  const { owner, repo } = parseRepo(config.sourceRepo, config.pname);
+  const license = config.license ?? 'licenses.mit';
+  const platforms = config.platforms ?? 'platforms.unix';
+  const maintainer = config.maintainerHandle ? `\n    maintainers = with maintainers; [ ${config.maintainerHandle} ];` : '';
+  return [
+    '{ lib, stdenv, fetchFromGitHub }:',
+    '',
+    'stdenv.mkDerivation rec {',
+    `  pname = ${nixString(config.pname)};`,
+    `  version = ${nixString(version)};`,
+    '',
+    '  src = fetchFromGitHub {',
+    `    owner = ${nixString(owner)};`,
+    `    repo = ${nixString(repo)};`,
+    `    rev = ${nixString(config.rev ?? `v${version}`)};`,
+    `    hash = ${config.sha256 ? nixString(config.sha256) : 'lib.fakeHash'};`,
+    '  };',
+    '',
+    `  nativeBuildInputs = ${nixList(config.nativeBuildInputs)};`,
+    `  buildInputs = ${nixList(config.buildInputs)};`,
+    '',
+    "  installPhase = ''",
+    nixIndentedString(config.installPhase ?? defaultInstallPhase(config)).split('\n').map((line) => `    ${line}`).join('\n'),
+    "  '';",
+    '',
+    '  meta = with lib; {',
+    `    description = ${nixString(config.description ?? `Release package for ${config.pname}`)};`,
+    `    homepage = ${nixString(config.homepage ?? 'https://sh1pt.com')};`,
+    `    license = ${license};`,
+    `    platforms = ${platforms};`,
+    `    mainProgram = ${nixString(config.mainProgram ?? config.pname)};${maintainer}`,
+    '  };',
+    '}',
+    '',
+  ].join('\n');
 }
 
 export default defineTarget<Config>({
@@ -12,10 +100,11 @@ export default defineTarget<Config>({
   kind: 'package-manager',
   label: 'nixpkgs',
   async build(ctx, config) {
+    const expressionPath = join(ctx.outDir, 'default.nix');
     ctx.log(`generate default.nix for ${config.pname} v${ctx.version}`);
-    // TODO: render default.nix / package.nix expression from template
-    // Includes src hash (fetchFromGitHub), buildInputs, meta block
-    return { artifact: `${ctx.outDir}/default.nix` };
+    await mkdir(ctx.outDir, { recursive: true });
+    await writeFile(expressionPath, renderDefaultNix(ctx, config), 'utf-8');
+    return { artifact: expressionPath };
   },
   async ship(ctx, config) {
     const repo = config.nixpkgsRepo ?? 'NixOS/nixpkgs';


### PR DESCRIPTION
## Summary
- render a concrete default.nix for the pkg-nix target
- support fetchFromGitHub source metadata, build inputs, native build inputs, install phase, and package meta fields
- add focused tests for expression generation and dry-run shipping

## Validation
- corepack pnpm exec vitest run packages/targets/pkg-nix/src/index.test.ts
- corepack pnpm exec tsc -p packages/targets/pkg-nix/tsconfig.json --noEmit
- corepack pnpm --filter @profullstack/sh1pt-target-pkg-nix build
- git diff --check