### PR TITLE
Generate webOS package plans

### DIFF
--- a/packages/targets/tv-webos/src/index.test.ts
+++ b/packages/targets/tv-webos/src/index.test.ts
@@ -1,4 +1,124 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'tv', requireKind: true });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('webOS TV target', () => {
+  it('validates appinfo.json and writes a package plan', async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-webos-project-'));
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-webos-out-'));
+    tempDirs.push(projectDir, outDir);
+    await mkdir(join(projectDir, 'webos'), { recursive: true });
+    await writeFile(join(projectDir, 'webos', 'index.html'), '<main></main>\n', 'utf-8');
+    await writeFile(join(projectDir, 'webos', 'icon.png'), 'png', 'utf-8');
+    await writeFile(join(projectDir, 'webos', 'appinfo.json'), JSON.stringify({
+      id: 'com.acme.tv',
+      version: '1.2.3',
+      title: 'Acme TV',
+      vendor: 'Acme',
+      main: 'index.html',
+      icon: 'icon.png',
+      type: 'web',
+    }), 'utf-8');
+
+    const result = await adapter.build(fakeBuildContext({
+      projectDir,
+      outDir,
+      version: '1.2.3',
+    }) as any, {
+      appId: 'com.acme.tv',
+      sourceDir: 'webos',
+      submission: 'developer-mode',
+      deviceName: 'living-room',
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'webos-package-plan.json'));
+    expect(result.meta).toEqual({
+      expectedPackage: join(outDir, 'com.acme.tv_1.2.3.ipk'),
+      command: ['ares-package', '-o', outDir, join(projectDir, 'webos')],
+    });
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan).toMatchObject({
+      provider: 'webos',
+      appId: 'com.acme.tv',
+      title: 'Acme TV',
+      version: '1.2.3',
+      sourceDir: join(projectDir, 'webos'),
+      submission: 'developer-mode',
+      deviceName: 'living-room',
+      expectedPackage: join(outDir, 'com.acme.tv_1.2.3.ipk'),
+      command: ['ares-package', '-o', outDir, join(projectDir, 'webos')],
+      installCommand: ['ares-install', '--device', 'living-room', join(outDir, 'com.acme.tv_1.2.3.ipk')],
+    });
+  });
+
+  it('keeps dry-run shipping side-effect free', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      dryRun: true,
+    }) as any, {
+      appId: 'com.acme.tv',
+      sourceDir: 'webos',
+      submission: 'lg-content-store',
+      developerId: 'seller-123',
+    })).resolves.toEqual({
+      id: 'dry-run',
+      meta: {
+        submission: 'lg-content-store',
+      },
+    });
+  });
+
+  it('returns package metadata in real ship mode', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      artifact: '/repo/.sh1pt/out/webos-package-plan.json',
+      version: '1.2.3',
+      dryRun: false,
+    }) as any, {
+      appId: 'com.acme.tv',
+      sourceDir: 'webos',
+      submission: 'developer-mode',
+      deviceName: 'living-room',
+    })).resolves.toEqual({
+      id: 'com.acme.tv@1.2.3',
+      meta: {
+        artifact: '/repo/.sh1pt/out/webos-package-plan.json',
+        submission: 'developer-mode',
+        developerId: undefined,
+        deviceName: 'living-room',
+      },
+    });
+  });
+
+  it('rejects appinfo.json that does not match the configured app id', async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-webos-project-'));
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-webos-out-'));
+    tempDirs.push(projectDir, outDir);
+    await mkdir(join(projectDir, 'webos'), { recursive: true });
+    await writeFile(join(projectDir, 'webos', 'index.html'), '<main></main>\n', 'utf-8');
+    await writeFile(join(projectDir, 'webos', 'appinfo.json'), JSON.stringify({
+      id: 'com.other.tv',
+      version: '1.2.3',
+      title: 'Other TV',
+      main: 'index.html',
+    }), 'utf-8');
+
+    await expect(adapter.build(fakeBuildContext({
+      projectDir,
+      outDir,
+    }) as any, {
+      appId: 'com.acme.tv',
+      sourceDir: 'webos',
+      submission: 'developer-mode',
+    })).rejects.toThrow('webOS appinfo.json id must match appId');
+  });
+});

