### PR TITLE
Implement CDN package target

### DIFF
--- a/packages/targets/pkg-cdn/src/index.test.ts
+++ b/packages/targets/pkg-cdn/src/index.test.ts
@@ -1,4 +1,195 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'pkg', requireKind: true });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('CDN package target', () => {
+  it('writes a manifest with resolved CDN mirror URLs', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-cdn-'));
+    tempDirs.push(outDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      version: '1.2.3',
+    }) as any, {
+      packageName: '@acme/ui',
+      mirrors: ['jsdelivr', 'unpkg', 'cdnjs', 'jsdelivr'],
+      cdnjs: {
+        autoupdateSource: 'npm',
+        libraryName: 'acme-ui',
+        sourceRepo: 'https://github.com/acme/ui',
+      },
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'cdn-manifest.json'));
+    expect(result.meta).toEqual({
+      urls: [
+        'https://cdn.jsdelivr.net/npm/@acme/ui@1.2.3/',
+        'https://unpkg.com/@acme/ui@1.2.3/',
+        'https://cdnjs.cloudflare.com/ajax/libs/acme-ui/1.2.3/',
+      ],
+    });
+
+    const manifest = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(manifest).toMatchObject({
+      provider: 'pkg-cdn',
+      packageName: '@acme/ui',
+      version: '1.2.3',
+      cdnjs: {
+        libraryName: 'acme-ui',
+        autoupdateSource: 'npm',
+        sourceRepo: 'https://github.com/acme/ui',
+        requiresManualSubmission: true,
+      },
+    });
+    expect(manifest.mirrors).toEqual([
+      {
+        mirror: 'jsdelivr',
+        url: 'https://cdn.jsdelivr.net/npm/@acme/ui@1.2.3/',
+        source: 'npm',
+        autoMirrored: true,
+      },
+      {
+        mirror: 'unpkg',
+        url: 'https://unpkg.com/@acme/ui@1.2.3/',
+        source: 'npm',
+        autoMirrored: true,
+      },
+      {
+        mirror: 'cdnjs',
+        url: 'https://cdnjs.cloudflare.com/ajax/libs/acme-ui/1.2.3/',
+        source: 'manual',
+        autoMirrored: false,
+      },
+    ]);
+  });
+
+  it('keeps dry-run shipping side-effect free', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      packageName: 'my-lib',
+      mirrors: ['esm.sh', 'jspm'],
+    })).resolves.toEqual({
+      id: 'dry-run',
+      meta: {
+        urls: [
+          'https://esm.sh/my-lib@1.2.3',
+          'https://ga.jspm.io/npm:my-lib@1.2.3/',
+        ],
+        mirrors: [
+          {
+            mirror: 'esm.sh',
+            url: 'https://esm.sh/my-lib@1.2.3',
+            source: 'npm',
+            autoMirrored: true,
+          },
+          {
+            mirror: 'jspm',
+            url: 'https://ga.jspm.io/npm:my-lib@1.2.3/',
+            source: 'npm',
+            autoMirrored: true,
+          },
+        ],
+      },
+    });
+  });
+
+  it('checks CDN URLs before reporting a real shipment', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, status: 200 })
+      .mockResolvedValueOnce({ ok: false, status: 405 })
+      .mockResolvedValueOnce({ ok: true, status: 206 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(adapter.ship(fakeShipContext({
+      version: '1.2.3',
+      dryRun: false,
+    }) as any, {
+      packageName: 'my-lib',
+      mirrors: ['jsdelivr', 'skypack'],
+    })).resolves.toEqual({
+      id: 'my-lib@1.2.3',
+      url: 'https://cdn.jsdelivr.net/npm/my-lib@1.2.3/',
+      meta: {
+        urls: [
+          'https://cdn.jsdelivr.net/npm/my-lib@1.2.3/',
+          'https://cdn.skypack.dev/my-lib@1.2.3',
+        ],
+        mirrors: [
+          {
+            mirror: 'jsdelivr',
+            url: 'https://cdn.jsdelivr.net/npm/my-lib@1.2.3/',
+            source: 'npm',
+            autoMirrored: true,
+          },
+          {
+            mirror: 'skypack',
+            url: 'https://cdn.skypack.dev/my-lib@1.2.3',
+            source: 'npm',
+            autoMirrored: true,
+          },
+        ],
+        checks: [
+          {
+            mirror: 'jsdelivr',
+            url: 'https://cdn.jsdelivr.net/npm/my-lib@1.2.3/',
+            ok: true,
+            status: 200,
+            method: 'HEAD',
+          },
+          {
+            mirror: 'skypack',
+            url: 'https://cdn.skypack.dev/my-lib@1.2.3',
+            ok: true,
+            status: 206,
+            method: 'GET',
+          },
+        ],
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledWith('https://cdn.jsdelivr.net/npm/my-lib@1.2.3/', {
+      method: 'HEAD',
+      redirect: 'follow',
+    });
+    expect(fetchMock).toHaveBeenCalledWith('https://cdn.skypack.dev/my-lib@1.2.3', {
+      method: 'GET',
+      headers: { range: 'bytes=0-0' },
+      redirect: 'follow',
+    });
+  });
+
+  it('fails real shipments when a mirror does not resolve', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+
+    await expect(adapter.ship(fakeShipContext({
+      version: '1.2.3',
+      dryRun: false,
+    }) as any, {
+      packageName: 'missing-lib',
+      mirrors: ['unpkg'],
+    })).rejects.toThrow('CDN mirror checks failed: unpkg HEAD 404 https://unpkg.com/missing-lib@1.2.3/');
+  });
+
+  it('rejects unsupported mirror names with a clear error', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      packageName: 'my-lib',
+      mirrors: ['made-up-cdn'],
+    } as any)).rejects.toThrow('pkg-cdn unsupported mirror: made-up-cdn');
+  });
+});

