### PR TITLE
Implement Render deploy target

### DIFF
--- a/packages/targets/deploy-render/src/index.test.ts
+++ b/packages/targets/deploy-render/src/index.test.ts
@@ -1,4 +1,60 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'deploy', requireKind: true });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Render deployment target', () => {
+  it('writes a deploy plan with resolved blueprint metadata', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-render-'));
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-project-'));
+    tempDirs.push(outDir, projectDir);
+    const blueprint = join(projectDir, 'infra', 'render.yaml');
+    await mkdir(dirname(blueprint), { recursive: true });
+    await writeFile(blueprint, 'services: []\n', 'utf-8');
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      projectDir,
+      version: '1.2.3',
+    }) as any, {
+      serviceId: 'srv-123',
+      blueprint: 'infra/render.yaml',
+      waitForDeploy: true,
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'render-deploy.json'));
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan.provider).toBe('render');
+    expect(plan.serviceId).toBe('srv-123');
+    expect(plan.blueprint).toBe(blueprint);
+    expect(plan.trigger).toBe('api');
+    expect(plan.waitForDeploy).toBe(true);
+    expect(plan.version).toBe('1.2.3');
+  });
+
+  it('keeps dry-run shipping side-effect free', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      dryRun: true,
+    }) as any, {
+      serviceId: 'srv-123',
+    })).resolves.toEqual({ id: 'dry-run' });
+  });
+
+  it('requires a vault token for real API deploys', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      dryRun: false,
+    }) as any, {
+      serviceId: 'srv-123',
+    })).rejects.toThrow('RENDER_API_KEY not in vault');
+  });
+});

--- a/packages/targets/deploy-render/src/index.ts
+++ b/packages/targets/deploy-render/src/index.ts
@@ -1,8 +1,67 @@
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { isAbsolute, join } from 'node:path';
 
 interface Config {
   serviceId?: string;
   blueprint?: string;
+  deployHookUrl?: string;
+  waitForDeploy?: boolean;
+}
+
+interface RenderDeployResponse {
+  id?: string;
+  deploy?: { id?: string };
+}
+
+function blueprintPath(ctx: { projectDir: string }, config: Config): string {
+  const blueprint = config.blueprint ?? 'render.yaml';
+  return isAbsolute(blueprint) ? blueprint : join(ctx.projectDir, blueprint);
+}
+
+function renderPlan(ctx: { projectDir: string; version: string }, config: Config): string {
+  return `${JSON.stringify({
+    provider: 'render',
+    serviceId: config.serviceId ?? null,
+    blueprint: blueprintPath(ctx, config),
+    trigger: config.deployHookUrl ? 'deploy-hook' : 'api',
+    waitForDeploy: config.waitForDeploy ?? false,
+    version: ctx.version,
+  }, null, 2)}\n`;
+}
+
+async function blueprintExists(path: string): Promise<boolean> {
+  try {
+    await readFile(path, 'utf-8');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function triggerDeployHook(url: string): Promise<string> {
+  const res = await fetch(url, { method: 'POST' });
+  if (!res.ok) throw new Error(`Render deploy hook failed (${res.status})`);
+  return `deploy-hook-${Date.now()}`;
+}
+
+async function createDeploy(ctx: { secret(key: string): string | undefined; version: string }, config: Config): Promise<string> {
+  if (!config.serviceId) throw new Error('Render serviceId is required for API deploys');
+  const token = ctx.secret('RENDER_API_KEY');
+  if (!token) throw new Error('RENDER_API_KEY not in vault — run: sh1pt secret set RENDER_API_KEY <token>');
+
+  const res = await fetch(`https://api.render.com/v1/services/${config.serviceId}/deploys`, {
+    method: 'POST',
+    headers: {
+      accept: 'application/json',
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ clearCache: 'do_not_clear' }),
+  });
+  const data = await res.json().catch(() => ({})) as RenderDeployResponse;
+  if (!res.ok) throw new Error(`Render deploy failed (${res.status})`);
+  return data.deploy?.id ?? data.id ?? `${config.serviceId}@${ctx.version}`;
 }
 
 export default defineTarget<Config>({
@@ -10,13 +69,26 @@ export default defineTarget<Config>({
   kind: 'web',
   label: 'Render',
   async build(ctx, config) {
+    const planPath = join(ctx.outDir, 'render-deploy.json');
+    const blueprint = blueprintPath(ctx, config);
     ctx.log(`render blueprint validate ${config.blueprint ?? 'render.yaml'}`);
-    return { artifact: `${ctx.outDir}/render-blueprint` };
+    await mkdir(ctx.outDir, { recursive: true });
+    await writeFile(planPath, renderPlan(ctx, config), 'utf-8');
+    if (!(await blueprintExists(blueprint))) {
+      ctx.log(`Render blueprint not found at ${blueprint}; continuing with deploy plan only`, 'warn');
+    }
+    return { artifact: planPath };
   },
   async ship(ctx, config) {
     ctx.log(`render deploys create · service=${config.serviceId ?? 'linked'}`);
     if (ctx.dryRun) return { id: 'dry-run' };
-    return { id: `${config.serviceId ?? 'render'}@${ctx.version}` };
+    const id = config.deployHookUrl
+      ? await triggerDeployHook(config.deployHookUrl)
+      : await createDeploy(ctx, config);
+    return {
+      id,
+      url: config.serviceId ? `https://dashboard.render.com/web/${config.serviceId}` : undefined,
+    };
   },
   setup: manualSetup({
     label: 'Render CLI',


### PR DESCRIPTION
## Summary
- generate a Render deployment plan during build
- support deploy hooks and Render API deploy creation
- require RENDER_API_KEY from the sh1pt vault for real API deploys
- add focused tests for plan generation, dry-run shipping, and missing-token protection

## Validation
- corepack pnpm exec vitest run packages/targets/deploy-render/src/index.test.ts
- corepack pnpm exec tsc -p packages/targets/deploy-render/tsconfig.json --noEmit
- corepack pnpm --filter @profullstack/sh1pt-target-deploy-render build
- git diff --check