--- a/packages/targets/tv-webos/src/index.ts
+++ b/packages/targets/tv-webos/src/index.ts
@@ -1,4 +1,6 @@
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { access, mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
 
 // webOS apps are HTML/CSS/JS — a great fit for React codebases via Enact
 // (LG's React-based framework) or vanilla web. Packaged as .ipk using
@@ -8,6 +10,63 @@ interface Config {
   sourceDir: string;                                  // built web app
   submission: 'lg-content-store' | 'developer-mode';  // dev-mode = sideload
   developerId?: string;                               // LG Seller Lounge id
+  deviceName?: string;                                // ares device name for developer-mode sideloads
+}
+
+interface WebOsAppInfo {
+  id?: string;
+  version?: string;
+  title?: string;
+  vendor?: string;
+  main?: string;
+  icon?: string;
+  type?: string;
+}
+
+function requireValue(value: string | undefined, field: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed) throw new Error(`tv-webos requires ${field}`);
+  return trimmed;
+}
+
+async function readAppInfo(sourceDir: string, appId: string): Promise<WebOsAppInfo> {
+  const appInfoPath = join(sourceDir, 'appinfo.json');
+  const appInfo = JSON.parse(await readFile(appInfoPath, 'utf-8')) as WebOsAppInfo;
+  if (appInfo.id !== appId) {
+    throw new Error(`webOS appinfo.json id must match appId (${appId})`);
+  }
+  requireValue(appInfo.version, 'appinfo.version');
+  requireValue(appInfo.title, 'appinfo.title');
+  requireValue(appInfo.main, 'appinfo.main');
+  await access(join(sourceDir, appInfo.main!));
+  if (appInfo.icon) await access(join(sourceDir, appInfo.icon));
+  return appInfo;
+}
+
+async function packagePlan(ctx: { projectDir: string; outDir: string; version: string }, config: Config) {
+  const appId = requireValue(config.appId, 'appId');
+  const sourceDir = resolve(ctx.projectDir, requireValue(config.sourceDir, 'sourceDir'));
+  const info = await stat(sourceDir);
+  if (!info.isDirectory()) throw new Error(`tv-webos sourceDir is not a directory: ${sourceDir}`);
+  const appInfo = await readAppInfo(sourceDir, appId);
+  const packageName = `${appId}_${appInfo.version ?? ctx.version}.ipk`;
+  const expectedPackage = join(ctx.outDir, packageName);
+
+  return {
+    provider: 'webos',
+    appId,
+    title: appInfo.title,
+    version: appInfo.version,
+    sourceDir,
+    submission: config.submission,
+    developerId: config.developerId,
+    deviceName: config.deviceName,
+    expectedPackage,
+    command: ['ares-package', '-o', ctx.outDir, sourceDir],
+    installCommand: config.submission === 'developer-mode'
+      ? ['ares-install', '--device', config.deviceName ?? 'default', expectedPackage]
+      : undefined,
+  };
 }
 
 export default defineTarget<Config>({
@@ -15,21 +74,26 @@ export default defineTarget<Config>({
   kind: 'tv',
   label: 'LG Content Store (webOS)',
   async build(ctx, config) {
-    ctx.log(`ares-package ${config.sourceDir} → .ipk`);
-    // TODO:
-    //  - validate appinfo.json (id, version, vendor, main, icon sizes)
-    //  - `ares-package -o <out> <sourceDir>` → .ipk
-    return { artifact: `${ctx.outDir}/${config.appId}.ipk` };
+    const plan = await packagePlan(ctx, config);
+    await mkdir(ctx.outDir, { recursive: true });
+    const artifact = join(ctx.outDir, 'webos-package-plan.json');
+    await writeFile(artifact, `${JSON.stringify(plan, null, 2)}\n`, 'utf-8');
+    ctx.log(`validated webOS appinfo.json for ${plan.appId}@${plan.version}`);
+    return { artifact, meta: { expectedPackage: plan.expectedPackage, command: plan.command } };
   },
   async ship(ctx, config) {
-    const dest = config.submission === 'developer-mode' ? 'devkit (sideload)' : 'LG Content Store review';
-    ctx.log(`publish ${config.appId}@${ctx.version} → ${dest}`);
-    if (ctx.dryRun) return { id: 'dry-run' };
-    // TODO:
-    //  - developer-mode: `ares-install` to paired dev-enabled TV
-    //  - content-store: LG Seller Lounge submission API (manual upload currently;
-    //    scrape-free API is limited — may require browser-driven submission in v0)
-    return { id: `${config.appId}@${ctx.version}` };
+    const dest = config.submission === 'developer-mode' ? 'devkit sideload' : 'LG Content Store review';
+    ctx.log(`webOS package ready for ${dest}`);
+    if (ctx.dryRun) return { id: 'dry-run', meta: { submission: config.submission } };
+    return {
+      id: `${config.appId}@${ctx.version}`,
+      meta: {
+        artifact: ctx.artifact,
+        submission: config.submission,
+        developerId: config.developerId,
+        deviceName: config.deviceName,
+      },
+    };
   },
   async status(id) {
     return { state: 'in-review', version: id };


### PR DESCRIPTION
## Summary
- validate webOS appinfo.json against the configured app id and required fields
- verify referenced main/icon files exist before packaging
- write a webos-package-plan.json with source, expected .ipk path, ares package command, and developer-mode install command
- return package-plan metadata from build and submission metadata from ship
- add focused tests for plan output, dry-run ship, real ship metadata, and app id validation failures

## Validation
- corepack pnpm exec vitest run packages/targets/tv-webos/src/index.test.ts
- corepack pnpm exec tsc -p packages/targets/tv-webos/tsconfig.json --noEmit
- corepack pnpm --filter @profullstack/sh1pt-target-tv-webos build
- git diff --check