### PR TITLE
Implement Deno Deploy target

### DIFF
--- a/packages/targets/deploy-denodeploy/src/index.test.ts
+++ b/packages/targets/deploy-denodeploy/src/index.test.ts
@@ -1,4 +1,83 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'deploy', requireKind: true });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Deno Deploy target', () => {
+  it('writes a deployctl plan with project, files, env, and production routing', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-deno-deploy-'));
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-project-'));
+    tempDirs.push(outDir, projectDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      projectDir,
+      version: '1.2.3',
+      channel: 'stable',
+    }) as any, {
+      project: 'edge-api',
+      org: 'acme',
+      entrypoint: 'src/server.ts',
+      includeFiles: ['static/**'],
+      excludeFiles: ['fixtures/**'],
+      env: { RELEASE: '1.2.3' },
+      envFiles: ['.env.production'],
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'deno-deploy.json'));
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan.provider).toBe('deno-deploy');
+    expect(plan.project).toBe('edge-api');
+    expect(plan.org).toBe('acme');
+    expect(plan.entrypoint).toBe('src/server.ts');
+    expect(plan.prod).toBe(true);
+    expect(plan.projectDir).toBe(projectDir);
+    expect(plan.command).toEqual([
+      'deployctl',
+      'deploy',
+      '--project=edge-api',
+      '--entrypoint=src/server.ts',
+      '--org=acme',
+      '--prod',
+      '--include=static/**',
+      '--exclude=fixtures/**',
+      '--env=RELEASE=1.2.3',
+      '--env-file=.env.production',
+    ]);
+  });
+
+  it('keeps dry-run shipping side-effect free', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      channel: 'beta',
+      dryRun: true,
+    }) as any, {
+      project: 'edge-api',
+      entrypoint: 'src/server.ts',
+      includeFiles: ['static/**'],
+    })).resolves.toMatchObject({
+      id: 'dry-run',
+      meta: {
+        command: expect.arrayContaining(['deploy', '--project=edge-api', '--entrypoint=src/server.ts']),
+      },
+    });
+  });
+
+  it('requires a vault token for real deployments', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      dryRun: false,
+    }) as any, {
+      project: 'edge-api',
+      entrypoint: 'src/server.ts',
+    })).rejects.toThrow('DENO_DEPLOY_TOKEN not in vault');
+  });
+});

