### PR TITLE
Implement Discord chat target

### DIFF
--- a/packages/targets/chat-discord/src/index.test.ts
+++ b/packages/targets/chat-discord/src/index.test.ts
@@ -1,4 +1,162 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'chat', requireKind: true });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Discord chat target', () => {
+  it('writes a Discord command manifest with invite metadata', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-discord-'));
+    tempDirs.push(outDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      version: '1.2.3',
+    }) as any, {
+      applicationId: '123456',
+      distribution: 'public',
+      interactionsEndpointUrl: 'https://bot.example.com/interactions',
+      permissions: 2048,
+      slashCommands: [
+        { name: '/status', description: 'Show deployment status' },
+      ],
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'discord-commands.json'));
+    expect(result.meta).toEqual({
+      inviteUrl: 'https://discord.com/oauth2/authorize?client_id=123456&scope=bot+applications.commands&permissions=2048',
+      commands: 1,
+    });
+
+    const manifest = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(manifest).toMatchObject({
+      provider: 'discord',
+      applicationId: '123456',
+      version: '1.2.3',
+      distribution: 'public',
+      interactionsEndpointUrl: 'https://bot.example.com/interactions',
+      scopes: ['bot', 'applications.commands'],
+      permissions: 2048,
+      inviteUrl: 'https://discord.com/oauth2/authorize?client_id=123456&scope=bot+applications.commands&permissions=2048',
+      commands: [
+        { name: 'status', description: 'Show deployment status' },
+      ],
+      directoryReviewRequired: false,
+    });
+  });
+
+  it('keeps dry-run shipping side-effect free', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(adapter.ship(fakeShipContext({
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      applicationId: '123456',
+      distribution: 'directory',
+      scopes: ['applications.commands'],
+      slashCommands: [
+        { name: 'ship', description: 'Ship the current release' },
+      ],
+    })).resolves.toMatchObject({
+      id: 'dry-run',
+      meta: {
+        distribution: 'directory',
+        scopes: ['applications.commands'],
+        directoryReviewRequired: true,
+        commands: [
+          { name: 'ship', description: 'Ship the current release' },
+        ],
+      },
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('requires a Discord app token before real shipping', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      dryRun: false,
+    }) as any, {
+      applicationId: '123456',
+      distribution: 'private',
+    })).rejects.toThrow('DISCORD_APP_TOKEN not in vault');
+  });
+
+  it('patches the application and overwrites global slash commands', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, text: async () => '{"id":"123456"}' })
+      .mockResolvedValueOnce({ ok: true, status: 200, text: async () => '[{"id":"cmd"}]' });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.ship(fakeShipContext({
+      version: '1.2.3',
+      dryRun: false,
+      secret: (key: string) => ({ DISCORD_APP_TOKEN: 'discord-token' }[key]),
+    }) as any, {
+      applicationId: '123456',
+      distribution: 'public',
+      interactionsEndpointUrl: 'https://bot.example.com/interactions',
+      permissions: 8,
+      slashCommands: [
+        { name: '/deploy', description: 'Deploy the app', options: [{ name: 'target' }] },
+      ],
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, 'https://discord.com/api/v10/applications/123456', {
+      method: 'PATCH',
+      headers: {
+        authorization: 'Bot discord-token',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        interactions_endpoint_url: 'https://bot.example.com/interactions',
+      }),
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(2, 'https://discord.com/api/v10/applications/123456/commands', {
+      method: 'PUT',
+      headers: {
+        authorization: 'Bot discord-token',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify([
+        { name: 'deploy', description: 'Deploy the app', options: [{ name: 'target' }] },
+      ]),
+    });
+    expect(result).toEqual({
+      id: '123456@1.2.3',
+      url: 'https://discord.com/developers/applications/123456',
+      meta: {
+        inviteUrl: 'https://discord.com/oauth2/authorize?client_id=123456&scope=bot+applications.commands&permissions=8',
+        commands: 1,
+        directoryReviewRequired: false,
+      },
+    });
+  });
+
+  it('surfaces Discord API errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => '{"message":"401: Unauthorized"}',
+    }));
+
+    await expect(adapter.ship(fakeShipContext({
+      version: '1.2.3',
+      dryRun: false,
+      secret: (key: string) => ({ DISCORD_APP_TOKEN: 'bad-token' }[key]),
+    }) as any, {
+      applicationId: '123456',
+      distribution: 'private',
+    })).rejects.toThrow('401: Unauthorized');
+  });
+});

--- a/packages/targets/chat-discord/src/index.ts
+++ b/packages/targets/chat-discord/src/index.ts
@@ -1,4 +1,6 @@
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 // Discord apps — bots, slash commands, message components, modals.
 // Distribution surfaces:
