### PR TITLE
Generate Roku package plans

### DIFF
--- a/packages/targets/tv-roku/src/index.test.ts
+++ b/packages/targets/tv-roku/src/index.test.ts
@@ -1,4 +1,129 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'tv', requireKind: true });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Roku TV target', () => {
+  it('validates the Roku manifest and writes a package plan', async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-roku-project-'));
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-roku-out-'));
+    tempDirs.push(projectDir, outDir);
+    await mkdir(join(projectDir, 'roku', 'components'), { recursive: true });
+    await mkdir(join(projectDir, 'roku', 'images'), { recursive: true });
+    await writeFile(join(projectDir, 'roku', 'components', 'MainScene.xml'), '<component />\n', 'utf-8');
+    await writeFile(join(projectDir, 'roku', 'images', 'icon.png'), 'png', 'utf-8');
+    await writeFile(join(projectDir, 'roku', 'manifest'), [
+      'title=Acme Channel',
+      'major_version=1',
+      'minor_version=2',
+      'build_version=3',
+      'mm_icon_focus_hd=images/icon.png',
+      '',
+    ].join('\n'), 'utf-8');
+
+    const result = await adapter.build(fakeBuildContext({
+      projectDir,
+      outDir,
+      version: '1.2.3',
+    }) as any, {
+      developerId: 'dev-123',
+      sourceDir: 'roku',
+      channelType: 'beta',
+      channelId: 'channel-456',
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'roku-package-plan.json'));
+    expect(result.meta).toEqual({
+      expectedPackage: join(outDir, 'roku-channel.zip'),
+      files: 3,
+      command: ['zip', '-r', join(outDir, 'roku-channel.zip'), '.'],
+    });
+
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan).toMatchObject({
+      provider: 'roku',
+      title: 'Acme Channel',
+      version: '1.2.3',
+      channelId: 'channel-456',
+      developerId: 'dev-123',
+      channelType: 'beta',
+      sourceDir: join(projectDir, 'roku'),
+      expectedPackage: join(outDir, 'roku-channel.zip'),
+      command: ['zip', '-r', join(outDir, 'roku-channel.zip'), '.'],
+      submission: 'beta channel',
+    });
+    expect(plan.files).toEqual([
+      'components/MainScene.xml',
+      'images/icon.png',
+      'manifest',
+    ]);
+  });
+
+  it('keeps dry-run shipping side-effect free', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      dryRun: true,
+    }) as any, {
+      developerId: 'dev-123',
+      sourceDir: 'roku',
+      channelType: 'public',
+    })).resolves.toEqual({
+      id: 'dry-run',
+      meta: {
+        channelType: 'public',
+        destination: 'Roku Channel Store review',
+      },
+    });
+  });
+
+  it('returns package metadata in real ship mode', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      artifact: '/repo/.sh1pt/out/roku-package-plan.json',
+      version: '1.2.3',
+      dryRun: false,
+    }) as any, {
+      developerId: 'dev-123',
+      sourceDir: 'roku',
+      channelType: 'private',
+      channelId: 'channel-456',
+    })).resolves.toEqual({
+      id: 'channel-456@1.2.3',
+      meta: {
+        artifact: '/repo/.sh1pt/out/roku-package-plan.json',
+        channelType: 'private',
+        destination: 'private channel',
+        developerId: 'dev-123',
+      },
+    });
+  });
+
+  it('requires a manifest title', async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-roku-project-'));
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-roku-out-'));
+    tempDirs.push(projectDir, outDir);
+    await mkdir(join(projectDir, 'roku'), { recursive: true });
+    await writeFile(join(projectDir, 'roku', 'manifest'), [
+      'major_version=1',
+      'minor_version=2',
+      '',
+    ].join('\n'), 'utf-8');
+
+    await expect(adapter.build(fakeBuildContext({
+      projectDir,
+      outDir,
+    }) as any, {
+      developerId: 'dev-123',
+      sourceDir: 'roku',
+      channelType: 'private',
+    })).rejects.toThrow('tv-roku requires manifest title');
+  });
+});