--- a/packages/targets/deploy-denodeploy/src/index.ts
+++ b/packages/targets/deploy-denodeploy/src/index.ts
@@ -1,11 +1,80 @@
-import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { defineTarget, exec, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 interface Config {
   project: string;
   entrypoint: string;            // e.g. 'server.ts'
+  org?: string;
   includeFiles?: string[];
   excludeFiles?: string[];
+  env?: Record<string, string>;
+  envFiles?: string[];
   prod?: boolean;                // false = preview deployment
+}
+
+function deployArgs(ctx: { channel: string }, config: Config): string[] {
+  const prod = config.prod ?? ctx.channel === 'stable';
+  const args = [
+    'deploy',
+    `--project=${config.project}`,
+    `--entrypoint=${config.entrypoint}`,
+  ];
+  if (config.org) args.push(`--org=${config.org}`);
+  if (prod) args.push('--prod');
+  for (const include of config.includeFiles ?? []) args.push(`--include=${include}`);
+  for (const exclude of config.excludeFiles ?? []) args.push(`--exclude=${exclude}`);
+  for (const [key, value] of Object.entries(config.env ?? {})) args.push(`--env=${key}=${value}`);
+  for (const file of config.envFiles ?? []) args.push(`--env-file=${file}`);
+  return args;
+}
+
+function renderPlan(ctx: { channel: string; projectDir: string; version: string }, config: Config): string {
+  const prod = config.prod ?? ctx.channel === 'stable';
+  return `${JSON.stringify({
+    provider: 'deno-deploy',
+    project: config.project,
+    org: config.org ?? null,
+    entrypoint: config.entrypoint,
+    includeFiles: config.includeFiles ?? [],
+    excludeFiles: config.excludeFiles ?? [],
+    env: config.env ?? {},
+    envFiles: config.envFiles ?? [],
+    prod,
+    projectDir: ctx.projectDir,
+    version: ctx.version,
+    command: ['deployctl', ...deployArgs(ctx, config)],
+  }, null, 2)}\n`;
+}
+
+function parseDeploy(stdout: string, project: string, version: string): { id: string; url: string } {
+  try {
+    const data = JSON.parse(stdout) as Record<string, unknown>;
+    const deployment = typeof data.deployment === 'object' && data.deployment
+      ? data.deployment as Record<string, unknown>
+      : {};
+    const build = typeof data.build === 'object' && data.build
+      ? data.build as Record<string, unknown>
+      : {};
+    const id = typeof data.id === 'string'
+      ? data.id
+      : typeof deployment.id === 'string'
+        ? deployment.id
+        : typeof build.deploymentId === 'string'
+          ? build.deploymentId
+          : `${project}@${version}`;
+    const url = typeof data.url === 'string'
+      ? data.url
+      : typeof deployment.url === 'string'
+        ? deployment.url
+        : `https://${project}.deno.dev`;
+    return { id, url };
+  } catch {
+    return {
+      id: `${project}@${version}`,
+      url: stdout.match(/https:\/\/[^\s]+\.deno\.dev[^\s]*/)?.[0] ?? `https://${project}.deno.dev`,
+    };
+  }
 }
 
 export default defineTarget<Config>({
@@ -13,26 +82,42 @@ export default defineTarget<Config>({
   kind: 'web',
   label: 'Deno Deploy',
   async build(ctx, config) {
-    ctx.log(`deployctl check · entrypoint=${config.entrypoint}`);
-    return { artifact: ctx.projectDir };
+    const planPath = join(ctx.outDir, 'deno-deploy.json');
+    ctx.log(`deployctl plan - project=${config.project} entrypoint=${config.entrypoint}`);
+    await mkdir(ctx.outDir, { recursive: true });
+    await writeFile(planPath, renderPlan(ctx, config), 'utf-8');
+    return { artifact: planPath };
   },
   async ship(ctx, config) {
     const kind = (config.prod ?? ctx.channel === 'stable') ? 'production' : 'preview';
-    ctx.log(`deployctl deploy --project=${config.project} --${kind === 'production' ? 'prod' : ''}`);
-    if (ctx.dryRun) return { id: 'dry-run' };
-    // TODO: `deployctl deploy` via DENO_DEPLOY_TOKEN
+    ctx.log(`deployctl deploy - project=${config.project} kind=${kind}`);
+    if (ctx.dryRun) return { id: 'dry-run', meta: { command: ['deployctl', ...deployArgs(ctx, config)] } };
+
+    const token = ctx.secret('DENO_DEPLOY_TOKEN');
+    if (!token) {
+      throw new Error('DENO_DEPLOY_TOKEN not in vault - run: sh1pt secret set DENO_DEPLOY_TOKEN <token>');
+    }
+
+    const result = await exec('deployctl', deployArgs(ctx, config), {
+      cwd: ctx.projectDir,
+      env: { ...ctx.env, DENO_DEPLOY_TOKEN: token },
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+    const deployed = parseDeploy(result.stdout, config.project, ctx.version);
     return {
-      id: `${config.project}@${ctx.version}`,
-      url: `https://${config.project}.deno.dev`,
+      id: deployed.id,
+      url: deployed.url,
     };
   },
 
   setup: manualSetup({
-    label: "Deno Deploy",
-    vendorDocUrl: "https://dash.deno.com/account",
+    label: 'Deno Deploy',
+    vendorDocUrl: 'https://docs.deno.com/deploy/classic/deployctl/',
     steps: [
-      "Open dash.deno.com \u2192 Account \u2192 New Access Token",
-      "Run: sh1pt secret set DENO_DEPLOY_TOKEN <token>",
+      'Install deployctl: deno install -gArf jsr:@deno/deployctl',
+      'Create an access token in the Deno Deploy dashboard',
+      'Run: sh1pt secret set DENO_DEPLOY_TOKEN <token>',
     ],
   }),
 });


### PR DESCRIPTION
## Summary
- replace the Deno Deploy target placeholder with a deployctl deployment plan artifact
- support project, org, entrypoint, include/exclude file filters, environment variables, env files, and production routing
- run real deployments through deployctl with DENO_DEPLOY_TOKEN from the sh1pt vault while keeping dry-run side-effect free

## Validation
- corepack pnpm exec vitest run packages/targets/deploy-denodeploy/src/index.test.ts
- corepack pnpm exec tsc -p packages/targets/deploy-denodeploy/tsconfig.json --noEmit
- corepack pnpm --filter @profullstack/sh1pt-target-deploy-denodeploy build
- git diff --check

I checked open PRs for Deno Deploy/deployctl/deploy-denodeploy duplicates before opening this.