### PR TITLE
Add JSON output for remaining CLI list/status commands

### DIFF
--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -43,7 +43,12 @@ const paymentsCmd = configCmd
 paymentsCmd
   .command('list')
   .description('Show enabled providers and which is the default')
-  .action(() => {
+  .option('--json')
+  .action((opts: { json?: boolean }) => {
+    if (opts.json) {
+      console.log(JSON.stringify({ providers: [], defaultProvider: null }, null, 2));
+      return;
+    }
     console.log(kleur.dim('[stub] config payments list — read manifest.payments'));
   });
 
@@ -86,7 +91,12 @@ const stackCmd = configCmd
 stackCmd
   .command('list')
   .description('Supported and planned stacks')
-  .action(() => {
+  .option('--json')
+  .action((opts: { json?: boolean }) => {
+    if (opts.json) {
+      console.log(JSON.stringify({ stacks: STACKS }, null, 2));
+      return;
+    }
     for (const s of STACKS) {
       const icon = s.supported ? kleur.green('●') : kleur.gray('○');
       const label = s.supported ? kleur.bold(s.title) : kleur.dim(s.title);

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -79,6 +79,11 @@ deployCmd
   .command('status <instanceId>')
   .description('Check instance health + hourly cost')
   .requiredOption('--provider <id>')
-  .action((id: string, opts: { provider: string }) => {
+  .option('--json')
+  .action((id: string, opts: { provider: string; json?: boolean }) => {
+    if (opts.json) {
+      console.log(JSON.stringify({ instanceId: id, provider: opts.provider, status: 'unknown', health: null, hourlyCost: null }, null, 2));
+      return;
+    }
     console.log(kleur.dim(`[stub] deploy status ${id} on ${opts.provider}`));
   });

--- a/packages/cli/src/commands/entity.ts
+++ b/packages/cli/src/commands/entity.ts
@@ -123,14 +123,24 @@ complianceCmd
   .command('list <slug>')
   .description('Show open / overdue / upcoming compliance tasks')
   .option('--status <status>', 'filter by status (open, blocked, submitted, complete, overdue)')
-  .action((slug: string, opts: { status?: string }) => {
+  .option('--json')
+  .action((slug: string, opts: { status?: string; json?: boolean }) => {
+    if (opts.json) {
+      console.log(JSON.stringify({ entity: slug, status: opts.status ?? null, tasks: [] }, null, 2));
+      return;
+    }
     console.log(kleur.dim(`[stub] entity compliance list ${slug}${opts.status ? ` · ${opts.status}` : ''}`));
   });
 
 entityCmd
   .command('status <slug>')
   .description('Show the entity lifecycle state (draft → planned → packet-ready → ... → active)')
-  .action((slug: string) => {
+  .option('--json')
+  .action((slug: string, opts: { json?: boolean }) => {
+    if (opts.json) {
+      console.log(JSON.stringify({ entity: slug, state: 'unknown' }, null, 2));
+      return;
+    }
     console.log(kleur.dim(`[stub] entity status ${slug}`));
   });
 

--- a/packages/cli/src/commands/json-output.test.ts
+++ b/packages/cli/src/commands/json-output.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import type { Command } from 'commander';
+import { buildCmd } from './build.js';
+import { configCmd } from './config.js';
+import { promoteCmd } from './promote.js';
+import { scaleCmd } from './scale.js';
+
+const roots = [buildCmd, configCmd, promoteCmd, scaleCmd];
+
+function walk(command: Command, path: string[] = []): Array<{ path: string[]; command: Command }> {
+  const current = [...path, command.name()];
+  return [
+    { path: current, command },
+    ...command.commands.flatMap((child) => walk(child, current)),
+  ];
+}
+
+function hasJsonOption(command: Command): boolean {
+  return command.options.some((option) => option.long === '--json');
+}
+
+describe('CLI JSON output convention', () => {
+  it('adds --json to every list and status subcommand under the primary verbs', () => {
+    const missing = roots
+      .flatMap((root) => walk(root))
+      .filter(({ path }) => ['list', 'status'].includes(path.at(-1) ?? ''))
+      .filter(({ command }) => !hasJsonOption(command))
+      .map(({ path }) => path.join(' '));
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/ship.ts
+++ b/packages/cli/src/commands/ship.ts
@@ -149,7 +149,12 @@ targetSubCmd
 targetSubCmd
   .command('list')
   .description('List enabled targets for this project')
-  .action(() => {
+  .option('--json')
+  .action((opts: { json?: boolean }) => {
+    if (opts.json) {
+      console.log(JSON.stringify({ targets: [] }, null, 2));
+      return;
+    }
     console.log(kleur.dim('[stub] target list — read sh1pt.config.ts'));
   });
 


### PR DESCRIPTION
Closes #142. Related to #133.

This fills in a few CLI convention gaps where nested list/status commands only had human-readable stub output even though the docs say those commands should support --json.

What changed:
- added --json output to the remaining list/status subcommands under the primary CLI verbs
- added a command-tree test that walks uild, config, promote, and scale so new list/status commands under those verbs keep the JSON option

Verified:
- corepack pnpm --filter @profullstack/sh1pt typecheck
- corepack pnpm vitest run packages/cli/src/input.test.ts packages/cli/src/commands/json-output.test.ts
- corepack pnpm --filter @profullstack/sh1pt-core --filter @profullstack/sh1pt-policy --filter @profullstack/sh1pt build
- smoke-tested a few commands via corepack pnpm exec tsx packages/cli/src/index.ts ... --json

I kept this intentionally small so it is easy to review and does not change the placeholder implementation behind the stubs.