### PR TITLE
Stage static web artifacts

### DIFF
--- a/packages/targets/web-static/src/index.test.ts
+++ b/packages/targets/web-static/src/index.test.ts
@@ -1,4 +1,109 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'web', requireKind: true });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('static web target', () => {
+  it('copies a prebuilt site into the output directory and writes a manifest', async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-web-project-'));
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-web-out-'));
+    tempDirs.push(projectDir, outDir);
+    await mkdir(join(projectDir, 'dist', 'assets'), { recursive: true });
+    await writeFile(join(projectDir, 'dist', 'index.html'), '<h1>Hello</h1>\n', 'utf-8');
+    await writeFile(join(projectDir, 'dist', 'assets', 'app.js'), 'console.log("hi");\n', 'utf-8');
+
+    const result = await adapter.build(fakeBuildContext({
+      projectDir,
+      outDir,
+      version: '1.2.3',
+    }) as any, {
+      dir: 'dist',
+      provider: 'cloudflare-pages',
+      project: 'site',
+      domain: 'example.com',
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'static'));
+    expect(result.meta).toEqual({
+      files: 2,
+      manifest: join(outDir, 'web-static-manifest.json'),
+    });
+    await expect(readFile(join(outDir, 'static', 'index.html'), 'utf-8')).resolves.toBe('<h1>Hello</h1>\n');
+    await expect(readFile(join(outDir, 'static', 'assets', 'app.js'), 'utf-8')).resolves.toBe('console.log("hi");\n');
+
+    const manifest = JSON.parse(await readFile(join(outDir, 'web-static-manifest.json'), 'utf-8'));
+    expect(manifest).toMatchObject({
+      provider: 'cloudflare-pages',
+      project: 'site',
+      domain: 'example.com',
+      artifact: join(outDir, 'static'),
+      version: '1.2.3',
+      files: ['assets/app.js', 'index.html'],
+    });
+  });
+
+  it('keeps dry-run shipping side-effect free with provider metadata', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      artifact: '/repo/.sh1pt/out/static',
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      dir: 'dist',
+      provider: 'netlify',
+      project: 'docs',
+      domain: 'docs.example.com',
+    })).resolves.toEqual({
+      id: 'dry-run',
+      url: 'https://docs.example.com',
+      meta: {
+        provider: 'netlify',
+        project: 'docs',
+      },
+    });
+  });
+
+  it('returns the staged artifact and production URL in real ship mode', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      artifact: '/repo/.sh1pt/out/static',
+      version: '1.2.3',
+      dryRun: false,
+    }) as any, {
+      dir: 'dist',
+      provider: 's3-cloudfront',
+      project: 'site',
+      domain: 'example.com',
+    })).resolves.toEqual({
+      id: 's3-cloudfront:1.2.3',
+      url: 'https://example.com',
+      meta: {
+        artifact: '/repo/.sh1pt/out/static',
+        provider: 's3-cloudfront',
+        project: 'site',
+      },
+    });
+  });
+
+  it('requires an existing source directory', async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-web-project-'));
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-web-out-'));
+    tempDirs.push(projectDir, outDir);
+
+    await expect(adapter.build(fakeBuildContext({
+      projectDir,
+      outDir,
+    }) as any, {
+      dir: 'missing',
+      provider: 'vercel',
+    })).rejects.toThrow('ENOENT');
+  });
+});

--- a/packages/targets/web-static/src/index.ts
+++ b/packages/targets/web-static/src/index.ts
@@ -1,4 +1,6 @@
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { cp, mkdir, readdir, stat, writeFile } from 'node:fs/promises';
+import { join, relative, resolve } from 'node:path';
 
 interface Config {
   dir: string;                 // built output directory
@@ -7,22 +9,66 @@ interface Config {
   domain?: string;
 }
 
+async function listFiles(root: string, dir = root): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(entries.map(async (entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return listFiles(root, path);
+    if (entry.isFile()) return [relative(root, path)];
+    return [];
+  }));
+  return files.flat().sort();
+}
+
+function resolveSourceDir(ctx: { projectDir: string }, dir: string): string {
+  if (!dir?.trim()) throw new Error('web-static requires dir');
+  return resolve(ctx.projectDir, dir);
+}
+
+function siteUrl(config: Config): string | undefined {
+  return config.domain ? `https://${config.domain}` : undefined;
+}
+
 export default defineTarget<Config>({
   id: 'web-static',
   kind: 'web',
   label: 'Static web (CDN)',
   async build(ctx, config) {
-    ctx.log(`assume prebuilt site in ${config.dir}`);
-    // TODO: optionally run a user-defined build command; copy dir into ctx.outDir
-    return { artifact: config.dir };
+    const sourceDir = resolveSourceDir(ctx, config.dir);
+    const info = await stat(sourceDir);
+    if (!info.isDirectory()) throw new Error(`web-static dir is not a directory: ${sourceDir}`);
+
+    const artifact = join(ctx.outDir, 'static');
+    await mkdir(ctx.outDir, { recursive: true });
+    await cp(sourceDir, artifact, { recursive: true, force: true });
+
+    const files = await listFiles(artifact);
+    const manifest = {
+      provider: config.provider,
+      project: config.project,
+      domain: config.domain,
+      sourceDir,
+      artifact,
+      version: ctx.version,
+      files,
+    };
+    await writeFile(join(ctx.outDir, 'web-static-manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf-8');
+    ctx.log(`staged static site from ${sourceDir} · files=${files.length}`);
+    return { artifact, meta: { files: files.length, manifest: join(ctx.outDir, 'web-static-manifest.json') } };
   },
   async ship(ctx, config) {
-    ctx.log(`deploy to ${config.provider}${config.project ? `/${config.project}` : ''}`);
-    if (ctx.dryRun) return { id: 'dry-run' };
-    // TODO: dispatch to per-provider deploy (wrangler / netlify / s3 sync / vercel)
+    const url = siteUrl(config);
+    const project = config.project ? `/${config.project}` : '';
+    ctx.log(`static site ready for ${config.provider}${project}${url ? ` · ${url}` : ''}`);
+    if (ctx.dryRun) return { id: 'dry-run', url, meta: { provider: config.provider, project: config.project } };
     return {
       id: `${config.provider}:${ctx.version}`,
-      url: config.domain ? `https://${config.domain}` : undefined,
+      url,
+      meta: {
+        artifact: ctx.artifact,
+        provider: config.provider,
+        project: config.project,
+      },
     };
   },
 


### PR DESCRIPTION
## Summary
- copy the configured prebuilt static site into the sh1pt output directory during build
- write a web-static-manifest.json with provider, project/domain, source, artifact, version, and file list
- return file-count/manifest metadata from build and provider/artifact metadata from ship
- add focused tests for staging, manifest output, dry-run ship metadata, real ship metadata, and missing directories

## Validation
- corepack pnpm exec vitest run packages/targets/web-static/src/index.test.ts
- corepack pnpm exec tsc -p packages/targets/web-static/tsconfig.json --noEmit
- corepack pnpm --filter @profullstack/sh1pt-target-web-static build
- git diff --check