@@ -9,6 +11,7 @@ interface Config {
   applicationId: string;
   distribution: 'private' | 'public' | 'directory';
   interactionsEndpointUrl?: string;      // HTTP interactions target (alternative to gateway)
+  tokenKey?: string;                     // defaults to DISCORD_APP_TOKEN
   slashCommands?: {
     name: string;
     description: string;
@@ -18,24 +21,124 @@ interface Config {
   permissions?: number;                  // bitfield
 }
 
+interface DiscordCommand {
+  name: string;
+  description: string;
+  options?: unknown[];
+}
+
+function requireApplicationId(config: Config): string {
+  const applicationId = config.applicationId?.trim();
+  if (!applicationId) throw new Error('chat-discord requires applicationId');
+  return applicationId;
+}
+
+function normalizeCommands(commands: Config['slashCommands']): DiscordCommand[] {
+  return (commands ?? []).map((command) => {
+    const name = command.name.replace(/^\//, '').trim().toLowerCase();
+    if (!name) throw new Error('chat-discord slash command name is required');
+    const description = command.description.trim();
+    if (!description) throw new Error(`chat-discord slash command "${name}" requires description`);
+
+    return {
+      name,
+      description,
+      ...(command.options ? { options: command.options } : {}),
+    };
+  });
+}
+
+function scopesFor(config: Config): string[] {
+  return config.scopes?.length ? config.scopes : ['bot', 'applications.commands'];
+}
+
+function inviteUrl(config: Config): string {
+  const query = new URLSearchParams({
+    client_id: requireApplicationId(config),
+    scope: scopesFor(config).join(' '),
+    permissions: String(config.permissions ?? 0),
+  });
+  return `https://discord.com/oauth2/authorize?${query.toString()}`;
+}
+
+function manifestFor(config: Config, version: string) {
+  const commands = normalizeCommands(config.slashCommands);
+  return {
+    provider: 'discord',
+    applicationId: requireApplicationId(config),
+    version,
+    distribution: config.distribution,
+    interactionsEndpointUrl: config.interactionsEndpointUrl,
+    scopes: scopesFor(config),
+    permissions: config.permissions ?? 0,
+    inviteUrl: inviteUrl(config),
+    commands,
+    directoryReviewRequired: config.distribution === 'directory',
+  };
+}
+
+async function callDiscord<T>(
+  token: string,
+  method: 'PATCH' | 'PUT',
+  path: string,
+  body: Record<string, unknown> | DiscordCommand[],
+): Promise<T | undefined> {
+  if (typeof fetch !== 'function') throw new Error('global fetch is not available for Discord API calls');
+
+  const res = await fetch(`https://discord.com/api/v10${path}`, {
+    method,
+    headers: {
+      authorization: `Bot ${token}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  const data = text ? JSON.parse(text) as { message?: string } & T : undefined;
+  if (!res.ok) {
+    const message = data && 'message' in data ? data.message : undefined;
+    throw new Error(message ?? `Discord ${method} ${path} failed (${res.status})`);
+  }
+  return data as T | undefined;
+}
+
 export default defineTarget<Config>({
   id: 'chat-discord',
   kind: 'chat',
   label: 'Discord App Directory',
   async build(ctx, config) {
-    ctx.log(`render discord command manifest · ${config.slashCommands?.length ?? 0} commands`);
-    return { artifact: `${ctx.outDir}/discord-commands.json` };
+    const manifest = manifestFor(config, ctx.version);
+    const artifact = join(ctx.outDir, 'discord-commands.json');
+    await mkdir(ctx.outDir, { recursive: true });
+    await writeFile(artifact, `${JSON.stringify(manifest, null, 2)}\n`, 'utf-8');
+    ctx.log(`rendered discord command manifest · ${manifest.commands.length} commands`);
+    return { artifact, meta: { inviteUrl: manifest.inviteUrl, commands: manifest.commands.length } };
   },
   async ship(ctx, config) {
-    ctx.log(`discord · bulk overwrite commands + update application${config.distribution === 'directory' ? ' + submit for review' : ''}`);
-    if (ctx.dryRun) return { id: 'dry-run' };
-    // TODO:
-    //  - PUT /applications/:id/commands (bulk overwrite global slash commands)
-    //  - PATCH /applications/:id (description, icon, tags, interactions URL)
-    //  - if distribution='directory': apps.submit via Developer Portal (manual UI currently)
+    const manifest = manifestFor(config, ctx.version);
+    ctx.log(`discord · bulk overwrite ${manifest.commands.length} commands${manifest.interactionsEndpointUrl ? ' + update interactions endpoint' : ''}`);
+    if (ctx.dryRun) return { id: 'dry-run', meta: manifest };
+
+    const tokenKey = config.tokenKey ?? 'DISCORD_APP_TOKEN';
+    const token = ctx.secret(tokenKey);
+    if (!token) throw new Error(`${tokenKey} not in vault — run: sh1pt secret set ${tokenKey} <bot-token>`);
+
+    if (manifest.interactionsEndpointUrl) {
+      await callDiscord(token, 'PATCH', `/applications/${manifest.applicationId}`, {
+        interactions_endpoint_url: manifest.interactionsEndpointUrl,
+      });
+    }
+
+    await callDiscord(token, 'PUT', `/applications/${manifest.applicationId}/commands`, manifest.commands);
+
     return {
-      id: `${config.applicationId}@${ctx.version}`,
-      url: `https://discord.com/developers/applications/${config.applicationId}`,
+      id: `${manifest.applicationId}@${ctx.version}`,
+      url: `https://discord.com/developers/applications/${manifest.applicationId}`,
+      meta: {
+        inviteUrl: manifest.inviteUrl,
+        commands: manifest.commands.length,
+        directoryReviewRequired: manifest.directoryReviewRequired,
+      },
     };
   },
   async status(id) {


### PR DESCRIPTION
## Summary
- write a real Discord command/application manifest during build
- generate OAuth invite metadata with scopes and permissions
- sync global slash commands through Discord REST during real ship
- optionally patch the interactions endpoint and expose directory-review metadata
- add focused tests for manifest output, dry-run behavior, token guard, API calls, and API errors

## Validation
- corepack pnpm exec vitest run packages/targets/chat-discord/src/index.test.ts
- corepack pnpm exec tsc -p packages/targets/chat-discord/tsconfig.json --noEmit
- corepack pnpm --filter @profullstack/sh1pt-target-chat-discord build
- git diff --check