### PR TITLE
Add dry-run guardrails for scale commands

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -71,8 +71,10 @@ deployCmd
   .command('destroy <instanceId>')
   .description('Tear down an instance (stops billing)')
   .requiredOption('--provider <id>')
-  .action((id: string, opts: { provider: string }) => {
-    console.log(kleur.red(`[stub] deploy destroy ${id} on ${opts.provider}`));
+  .option('--dry-run', 'show the teardown plan without destroying the instance')
+  .action((id: string, opts: { provider: string; dryRun?: boolean }) => {
+    const tag = opts.dryRun ? ' (dry-run)' : '';
+    console.log(kleur.red(`[stub] deploy destroy${tag} ${id} on ${opts.provider}`));
   });
 
 deployCmd

--- a/packages/cli/src/commands/dry-run-guardrails.test.ts
+++ b/packages/cli/src/commands/dry-run-guardrails.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import type { Command } from 'commander';
+import { scaleCmd } from './scale.js';
+
+const commandsThatMutateInfra = [
+  ['scale', 'up'],
+  ['scale', 'down'],
+  ['scale', 'auto'],
+  ['scale', 'dns'],
+  ['scale', 'rollout'],
+  ['scale', 'deploy', 'destroy'],
+];
+
+function findCommand(root: Command, path: string[]): Command | undefined {
+  const [name, ...rest] = path;
+  if (root.name() !== name) return undefined;
+  return rest.reduce<Command | undefined>(
+    (command, childName) => command?.commands.find((child) => child.name() === childName),
+    root,
+  );
+}
+
+function hasDryRunOption(command: Command): boolean {
+  return command.options.some((option) => option.long === '--dry-run');
+}
+
+describe('CLI dry-run guardrails', () => {
+  it('keeps mutating scale commands previewable', () => {
+    const missing = commandsThatMutateInfra
+      .map((path) => ({ path, command: findCommand(scaleCmd, path) }))
+      .filter(({ command }) => !command || !hasDryRunOption(command))
+      .map(({ path }) => path.join(' '));
+
+    expect(missing).toEqual([]);
+  });
+
+  it('does not shadow the top-level version flag on scale rollout', () => {
+    const rollout = findCommand(scaleCmd, ['scale', 'rollout']);
+
+    expect(rollout?.options.some((option) => option.long === '--release')).toBe(true);
+    expect(rollout?.options.some((option) => option.long === '--version')).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/scale.ts
+++ b/packages/cli/src/commands/scale.ts
@@ -28,6 +28,7 @@ scaleCmd
   .option('--instances <n>', 'how many to add', Number)
   .option('--provider <id>', 'which cloud provider to add to (default: same as existing fleet)')
   .option('--max-hourly-price <usd>', 'abort if the new instances would push above this total/hr', Number)
+  .option('--dry-run', 'show the plan without provisioning instances')
   .action((opts) => {
     console.log(kleur.green(`[stub] scale up ${JSON.stringify(opts)}`));
     // TODO: resolve current fleet, call CloudProvider.provision() × N,
@@ -39,6 +40,7 @@ scaleCmd
   .description('Tear down instances (cheapest / least-healthy first)')
   .option('--instances <n>', 'number of instances to destroy', Number)
   .option('--provider <id>', 'cloud provider id')
+  .option('--dry-run', 'show the teardown plan without destroying instances')
   .action((opts) => {
     console.log(kleur.yellow(`[stub] scale down ${JSON.stringify(opts)}`));
     // TODO: pick N victims, CloudProvider.destroy() each, syncRoundRobin() with remaining IPs
@@ -51,6 +53,7 @@ scaleCmd
   .option('--max <n>', 'maximum instances', Number, 10)
   .option('--target-cpu <percent>', 'target CPU utilization to maintain', Number, 70)
   .option('--cooldown <seconds>', 'minimum time between scale events', Number, 300)
+  .option('--dry-run', 'validate the auto-scale rule without saving it')
   .action((opts) => {
     console.log(kleur.cyan(`[stub] scale auto ${JSON.stringify(opts)}`));
     // TODO: PUT /v1/scale/rules — sh1pt cloud evaluates periodically
@@ -62,6 +65,7 @@ scaleCmd
   .requiredOption('--provider <id>', 'dns-porkbun | dns-cloudflare')
   .requiredOption('--domain <fqdn>', 'e.g. api.example.com')
   .option('--ttl <seconds>', '', Number, 60)
+  .option('--dry-run', 'show DNS record changes without applying them')
   .option('--proxied', 'cloudflare only — route through the CF edge (orange cloud)')
   .action((opts) => {
     console.log(kleur.cyan(`[stub] scale dns ${JSON.stringify(opts)}`));
@@ -71,7 +75,8 @@ scaleCmd
 scaleCmd
   .command('rollout')
   .description('Stage a new version across the fleet (canary / blue-green)')
-  .requiredOption('--version <id>')
+  .requiredOption('--release <id>', 'release id to roll out')
+  .option('--dry-run', 'show the rollout plan without changing traffic')
   .option('--strategy <kind>', 'canary | blue-green | rolling', 'canary')
   .option('--percent <n>', 'canary only — start at N% of traffic', Number, 5)
   .action((opts) => {

--- a/sites/sh1pt.com/app/docs/page.tsx
+++ b/sites/sh1pt.com/app/docs/page.tsx
@@ -321,10 +321,11 @@ export default function DocsPage() {
               { flag: '--instances <n>', description: 'how many to add' },
               { flag: '--provider <id>', description: 'cloud provider (default: same as existing fleet)' },
               { flag: '--max-hourly-price <usd>', description: 'abort if total/hr would exceed this' },
+              { flag: '--dry-run', description: 'show the plan without provisioning instances' },
             ]}
-            examples={[{ command: 'sh1pt scale up --instances 3 --max-hourly-price 1.50' }]}
+            examples={[{ command: 'sh1pt scale up --instances 3 --max-hourly-price 1.50 --dry-run' }]}
           />
-          <CommandBlock signature="sh1pt scale down" description="Tear down instances (cheapest / least-healthy first)." examples={[{ command: 'sh1pt scale down --instances 1' }]} />
+          <CommandBlock signature="sh1pt scale down" description="Tear down instances (cheapest / least-healthy first)." options={[{ flag: '--dry-run', description: 'show the teardown plan without destroying instances' }]} examples={[{ command: 'sh1pt scale down --instances 1 --dry-run' }]} />
           <CommandBlock
             signature="sh1pt scale auto"
             description="Set auto-scale rules. sh1pt cloud polls metrics and runs scale up/down on your behalf."
@@ -332,8 +333,9 @@ export default function DocsPage() {
               { flag: '--min / --max', description: 'instance count bounds' },
               { flag: '--target-cpu <percent>', description: 'utilization to maintain (default: 70)' },
               { flag: '--cooldown <seconds>', description: 'minimum gap between scale events' },
+              { flag: '--dry-run', description: 'validate the rule without saving it' },
             ]}
-            examples={[{ command: 'sh1pt scale auto --min 2 --max 10 --target-cpu 65 --cooldown 300' }]}
+            examples={[{ command: 'sh1pt scale auto --min 2 --max 10 --target-cpu 65 --cooldown 300 --dry-run' }]}
           />
           <CommandBlock
             signature="sh1pt scale dns"
@@ -342,19 +344,21 @@ export default function DocsPage() {
               { flag: '--provider', description: 'dns-porkbun | dns-cloudflare' },
               { flag: '--domain <fqdn>', description: 'e.g. api.example.com' },
               { flag: '--ttl <seconds>', description: 'default 60' },
+              { flag: '--dry-run', description: 'show DNS changes without applying them' },
               { flag: '--proxied', description: 'cloudflare only — orange cloud' },
             ]}
-            examples={[{ command: 'sh1pt scale dns --provider dns-cloudflare --domain api.example.com --proxied' }]}
+            examples={[{ command: 'sh1pt scale dns --provider dns-cloudflare --domain api.example.com --proxied --dry-run' }]}
           />
           <CommandBlock
             signature="sh1pt scale rollout"
             description="Stage a new version across the fleet."
             options={[
-              { flag: '--version <id>', description: 'release id to roll out' },
+              { flag: '--release <id>', description: 'release id to roll out' },
+              { flag: '--dry-run', description: 'show the rollout plan without changing traffic' },
               { flag: '--strategy', description: 'canary | blue-green | rolling' },
               { flag: '--percent <n>', description: 'canary only — start at N% of traffic' },
             ]}
-            examples={[{ command: 'sh1pt scale rollout --version v1.4.2 --strategy canary --percent 10' }]}
+            examples={[{ command: 'sh1pt scale rollout --release v1.4.2 --strategy canary --percent 10 --dry-run' }]}
           />
           <CommandBlock signature="sh1pt scale cost" description="Spend totals + per-provider breakdown + rightsizing suggestions." examples={[{ command: 'sh1pt scale cost --json' }]} />
           <CommandBlock signature="sh1pt scale status" description="Current fleet: instance count, DNS records, load distribution." examples={[{ command: 'sh1pt scale status --json' }]} />
@@ -385,7 +389,7 @@ export default function DocsPage() {
             examples={[{ command: 'sh1pt scale deploy provision --provider cloud-runpod --kind gpu --gpu A100 --max-hourly-price 4.00' }]}
           />
           <CommandBlock signature="sh1pt scale deploy list" description="All instances sh1pt is tracking across providers." examples={[{ command: 'sh1pt scale deploy list --json' }]} />
-          <CommandBlock signature="sh1pt scale deploy destroy <instanceId> --provider <id>" description="Tear down an instance (stops billing)." examples={[{ command: 'sh1pt scale deploy destroy ix-abc123 --provider cloud-runpod' }]} />
+          <CommandBlock signature="sh1pt scale deploy destroy <instanceId> --provider <id>" description="Tear down an instance (stops billing)." options={[{ flag: '--dry-run', description: 'show the teardown plan without destroying the instance' }]} examples={[{ command: 'sh1pt scale deploy destroy ix-abc123 --provider cloud-runpod --dry-run' }]} />
           <CommandBlock signature="sh1pt scale deploy status <instanceId> --provider <id>" description="Health + hourly cost." examples={[{ command: 'sh1pt scale deploy status ix-abc123 --provider cloud-runpod' }]} />
         </div>
       </section>


### PR DESCRIPTION
Closes #144. Related to #133.

This follows the docs convention that commands which spend money or change live systems should be previewable with --dry-run.

What changed:
- added --dry-run to mutating scale commands: up, down, uto, dns, ollout, and deploy destroy
- updated the docs examples/options for those scale commands
- changed scale rollout --version <id> to --release <id> because Commander already uses --version as the top-level CLI version flag, so the documented rollout command could not actually run
- added a focused regression test for the dry-run guardrails and the rollout flag conflict

Verified:
- corepack pnpm --filter @profullstack/sh1pt typecheck
- corepack pnpm vitest run packages/cli/src/commands/dry-run-guardrails.test.ts
- corepack pnpm --filter @profullstack/sh1pt-core --filter @profullstack/sh1pt-policy --filter @profullstack/sh1pt build
- corepack pnpm --filter sh1pt-dot-com build
- smoke-tested scale up, scale rollout, and scale deploy destroy through 	sx packages/cli/src/index.ts

I kept the command behavior as stubs; this only makes the planned mutating operations previewable and fixes the rollout option name so it does not collide with the CLI version flag.