### PR TITLE
Implement deno.land package target

### DIFF
--- a/packages/targets/pkg-deno/src/index.test.ts
+++ b/packages/targets/pkg-deno/src/index.test.ts
@@ -1,4 +1,140 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { execMock } = vi.hoisted(() => ({
+  execMock: vi.fn(),
+}));
+
+vi.mock('@profullstack/sh1pt-core', async () => ({
+  ...await vi.importActual<typeof import('@profullstack/sh1pt-core')>('@profullstack/sh1pt-core'),
+  exec: execMock,
+}));
+
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'pkg', requireKind: true });
+
+const tempDirs: string[] = [];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('deno.land/x package target', () => {
+  it('writes a git-tag publish plan for deno.land/x', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-deno-'));
+    tempDirs.push(outDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      version: '1.2.3',
+    }) as any, {
+      moduleName: 'my_mod',
+      sourceRepo: 'acme/my-mod',
+      tagPrefix: 'v',
+      remote: 'upstream',
+    });
+
+    expect(result).toEqual({
+      artifact: join(outDir, 'deno-land-publish.json'),
+      meta: {
+        tag: 'v1.2.3',
+        url: 'https://deno.land/x/my_mod@v1.2.3',
+      },
+    });
+
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan).toMatchObject({
+      provider: 'deno.land/x',
+      moduleName: 'my_mod',
+      sourceRepo: 'acme/my-mod',
+      version: '1.2.3',
+      tag: 'v1.2.3',
+      remote: 'upstream',
+      url: 'https://deno.land/x/my_mod@v1.2.3',
+      commands: {
+        tag: ['git', 'tag', 'v1.2.3'],
+        push: ['git', 'push', 'upstream', 'v1.2.3'],
+      },
+    });
+  });
+
+  it('keeps dry-run shipping side-effect free', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      moduleName: 'my_mod',
+      sourceRepo: 'acme/my-mod',
+    })).resolves.toMatchObject({
+      id: 'dry-run',
+      meta: {
+        tag: '1.2.3',
+        remote: 'origin',
+        url: 'https://deno.land/x/my_mod@1.2.3',
+      },
+    });
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  it('creates and pushes the release tag in real ship mode', async () => {
+    execMock
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ exitCode: 0, stdout: '', stderr: '' });
+
+    const ctx = fakeShipContext({
+      projectDir: '/repo',
+      version: '1.2.3',
+      dryRun: false,
+      env: { CI: 'true' },
+    });
+    const result = await adapter.ship(ctx as any, {
+      moduleName: 'my_mod',
+      sourceRepo: 'acme/my-mod',
+      tagPrefix: 'v',
+      remote: 'upstream',
+      tagMessage: 'Release v1.2.3',
+    });
+
+    expect(execMock).toHaveBeenNthCalledWith(1, 'git', ['tag', '-a', 'v1.2.3', '-m', 'Release v1.2.3'], {
+      cwd: '/repo',
+      env: { CI: 'true' },
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+    expect(execMock).toHaveBeenNthCalledWith(2, 'git', ['push', 'upstream', 'v1.2.3'], {
+      cwd: '/repo',
+      env: { CI: 'true' },
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+    expect(result).toEqual({
+      id: 'my_mod@v1.2.3',
+      url: 'https://deno.land/x/my_mod@v1.2.3',
+      meta: {
+        tag: 'v1.2.3',
+        remote: 'upstream',
+        sourceRepo: 'acme/my-mod',
+      },
+    });
+  });
+
+  it('requires module name and linked source repository', async () => {
+    await expect(adapter.build(fakeBuildContext() as any, {
+      moduleName: '',
+      sourceRepo: 'acme/my-mod',
+    })).rejects.toThrow('pkg-deno requires moduleName');
+
+    await expect(adapter.build(fakeBuildContext() as any, {
+      moduleName: 'my_mod',
+      sourceRepo: '',
+    })).rejects.toThrow('pkg-deno requires sourceRepo');
+  });
+});

