### PR TITLE
feat(docs): generate Pandoc documents

### DIFF
--- a/packages/docs/pandoc/src/index.test.ts
+++ b/packages/docs/pandoc/src/index.test.ts
@@ -1,4 +1,108 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
-import adapter from './index.js';
+import { contractTestDocs } from '@profullstack/sh1pt-core/testing';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import docs from './index.js';
 
-smokeTest(adapter, { idPrefix: 'docs', requireSupports: true });
+contractTestDocs(docs, {
+  sampleConfig: {},
+  sampleSpec: {
+    kind: 'whitepaper',
+    title: 'test paper',
+    format: 'docx',
+    markdown: '# Hello\n\nBody text',
+  },
+});
+
+const tempDirs: string[] = [];
+const oldPath = process.env.PATH;
+
+afterEach(async () => {
+  process.env.PATH = oldPath;
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('docs-pandoc generation', () => {
+  it('writes markdown directly when md output is requested', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-pandoc-'));
+    tempDirs.push(outDir);
+
+    const result = await docs.generate({ secret: () => undefined, log: () => {}, dryRun: false }, {
+      kind: 'proposal',
+      title: 'Proposal',
+      format: 'md',
+      markdown: '# Proposal\n\nScope',
+    }, { outDir });
+
+    expect(result).toEqual({
+      id: 'pandoc_proposal_md',
+      format: 'md',
+      localPath: join(outDir, 'proposal.md'),
+    });
+    await expect(readFile(join(outDir, 'proposal.md'), 'utf-8')).resolves.toBe('# Proposal\n\nScope');
+  });
+
+  it('invokes pandoc with input, output, metadata, reference doc, and pdf engine', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-pandoc-out-'));
+    const binDir = await mkdtemp(join(tmpdir(), 'sh1pt-pandoc-bin-'));
+    tempDirs.push(outDir, binDir);
+    await installFakePandoc(binDir);
+    process.env.PATH = `${binDir}:${oldPath ?? ''}`;
+
+    const result = await docs.generate({ secret: () => undefined, log: () => {}, dryRun: false }, {
+      kind: 'whitepaper',
+      title: 'Whitepaper',
+      format: 'pdf',
+      markdown: '# Whitepaper\n\nBody',
+    }, {
+      outDir,
+      referenceDoc: './templates/brand.docx',
+      pdfEngine: 'xelatex',
+      metadata: { title: 'Whitepaper', author: 'sh1pt' },
+    });
+
+    expect(result).toEqual({
+      id: 'pandoc_whitepaper_pdf',
+      format: 'pdf',
+      localPath: join(outDir, 'whitepaper.pdf'),
+    });
+
+    const args = JSON.parse(await readFile(join(outDir, 'pandoc-args.json'), 'utf-8')) as string[];
+    expect(args).toEqual([
+      join(outDir, 'whitepaper.md'),
+      '-f',
+      'markdown',
+      '-t',
+      'pdf',
+      '-o',
+      join(outDir, 'whitepaper.pdf'),
+      '--reference-doc=./templates/brand.docx',
+      '--pdf-engine=xelatex',
+      '--metadata',
+      'title=Whitepaper',
+      '--metadata',
+      'author=sh1pt',
+    ]);
+    await expect(readFile(join(outDir, 'whitepaper.pdf'), 'utf-8')).resolves.toBe('fake pandoc output\n');
+    await expect(readFile(join(outDir, 'whitepaper.md'), 'utf-8')).resolves.toBe('# Whitepaper\n\nBody');
+  });
+});
+
+async function installFakePandoc(binDir: string): Promise<void> {
+  const script = join(binDir, 'pandoc');
+  await writeFile(script, [
+    '#!/usr/bin/env bash',
+    'set -euo pipefail',
+    'out=""',
+    'args=("$@")',
+    'for ((i=0; i<${#args[@]}; i++)); do',
+    '  if [[ "${args[$i]}" == "-o" ]]; then',
+    '    out="${args[$((i+1))]}"',
+    '  fi',
+    'done',
+    'node -e "require(\'fs\').writeFileSync(process.argv[1], JSON.stringify(process.argv.slice(2)))" "$(dirname "$out")/pandoc-args.json" "$@"',
+    'printf "fake pandoc output\\n" > "$out"',
+  ].join('\n'), 'utf-8');
+  await chmod(script, 0o755);
+}

