### PR TITLE
Add JSON output for utility list commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ sh1pt promote outreach status
 Drive AI coding CLIs — sh1pt wraps Claude Code, Codex, and Qwen so you can generate/iterate on a project from the same manifest.
 
 ```bash
-sh1pt iterate agents list                              # which CLIs are installed locally
+sh1pt iterate agents list --json                       # which CLIs are installed locally
 sh1pt iterate agents setup --agent claude codex qwen   # install + auth each one
 sh1pt iterate agents talk [agent] --recipe <id>        # interactive session with a preloaded recipe prompt
 sh1pt iterate agents run <agent> "add stripe checkout to /waitlist/checkout"
@@ -576,6 +576,7 @@ sh1pt iterate agents generate --recipe waitlist-crypto-investor --boilerplate ne
 ```bash
 sh1pt login                      # authenticate with sh1pt cloud (device-code flow)
 sh1pt secret set|get|list|rm     # manage credentials vault (used by every verb)
+sh1pt secret list --json         # machine-readable key metadata, never values
 sh1pt config show                # print the resolved manifest
 sh1pt config stack set           # prompts — node / bun / python / rust / custom
 sh1pt config payments add        # payment providers: CoinPay default, Stripe/PayPal opt-in

--- a/packages/cli/src/commands/adapter-cmd.ts
+++ b/packages/cli/src/commands/adapter-cmd.ts
@@ -31,7 +31,13 @@ export function makeCategoryCmd(category: AdapterCategory): Command {
   cmd
     .command('list')
     .description(`List all ${category.id} adapters`)
-    .action(() => {
+    .option('--json')
+    .action((opts: { json?: boolean }) => {
+      const adapters = category.adapters.map((name) => ({ name, package: packageFor(category, name) }));
+      if (opts.json) {
+        console.log(JSON.stringify({ category: category.id, adapters }, null, 2));
+        return;
+      }
       for (const name of category.adapters) {
         console.log(`  ${kleur.cyan(name)}  ${kleur.dim(packageFor(category, name))}`);
       }

--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -10,8 +10,13 @@ export const agentsCmd = new Command('agents')
 agentsCmd
   .command('list')
   .description('Which agent CLIs are installed on this machine')
-  .action(() => {
+  .option('--json')
+  .action((opts: { json?: boolean }) => {
     const agents = ['claude', 'codex', 'qwen'];
+    if (opts.json) {
+      console.log(JSON.stringify({ agents: agents.map((id) => ({ id, installed: false })) }, null, 2));
+      return;
+    }
     for (const a of agents) {
       // TODO: resolve adapter, call check(), render real status
       console.log(`  ${kleur.gray('○')} ${kleur.bold(a)}  ${kleur.dim('run `sh1pt agents setup --agent ' + a + '`')}`);

--- a/packages/cli/src/commands/secrets.ts
+++ b/packages/cli/src/commands/secrets.ts
@@ -114,28 +114,44 @@ secretsCmd
   .description('List secret keys (never values)')
   .option('--local', 'list only the local vault')
   .option('--cloud', 'list only the cloud vault')
-  .action(async (opts: ScopeOpts) => {
+  .option('--json')
+  .action(async (opts: ScopeOpts & { json?: boolean }) => {
     const showLocal = !opts.cloud;
     const showCloud = opts.cloud || (!opts.local && (await isSignedIn()));
+    const result: {
+      local?: { path: string; entries: Array<{ key: string }> };
+      cloud?: { entries: Array<{ key: string; updated_at?: string }> };
+    } = {};
 
     if (showLocal) {
       const entries = await listSecretsLocal();
+      if (opts.json) {
+        result.local = { path: localVaultPath(), entries };
+      } else {
       console.log(kleur.bold(`local (${localVaultPath()})`));
       if (entries.length === 0) {
         console.log(kleur.dim('  (empty)'));
       } else {
         for (const e of entries) console.log(`  ${kleur.cyan(e.key)}`);
       }
+      }
     }
     if (showCloud) {
+      const entries = await listSecretsFromCloud();
+      if (opts.json) {
+        result.cloud = { entries };
+      } else {
       if (showLocal) console.log();
       console.log(kleur.bold('cloud (sh1pt.com vault)'));
-      const entries = await listSecretsFromCloud();
       if (entries.length === 0) {
         console.log(kleur.dim('  (empty)'));
       } else {
         for (const e of entries) console.log(`  ${kleur.cyan(e.key)}  ${kleur.dim(e.updated_at)}`);
       }
+      }
+    }
+    if (opts.json) {
+      console.log(JSON.stringify(result, null, 2));
     }
   });
 

--- a/packages/cli/src/commands/utility-json-output.test.ts
+++ b/packages/cli/src/commands/utility-json-output.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import type { Command } from 'commander';
+import { agentsCmd } from './agents.js';
+import { makeCategoryCmd } from './adapter-cmd.js';
+import { secretsCmd } from './secrets.js';
+import type { AdapterCategory } from '../adapter-registry.js';
+
+const sampleCategory: AdapterCategory = {
+  id: 'bots',
+  pkgPrefix: '@profullstack/sh1pt-bot',
+  description: 'Bot adapters',
+  adapters: ['discord'],
+};
+
+function findCommand(root: Command, path: string[]): Command | undefined {
+  const [name, ...rest] = path;
+  if (root.name() !== name) return undefined;
+  return rest.reduce<Command | undefined>(
+    (command, childName) => command?.commands.find((child) => child.name() === childName),
+    root,
+  );
+}
+
+function hasJsonOption(command: Command): boolean {
+  return command.options.some((option) => option.long === '--json');
+}
+
+describe('utility CLI JSON output', () => {
+  it('adds --json to non-primary list commands', () => {
+    const adapterCmd = makeCategoryCmd(sampleCategory);
+    const commands = [
+      findCommand(agentsCmd, ['agents', 'list']),
+      findCommand(secretsCmd, ['secret', 'list']),
+      findCommand(adapterCmd, ['bots', 'list']),
+    ];
+
+    expect(commands.every((command) => command && hasJsonOption(command))).toBe(true);
+  });
+});

--- a/sites/sh1pt.com/app/docs/page.tsx
+++ b/sites/sh1pt.com/app/docs/page.tsx
@@ -434,7 +434,7 @@ export default function DocsPage() {
           <CommandBlock signature="sh1pt iterate experiments" description="Active and recently-ended experiments with significance." examples={[{ command: 'sh1pt iterate experiments --json' }]} />
 
           <h3 style={{ marginTop: '2.5rem' }}>iterate agents — orchestrate AI coding CLIs</h3>
-          <CommandBlock signature="sh1pt iterate agents list" description="Which agent CLIs are installed on this machine." examples={[{ command: 'sh1pt iterate agents list' }]} />
+          <CommandBlock signature="sh1pt iterate agents list" description="Which agent CLIs are installed on this machine." examples={[{ command: 'sh1pt iterate agents list' }, { command: 'sh1pt iterate agents list --json' }]} />
           <CommandBlock signature="sh1pt iterate agents setup" description="Install + auth the agent CLIs you want sh1pt to drive." options={[{ flag: '--agent <id...>', description: 'subset (default: claude codex qwen)' }]} examples={[{ command: 'sh1pt iterate agents setup --agent claude codex' }]} />
           <CommandBlock
             signature="sh1pt iterate agents run <agent> <prompt...>"
@@ -481,7 +481,7 @@ export default function DocsPage() {
           </p>
           <CommandBlock signature="sh1pt secret set <key> [value]" description="Set a secret (value prompted if omitted)." examples={[{ command: 'sh1pt secret set OPENAI_API_KEY' }]} />
           <CommandBlock signature="sh1pt secret get <key>" description="Print a secret (requires interactive confirmation)." examples={[{ command: 'sh1pt secret get OPENAI_API_KEY' }]} />
-          <CommandBlock signature="sh1pt secret list" description="List secret keys (never values)." examples={[{ command: 'sh1pt secret list' }]} />
+          <CommandBlock signature="sh1pt secret list" description="List secret keys (never values)." examples={[{ command: 'sh1pt secret list' }, { command: 'sh1pt secret list --json' }]} />
           <CommandBlock signature="sh1pt secret rm <key>" description="Delete a secret." examples={[{ command: 'sh1pt secret rm OPENAI_API_KEY' }]} />
         </div>
       </section>
@@ -636,7 +636,7 @@ export default function DocsPage() {
           <div style={{ display: 'grid', gap: '0.75rem', maxWidth: 760 }}>
             <CopyableCommand label="Connect Discord bot credentials" command="sh1pt bots discord setup" />
             <CopyableCommand label="See what's known about deploy-vercel" command="sh1pt targets deploy-vercel info" />
-            <CopyableCommand label="List every cloud provider adapter" command="sh1pt cloud list" />
+            <CopyableCommand label="List every cloud provider adapter" command="sh1pt cloud list --json" />
             <CopyableCommand label="Wire a generic webhook target" command="sh1pt webhooks generic setup" />
           </div>
         </div>


### PR DESCRIPTION
Closes #146. Related to #133.

This covers the utility-side list commands that still only had the human-readable output path.

What changed:
- added --json to sh1pt iterate agents list
- added --json to generated adapter category list commands such as sh1pt bots list
- added --json to sh1pt secret list; it returns key metadata only and never secret values
- added a focused regression test that checks these command surfaces keep the JSON option

Verified:
- corepack pnpm --filter @profullstack/sh1pt typecheck
- corepack pnpm vitest run packages/cli/src/commands/utility-json-output.test.ts
- corepack pnpm --filter @profullstack/sh1pt-core --filter @profullstack/sh1pt-policy --filter @profullstack/sh1pt build
- smoke-tested:
  - corepack pnpm exec tsx packages/cli/src/index.ts iterate agents list --json
  - corepack pnpm exec tsx packages/cli/src/index.ts bots list --json
  - corepack pnpm exec tsx packages/cli/src/index.ts secret list --local --json

I kept this separate from the primary-verb JSON PR so the changes are easy to review independently.