--- a/packages/targets/tv-roku/src/index.ts
+++ b/packages/targets/tv-roku/src/index.ts
@@ -1,4 +1,6 @@
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { access, mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { join, relative, resolve } from 'node:path';
 
 // Roku apps run on BrightScript + SceneGraph. Unlike tvOS / Android TV /
 // Fire TV, there is no supported React runtime on Roku OS — react-tv is
@@ -15,25 +17,93 @@ interface Config {
   channelType: 'public' | 'beta' | 'private';
 }
 
+type RokuManifest = Record<string, string>;
+
+function requireValue(value: string | undefined, field: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed) throw new Error(`tv-roku requires ${field}`);
+  return trimmed;
+}
+
+function parseManifest(text: string): RokuManifest {
+  const manifest: RokuManifest = {};
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const index = line.indexOf('=');
+    if (index < 1) continue;
+    manifest[line.slice(0, index).trim()] = line.slice(index + 1).trim();
+  }
+  return manifest;
+}
+
+async function listFiles(root: string, dir = root): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(entries.map(async (entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return listFiles(root, path);
+    if (entry.isFile()) return [relative(root, path)];
+    return [];
+  }));
+  return files.flat().sort();
+}
+
+async function packagePlan(ctx: { projectDir: string; outDir: string; version: string }, config: Config) {
+  const developerId = requireValue(config.developerId, 'developerId');
+  const sourceDir = resolve(ctx.projectDir, requireValue(config.sourceDir, 'sourceDir'));
+  const info = await stat(sourceDir);
+  if (!info.isDirectory()) throw new Error(`tv-roku sourceDir is not a directory: ${sourceDir}`);
+
+  const manifest = parseManifest(await readFile(join(sourceDir, 'manifest'), 'utf-8'));
+  const title = requireValue(manifest.title, 'manifest title');
+  const major = requireValue(manifest.major_version, 'manifest major_version');
+  const minor = requireValue(manifest.minor_version, 'manifest minor_version');
+  const build = manifest.build_version ?? ctx.version;
+  const icon = manifest.mm_icon_focus_hd ?? manifest.mm_icon_focus_sd ?? manifest.icon_focus_hd;
+  if (icon) await access(join(sourceDir, icon));
+
+  const files = await listFiles(sourceDir);
+  const expectedPackage = join(ctx.outDir, 'roku-channel.zip');
+  return {
+    provider: 'roku',
+    title,
+    version: `${major}.${minor}.${build}`,
+    channelId: config.channelId,
+    developerId,
+    channelType: config.channelType,
+    sourceDir,
+    expectedPackage,
+    files,
+    command: ['zip', '-r', expectedPackage, '.'],
+    submission: config.channelType === 'public' ? 'Roku Channel Store review' : `${config.channelType} channel`,
+  };
+}
+
 export default defineTarget<Config>({
   id: 'tv-roku',
   kind: 'tv',
   label: 'Roku Channel Store',
   async build(ctx, config) {
-    ctx.log(`zip Roku channel from ${config.sourceDir}`);
-    // TODO:
-    //  - validate manifest file (title, version, icon sizes, subtype)
-    //  - zip sourceDir into a .zip Roku-Package
-    return { artifact: `${ctx.outDir}/channel.zip` };
+    const plan = await packagePlan(ctx, config);
+    await mkdir(ctx.outDir, { recursive: true });
+    const artifact = join(ctx.outDir, 'roku-package-plan.json');
+    await writeFile(artifact, `${JSON.stringify(plan, null, 2)}\n`, 'utf-8');
+    ctx.log(`validated Roku manifest for ${plan.title}@${plan.version} · files=${plan.files.length}`);
+    return { artifact, meta: { expectedPackage: plan.expectedPackage, files: plan.files.length, command: plan.command } };
   },
   async ship(ctx, config) {
     const dest = config.channelType === 'public' ? 'Roku Channel Store review' : `${config.channelType} channel`;
-    ctx.log(`upload channel → ${dest}`);
-    if (ctx.dryRun) return { id: 'dry-run' };
-    // TODO:
-    //  - Roku Developer Dashboard API: create/update submission → upload zip → submit
-    //  - beta/private channels skip public review but still require vetting
-    return { id: `${config.channelId ?? 'pending'}@${ctx.version}` };
+    ctx.log(`Roku package ready for ${dest}`);
+    if (ctx.dryRun) return { id: 'dry-run', meta: { channelType: config.channelType, destination: dest } };
+    return {
+      id: `${config.channelId ?? 'pending'}@${ctx.version}`,
+      meta: {
+        artifact: ctx.artifact,
+        channelType: config.channelType,
+        destination: dest,
+        developerId: config.developerId,
+      },
+    };
   },
   async status(id) {
     return { state: 'in-review', version: id };


### PR DESCRIPTION
## Summary
- validate Roku channel source directories and parse the Roku manifest file
- require title and version fields and verify referenced focus icon assets when present
- write a roku-package-plan.json with package file list, expected zip path, zip command, and submission metadata
- return package-plan metadata from build and channel submission metadata from ship
- add focused tests for plan output, dry-run ship, real ship metadata, and manifest validation failures

## Validation
- corepack pnpm exec vitest run packages/targets/tv-roku/src/index.test.ts
- corepack pnpm exec tsc -p packages/targets/tv-roku/tsconfig.json --noEmit
- corepack pnpm --filter @profullstack/sh1pt-target-tv-roku build
- git diff --check