### PR TITLE
Implement Vercel deploy target

### DIFF
--- a/packages/targets/deploy-vercel/src/index.test.ts
+++ b/packages/targets/deploy-vercel/src/index.test.ts
@@ -1,4 +1,75 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'deploy', requireKind: true });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Vercel deployment target', () => {
+  it('writes a deploy plan with the resolved Vercel CLI command', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-vercel-'));
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-project-'));
+    tempDirs.push(outDir, projectDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      projectDir,
+      channel: 'stable',
+    }) as any, {
+      project: 'myapp',
+      org: 'acme',
+      dir: 'web',
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'vercel-deploy.json'));
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan.provider).toBe('vercel');
+    expect(plan.project).toBe('myapp');
+    expect(plan.org).toBe('acme');
+    expect(plan.dir).toBe(join(projectDir, 'web'));
+    expect(plan.prod).toBe(true);
+    expect(plan.command).toEqual([
+      'npx',
+      '--yes',
+      'vercel',
+      'deploy',
+      join(projectDir, 'web'),
+      '--yes',
+      '--prod',
+      '--scope',
+      'acme',
+    ]);
+  });
+
+  it('keeps dry-run shipping side-effect free', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      channel: 'beta',
+      dryRun: true,
+    }) as any, {
+      project: 'myapp',
+      org: 'acme',
+      dir: 'web',
+    })).resolves.toMatchObject({
+      id: 'dry-run',
+      meta: {
+        command: expect.arrayContaining(['vercel', 'deploy', '--scope', 'acme']),
+      },
+    });
+  });
+
+  it('requires a vault token for real deployments', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      dryRun: false,
+    }) as any, {
+      project: 'myapp',
+    })).rejects.toThrow('VERCEL_TOKEN not in vault');
+  });
+});

--- a/packages/targets/deploy-vercel/src/index.ts
+++ b/packages/targets/deploy-vercel/src/index.ts
@@ -1,24 +1,75 @@
-import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { defineTarget, exec, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { isAbsolute, join } from 'node:path';
 
 interface Config {
   project?: string;
   org?: string;
   prod?: boolean;
+  dir?: string;
+}
+
+function deployDir(ctx: { projectDir: string }, config: Config): string {
+  if (!config.dir) return ctx.projectDir;
+  return isAbsolute(config.dir) ? config.dir : join(ctx.projectDir, config.dir);
+}
+
+function deployArgs(ctx: { channel: string; projectDir: string }, config: Config, token?: string): string[] {
+  const prod = config.prod ?? ctx.channel === 'stable';
+  const args = ['--yes', 'vercel', 'deploy', deployDir(ctx, config), '--yes'];
+  if (prod) args.push('--prod');
+  if (config.org) args.push('--scope', config.org);
+  if (token) args.push('--token', token);
+  return args;
+}
+
+function renderPlan(ctx: { channel: string; projectDir: string }, config: Config): string {
+  const prod = config.prod ?? ctx.channel === 'stable';
+  return `${JSON.stringify({
+    provider: 'vercel',
+    project: config.project ?? null,
+    org: config.org ?? null,
+    dir: deployDir(ctx, config),
+    prod,
+    command: ['npx', ...deployArgs(ctx, config)],
+  }, null, 2)}\n`;
+}
+
+function parseDeployUrl(stdout: string): string | undefined {
+  return stdout.match(/https:\/\/[^\s]+\.vercel\.app[^\s]*/)?.[0];
 }
 
 export default defineTarget<Config>({
   id: 'deploy-vercel',
   kind: 'web',
   label: 'Vercel',
-  async build(ctx) {
+  async build(ctx, config) {
+    const planPath = join(ctx.outDir, 'vercel-deploy.json');
     ctx.log('vercel build');
-    return { artifact: `${ctx.outDir}/vercel-output` };
+    await mkdir(ctx.outDir, { recursive: true });
+    await writeFile(planPath, renderPlan(ctx, config), 'utf-8');
+    return { artifact: planPath };
   },
   async ship(ctx, config) {
     const prod = config.prod ?? ctx.channel === 'stable';
     ctx.log(`vercel deploy ${prod ? '--prod' : ''} · project=${config.project ?? 'linked'}`);
-    if (ctx.dryRun) return { id: 'dry-run' };
-    return { id: `${config.project ?? 'vercel'}@${ctx.version}`, url: undefined };
+    if (ctx.dryRun) return { id: 'dry-run', meta: { command: ['npx', ...deployArgs(ctx, config)] } };
+
+    const token = ctx.secret('VERCEL_TOKEN');
+    if (!token) {
+      throw new Error('VERCEL_TOKEN not in vault — run: sh1pt secret set VERCEL_TOKEN <token>');
+    }
+
+    const result = await exec('npx', deployArgs(ctx, config, token), {
+      cwd: ctx.projectDir,
+      env: { ...ctx.env, VERCEL_TOKEN: token },
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+    return {
+      id: `${config.project ?? 'vercel'}@${ctx.version}`,
+      url: parseDeployUrl(result.stdout),
+    };
   },
   setup: manualSetup({
     label: 'Vercel CLI',


### PR DESCRIPTION
## Summary
- generate a Vercel deployment plan during build
- expose dry-run command metadata for deploys
- run Vercel CLI only for non-dry-run shipping and require VERCEL_TOKEN from the sh1pt vault
- add focused tests for plan generation, dry-run shipping, and missing-token protection

## Validation
- corepack pnpm exec vitest run packages/targets/deploy-vercel/src/index.test.ts
- corepack pnpm exec tsc -p packages/targets/deploy-vercel/tsconfig.json --noEmit
- corepack pnpm --filter @profullstack/sh1pt-target-deploy-vercel build
- git diff --check