--- a/packages/targets/pkg-cdn/src/index.ts
+++ b/packages/targets/pkg-cdn/src/index.ts
@@ -1,15 +1,18 @@
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 // JS/TS CDNs. Most auto-mirror npm, so "publish to CDN" = "publish to
 // npm + verify it resolves." Only cdnjs requires an explicit submission
 // (PR against cdnjs/packages).
 type Mirror = 'jsdelivr' | 'unpkg' | 'esm.sh' | 'cdnjs' | 'skypack' | 'jspm';
+const MIRRORS: readonly Mirror[] = ['jsdelivr', 'unpkg', 'esm.sh', 'cdnjs', 'skypack', 'jspm'];
 
 interface Config {
   packageName: string;                 // npm package name
   mirrors: Mirror[];
   // cdnjs submission inputs (only if 'cdnjs' in mirrors)
-  cdnjs?: { autoupdateSource: 'npm' | 'git'; sourceRepo?: string };
+  cdnjs?: { autoupdateSource: 'npm' | 'git'; sourceRepo?: string; libraryName?: string };
 }
 
 const URL_FOR: Record<Mirror, (pkg: string, v: string) => string> = {
@@ -21,23 +24,139 @@ const URL_FOR: Record<Mirror, (pkg: string, v: string) => string> = {
   jspm: (pkg, v) => `https://ga.jspm.io/npm:${pkg}@${v}/`,
 };
 
+interface MirrorEntry {
+  mirror: Mirror;
+  url: string;
+  source: 'npm' | 'manual';
+  autoMirrored: boolean;
+}
+
+interface CheckResult {
+  mirror: Mirror;
+  url: string;
+  ok: boolean;
+  status: number;
+  method: 'HEAD' | 'GET';
+}
+
+function requirePackageName(config: Config): string {
+  const packageName = config.packageName?.trim();
+  if (!packageName) throw new Error('pkg-cdn requires packageName');
+  return packageName;
+}
+
+function resolveMirrors(config: Config): Mirror[] {
+  if (!config.mirrors?.length) throw new Error('pkg-cdn requires at least one mirror');
+  const mirrors: Mirror[] = [];
+  for (const mirror of config.mirrors) {
+    if (!MIRRORS.includes(mirror)) throw new Error(`pkg-cdn unsupported mirror: ${String(mirror)}`);
+    if (!mirrors.includes(mirror)) mirrors.push(mirror);
+  }
+  return mirrors;
+}
+
+function cdnjsLibraryName(config: Config): string {
+  return config.cdnjs?.libraryName?.trim() || requirePackageName(config).replace(/^@/, '').replace('/', '-');
+}
+
+function resolveEntries(config: Config, version: string): MirrorEntry[] {
+  const packageName = requirePackageName(config);
+  return resolveMirrors(config).map((mirror) => {
+    const url = mirror === 'cdnjs'
+      ? URL_FOR.cdnjs(cdnjsLibraryName(config), version)
+      : URL_FOR[mirror](packageName, version);
+    const autoMirrored = mirror !== 'cdnjs';
+
+    return {
+      mirror,
+      url,
+      source: autoMirrored ? 'npm' : 'manual',
+      autoMirrored,
+    };
+  });
+}
+
+function manifestFor(config: Config, version: string) {
+  const entries = resolveEntries(config, version);
+  const usesCdnjs = entries.some((entry) => entry.mirror === 'cdnjs');
+
+  return {
+    provider: 'pkg-cdn',
+    packageName: requirePackageName(config),
+    version,
+    mirrors: entries,
+    cdnjs: usesCdnjs ? {
+      libraryName: cdnjsLibraryName(config),
+      autoupdateSource: config.cdnjs?.autoupdateSource ?? 'npm',
+      sourceRepo: config.cdnjs?.sourceRepo,
+      requiresManualSubmission: true,
+    } : undefined,
+  };
+}
+
+async function checkMirror(entry: MirrorEntry): Promise<CheckResult> {
+  if (typeof fetch !== 'function') {
+    throw new Error('global fetch is not available for CDN mirror checks');
+  }
+
+  const head = await fetch(entry.url, { method: 'HEAD', redirect: 'follow' });
+  if (head.ok || head.status !== 405) {
+    return {
+      mirror: entry.mirror,
+      url: entry.url,
+      ok: head.ok,
+      status: head.status,
+      method: 'HEAD',
+    };
+  }
+
+  const get = await fetch(entry.url, {
+    method: 'GET',
+    headers: { range: 'bytes=0-0' },
+    redirect: 'follow',
+  });
+
+  return {
+    mirror: entry.mirror,
+    url: entry.url,
+    ok: get.ok,
+    status: get.status,
+    method: 'GET',
+  };
+}
+
 export default defineTarget<Config>({
   id: 'pkg-cdn',
   kind: 'package-manager',
   label: 'JS/TS CDN mirrors (jsDelivr / unpkg / esm.sh / cdnjs / Skypack / JSPM)',
   async build(ctx, config) {
-    ctx.log(`no-op build — CDN mirrors consume the published npm tarball (pkg=${config.packageName})`);
-    return { artifact: `${ctx.outDir}/cdn-manifest.json` };
+    const manifest = manifestFor(config, ctx.version);
+    const artifact = join(ctx.outDir, 'cdn-manifest.json');
+    await mkdir(ctx.outDir, { recursive: true });
+    await writeFile(artifact, `${JSON.stringify(manifest, null, 2)}\n`, 'utf-8');
+    ctx.log(`wrote CDN mirror manifest for ${manifest.packageName}@${ctx.version}`);
+    return { artifact, meta: { urls: manifest.mirrors.map((entry) => entry.url) } };
   },
   async ship(ctx, config) {
-    const urls = config.mirrors.map((m) => URL_FOR[m](config.packageName, ctx.version));
+    const entries = resolveEntries(config, ctx.version);
+    const urls = entries.map((entry) => entry.url);
     ctx.log(`cdn mirrors:\n  ${urls.join('\n  ')}`);
-    if (ctx.dryRun) return { id: 'dry-run', meta: { urls } };
-    // TODO:
-    //  - for each auto-mirror: HEAD request to confirm URL resolves (may take ~minutes after npm publish)
-    //  - if 'cdnjs' in mirrors: clone cdnjs/packages, write packages/<pkg>.json with
-    //    autoupdate config, open PR via GH_TOKEN
-    return { id: `${config.packageName}@${ctx.version}`, meta: { urls } };
+    if (ctx.dryRun) return { id: 'dry-run', meta: { urls, mirrors: entries } };
+
+    const checks = await Promise.all(entries.map(checkMirror));
+    const failures = checks.filter((check) => !check.ok);
+    if (failures.length) {
+      const detail = failures
+        .map((check) => `${check.mirror} ${check.method} ${check.status} ${check.url}`)
+        .join('; ');
+      throw new Error(`CDN mirror checks failed: ${detail}`);
+    }
+
+    return {
+      id: `${requirePackageName(config)}@${ctx.version}`,
+      url: urls[0],
+      meta: { urls, mirrors: entries, checks },
+    };
   },
   async status(id) {
     return { state: 'live', version: id };


### PR DESCRIPTION
## Summary
- turn pkg-cdn build into a real cdn-manifest.json writer
- resolve and de-duplicate CDN mirror URLs, including cdnjs manual-submission metadata
- verify live CDN mirrors during real ship with HEAD checks and GET fallback for 405 responses
- add focused tests for manifest output, dry-run metadata, live checks, failures, and invalid mirrors

## Validation
- corepack pnpm exec vitest run packages/targets/pkg-cdn/src/index.test.ts
- corepack pnpm exec tsc -p packages/targets/pkg-cdn/tsconfig.json --noEmit
- corepack pnpm --filter @profullstack/sh1pt-target-pkg-cdn build
- git diff --check