### PR TITLE
Implement Netlify deploy target

### DIFF
--- a/packages/targets/deploy-netlify/src/index.test.ts
+++ b/packages/targets/deploy-netlify/src/index.test.ts
@@ -1,4 +1,79 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'deploy', requireKind: true });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Netlify deployment target', () => {
+  it('writes a deploy plan with the resolved Netlify CLI command', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-netlify-'));
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-project-'));
+    tempDirs.push(outDir, projectDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      projectDir,
+      version: '1.2.3',
+      channel: 'stable',
+    }) as any, {
+      siteId: 'site-123',
+      dir: 'dist',
+      message: 'release 1.2.3',
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'netlify-deploy.json'));
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan.provider).toBe('netlify');
+    expect(plan.siteId).toBe('site-123');
+    expect(plan.dir).toBe(join(projectDir, 'dist'));
+    expect(plan.prod).toBe(true);
+    expect(plan.command).toEqual([
+      'npx',
+      '--yes',
+      'netlify-cli',
+      'deploy',
+      '--json',
+      '--dir',
+      join(projectDir, 'dist'),
+      '--prod',
+      '--site',
+      'site-123',
+      '--message',
+      'release 1.2.3',
+    ]);
+  });
+
+  it('keeps dry-run shipping side-effect free', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      version: '1.2.3',
+      channel: 'beta',
+      dryRun: true,
+    }) as any, {
+      siteId: 'site-123',
+      dir: 'dist',
+    })).resolves.toMatchObject({
+      id: 'dry-run',
+      meta: {
+        command: expect.arrayContaining(['netlify-cli', 'deploy', '--site', 'site-123']),
+      },
+    });
+  });
+
+  it('requires a vault token for real deployments', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      version: '1.2.3',
+      dryRun: false,
+    }) as any, {
+      siteId: 'site-123',
+    })).rejects.toThrow('NETLIFY_AUTH_TOKEN not in vault');
+  });
+});

--- a/packages/targets/deploy-netlify/src/index.ts
+++ b/packages/targets/deploy-netlify/src/index.ts
@@ -1,9 +1,57 @@
-import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { defineTarget, exec, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { isAbsolute, join } from 'node:path';
 
 interface Config {
   siteId?: string;
   dir?: string;
   prod?: boolean;
+  message?: string;
+}
+
+function deployDir(ctx: { projectDir: string }, config: Config): string {
+  if (!config.dir) return ctx.projectDir;
+  return isAbsolute(config.dir) ? config.dir : join(ctx.projectDir, config.dir);
+}
+
+function deployArgs(ctx: { channel: string; projectDir: string; version: string }, config: Config, token?: string): string[] {
+  const prod = config.prod ?? ctx.channel === 'stable';
+  const args = ['--yes', 'netlify-cli', 'deploy', '--json', '--dir', deployDir(ctx, config)];
+  if (prod) args.push('--prod');
+  if (config.siteId) args.push('--site', config.siteId);
+  if (config.message) args.push('--message', config.message);
+  else args.push('--message', `sh1pt ${ctx.version}`);
+  if (token) args.push('--auth', token);
+  return args;
+}
+
+function renderPlan(ctx: { channel: string; projectDir: string; version: string }, config: Config): string {
+  const prod = config.prod ?? ctx.channel === 'stable';
+  return `${JSON.stringify({
+    provider: 'netlify',
+    siteId: config.siteId ?? null,
+    dir: deployDir(ctx, config),
+    prod,
+    command: ['npx', ...deployArgs(ctx, config)],
+  }, null, 2)}\n`;
+}
+
+function parseDeploy(stdout: string): { id?: string; url?: string } {
+  try {
+    const data = JSON.parse(stdout) as Record<string, unknown>;
+    return {
+      id: typeof data.deploy_id === 'string' ? data.deploy_id : typeof data.id === 'string' ? data.id : undefined,
+      url: typeof data.deploy_url === 'string'
+        ? data.deploy_url
+        : typeof data.ssl_url === 'string'
+          ? data.ssl_url
+          : typeof data.url === 'string'
+            ? data.url
+            : undefined,
+    };
+  } catch {
+    return {};
+  }
 }
 
 export default defineTarget<Config>({
@@ -11,14 +59,33 @@ export default defineTarget<Config>({
   kind: 'web',
   label: 'Netlify',
   async build(ctx, config) {
+    const planPath = join(ctx.outDir, 'netlify-deploy.json');
     ctx.log(`netlify build · dir=${config.dir ?? 'default'}`);
-    return { artifact: `${ctx.outDir}/netlify-site` };
+    await mkdir(ctx.outDir, { recursive: true });
+    await writeFile(planPath, renderPlan(ctx, config), 'utf-8');
+    return { artifact: planPath };
   },
   async ship(ctx, config) {
     const prod = config.prod ?? ctx.channel === 'stable';
     ctx.log(`netlify deploy ${prod ? '--prod' : ''} · site=${config.siteId ?? 'linked'}`);
-    if (ctx.dryRun) return { id: 'dry-run' };
-    return { id: `${config.siteId ?? 'netlify'}@${ctx.version}` };
+    if (ctx.dryRun) return { id: 'dry-run', meta: { command: ['npx', ...deployArgs(ctx, config)] } };
+
+    const token = ctx.secret('NETLIFY_AUTH_TOKEN');
+    if (!token) {
+      throw new Error('NETLIFY_AUTH_TOKEN not in vault — run: sh1pt secret set NETLIFY_AUTH_TOKEN <token>');
+    }
+
+    const result = await exec('npx', deployArgs(ctx, config, token), {
+      cwd: ctx.projectDir,
+      env: { ...ctx.env, NETLIFY_AUTH_TOKEN: token },
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+    const deployed = parseDeploy(result.stdout);
+    return {
+      id: deployed.id ?? `${config.siteId ?? 'netlify'}@${ctx.version}`,
+      url: deployed.url,
+    };
   },
   setup: manualSetup({
     label: 'Netlify CLI',


### PR DESCRIPTION
## Summary
- generate a Netlify deployment plan during build
- expose dry-run command metadata for deploys
- run Netlify CLI only for non-dry-run shipping and require NETLIFY_AUTH_TOKEN from the sh1pt vault
- add focused tests for plan generation, dry-run shipping, and missing-token protection

## Validation
- corepack pnpm exec vitest run packages/targets/deploy-netlify/src/index.test.ts
- corepack pnpm exec tsc -p packages/targets/deploy-netlify/tsconfig.json --noEmit
- corepack pnpm --filter @profullstack/sh1pt-target-deploy-netlify build
- git diff --check