--- a/packages/targets/pkg-deno/src/index.ts
+++ b/packages/targets/pkg-deno/src/index.ts
@@ -1,4 +1,6 @@
-import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { defineTarget, exec, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 // deno.land/x — the older Deno registry. No real "publish" — it
 // auto-imports from a linked GitHub repo whenever a git tag is pushed
@@ -8,6 +10,47 @@ interface Config {
   moduleName: string;            // registered at deno.land/x/<moduleName>
   sourceRepo: string;            // e.g. 'acme/my-lib' — must be pre-linked
   tagPrefix?: string;            // e.g. 'v' — default: empty
+  remote?: string;               // git remote to push tags to — default: origin
+  tagMessage?: string;           // set to create an annotated tag
+}
+
+function requireValue(value: string | undefined, field: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed) throw new Error(`pkg-deno requires ${field}`);
+  return trimmed;
+}
+
+function tagFor(config: Config, version: string): string {
+  return `${config.tagPrefix ?? ''}${version}`;
+}
+
+function urlFor(config: Config, tag: string): string {
+  return `https://deno.land/x/${requireValue(config.moduleName, 'moduleName')}@${tag}`;
+}
+
+function buildPlan(config: Config, version: string) {
+  const moduleName = requireValue(config.moduleName, 'moduleName');
+  const sourceRepo = requireValue(config.sourceRepo, 'sourceRepo');
+  const remote = config.remote?.trim() || 'origin';
+  const tag = tagFor(config, version);
+  const tagCommand = config.tagMessage
+    ? ['tag', '-a', tag, '-m', config.tagMessage]
+    : ['tag', tag];
+
+  return {
+    provider: 'deno.land/x',
+    moduleName,
+    sourceRepo,
+    version,
+    tag,
+    remote,
+    url: urlFor(config, tag),
+    commands: {
+      tag: ['git', ...tagCommand],
+      push: ['git', 'push', remote, tag],
+    },
+    note: 'deno.land/x imports from the linked GitHub repository when this tag is pushed.',
+  };
 }
 
 export default defineTarget<Config>({
@@ -15,17 +58,35 @@ export default defineTarget<Config>({
   kind: 'sdk',
   label: 'deno.land/x (git-tag registry)',
   async build(ctx, config) {
-    ctx.log(`no-op build — deno.land/x pulls from ${config.sourceRepo} on tag push`);
-    return { artifact: ctx.projectDir };
+    const plan = buildPlan(config, ctx.version);
+    const artifact = join(ctx.outDir, 'deno-land-publish.json');
+    await mkdir(ctx.outDir, { recursive: true });
+    await writeFile(artifact, `${JSON.stringify(plan, null, 2)}\n`, 'utf-8');
+    ctx.log(`wrote deno.land/x tag publish plan for ${plan.moduleName}@${plan.tag}`);
+    return { artifact, meta: { tag: plan.tag, url: plan.url } };
   },
   async ship(ctx, config) {
-    const tag = `${config.tagPrefix ?? ''}${ctx.version}`;
-    ctx.log(`git tag ${tag} + push · deno.land/x/${config.moduleName}@${tag}`);
-    if (ctx.dryRun) return { id: 'dry-run' };
-    // TODO: git tag + git push --tags via GH_TOKEN; deno.land's webhook publishes automatically
+    const plan = buildPlan(config, ctx.version);
+    ctx.log(`git ${plan.commands.tag.slice(1).join(' ')} + git ${plan.commands.push.slice(1).join(' ')} · ${plan.url}`);
+    if (ctx.dryRun) return { id: 'dry-run', meta: plan };
+
+    await exec('git', plan.commands.tag.slice(1), {
+      cwd: ctx.projectDir,
+      env: ctx.env,
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+    await exec('git', plan.commands.push.slice(1), {
+      cwd: ctx.projectDir,
+      env: ctx.env,
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+
     return {
-      id: `${config.moduleName}@${tag}`,
-      url: `https://deno.land/x/${config.moduleName}@${tag}`,
+      id: `${plan.moduleName}@${plan.tag}`,
+      url: plan.url,
+      meta: { tag: plan.tag, remote: plan.remote, sourceRepo: plan.sourceRepo },
     };
   },
 


### PR DESCRIPTION
## Summary
- turn pkg-deno build into a concrete deno.land/x publish-plan writer
- add tag/remote metadata plus optional annotated tag messages
- make real ship create and push the configured git tag so deno.land/x can import it from the linked GitHub repo
- add focused tests for plan output, dry-run behavior, real git commands, and required config fields

## Validation
- corepack pnpm exec vitest run packages/targets/pkg-deno/src/index.test.ts
- corepack pnpm exec tsc -p packages/targets/pkg-deno/tsconfig.json --noEmit
- corepack pnpm --filter @profullstack/sh1pt-target-pkg-deno build
- git diff --check