--- a/packages/docs/pandoc/src/index.ts
+++ b/packages/docs/pandoc/src/index.ts
@@ -1,4 +1,6 @@
-import { defineDocs, manualSetup } from '@profullstack/sh1pt-core';
+import { defineDocs, exec, manualSetup, type DocFormat } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 // Pandoc — universal document converter. Markdown → docx, pdf, html,
 // pptx, and back. Strongest at long-form content (whitepapers, memos,
@@ -7,7 +9,16 @@ interface Config {
   referenceDoc?: string;            // e.g. './templates/brand.docx' for --reference-doc (docx/pptx styling)
   pdfEngine?: 'xelatex' | 'weasyprint' | 'wkhtmltopdf';
   metadata?: Record<string, string>;
+  outDir?: string;                  // default './.sh1pt/docs'
 }
+
+const WRITERS: Partial<Record<DocFormat, string>> = {
+  docx: 'docx',
+  pdf: 'pdf',
+  html: 'html5',
+  pptx: 'pptx',
+  md: 'markdown',
+};
 
 export default defineDocs<Config>({
   id: 'docs-pandoc',
@@ -16,10 +27,37 @@ export default defineDocs<Config>({
 
   async generate(ctx, spec, config) {
     if (!spec.markdown) throw new Error('docs-pandoc requires spec.markdown');
+    const writer = WRITERS[spec.format];
+    if (!writer) throw new Error(`docs-pandoc does not support ${spec.format}`);
+
+    const outDir = config.outDir ?? join('.', '.sh1pt', 'docs');
+    const baseName = safeName(spec.kind);
+    const outputPath = join(outDir, `${baseName}.${spec.format}`);
+    const inputPath = join(outDir, `${baseName}.md`);
+
     ctx.log(`pandoc · md → ${spec.format}${config.pdfEngine ? ` · ${config.pdfEngine}` : ''}`);
-    if (ctx.dryRun) return { id: 'dry-run', format: spec.format, localPath: `./.sh1pt/docs/${spec.kind}.${spec.format}` };
-    // TODO: spawn `pandoc -f markdown -t <spec.format> ${referenceDoc ? `--reference-doc=${referenceDoc}` : ''} -o <out> -` with markdown on stdin
-    return { id: `pandoc_${Date.now()}`, format: spec.format, localPath: `./.sh1pt/docs/${spec.kind}.${spec.format}` };
+    if (ctx.dryRun) return { id: 'dry-run', format: spec.format, localPath: outputPath };
+
+    await mkdir(outDir, { recursive: true });
+    await writeFile(inputPath, spec.markdown, 'utf-8');
+
+    if (spec.format === 'md') {
+      await writeFile(outputPath, spec.markdown, 'utf-8');
+      return { id: `pandoc_${baseName}_md`, format: spec.format, localPath: outputPath };
+    }
+
+    const args = pandocArgs(inputPath, outputPath, writer, config);
+    try {
+      await exec('pandoc', args, { log: ctx.log, throwOnNonZero: true });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.startsWith('command not found: pandoc')) {
+        throw new Error('docs-pandoc requires pandoc on PATH. Install it from https://pandoc.org/installing.html');
+      }
+      throw err;
+    }
+
+    return { id: `pandoc_${baseName}_${spec.format}`, format: spec.format, localPath: outputPath };
   },
 
   setup: manualSetup({
@@ -31,3 +69,20 @@ export default defineDocs<Config>({
     ],
   }),
 });
+
+function pandocArgs(inputPath: string, outputPath: string, writer: string, config: Config): string[] {
+  const args = [inputPath, '-f', 'markdown', '-t', writer, '-o', outputPath];
+
+  if (config.referenceDoc) args.push(`--reference-doc=${config.referenceDoc}`);
+  if (config.pdfEngine) args.push(`--pdf-engine=${config.pdfEngine}`);
+  for (const [key, value] of Object.entries(config.metadata ?? {})) {
+    args.push('--metadata', `${key}=${value}`);
+  }
+
+  return args;
+}
+
+function safeName(value: string): string {
+  const name = value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  return name || 'document';
+}


### PR DESCRIPTION
## Summary
- replace the docs-pandoc placeholder with real local Pandoc generation
- write markdown input and generated outputs under .sh1pt/docs by default
- support markdown passthrough, metadata, reference docs, and configurable PDF engines
- add focused docs-pandoc contract and fake CLI tests

## Validation
- pnpm exec vitest run packages/docs/pandoc/src/index.test.ts
- pnpm --filter @profullstack/sh1pt-docs-pandoc typecheck
- git diff --check

Refs #6