### PR TITLE
Keep plugin-vscode dry-run builds side-effect free

### DIFF
--- a/packages/targets/plugin-vscode/src/index.test.ts
+++ b/packages/targets/plugin-vscode/src/index.test.ts
@@ -1,4 +1,102 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { execMock } = vi.hoisted(() => ({
+  execMock: vi.fn(),
+}));
+
+vi.mock('@profullstack/sh1pt-core', async () => ({
+  ...await vi.importActual<typeof import('@profullstack/sh1pt-core')>('@profullstack/sh1pt-core'),
+  exec: execMock,
+}));
+
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'plugin', requireKind: true });
+
+const tempDirs: string[] = [];
+const sampleConfig = {
+  publisher: 'acme',
+  extensionName: 'sample-extension',
+  packageDir: 'extensions/sample-extension',
+  target: 'linux-x64',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('plugin-vscode target adapter', () => {
+  it('writes a package plan without invoking vsce in dry-run builds', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-vscode-out-'));
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-vscode-project-'));
+    tempDirs.push(outDir, projectDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      projectDir,
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, sampleConfig);
+
+    expect(execMock).not.toHaveBeenCalled();
+    expect(result.artifact).toBe(join(outDir, 'vscode-package.json'));
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan).toEqual({
+      provider: 'vscode-marketplace',
+      publisher: 'acme',
+      extensionName: 'sample-extension',
+      version: '1.2.3',
+      packageDir: join(projectDir, 'extensions/sample-extension'),
+      artifact: join(outDir, 'sample-extension-1.2.3.vsix'),
+      command: [
+        'npx',
+        '--yes',
+        'vsce',
+        'package',
+        '--out',
+        outDir,
+        '--target',
+        'linux-x64',
+      ],
+    });
+  });
+
+  it('packages with vsce for real builds', async () => {
+    execMock.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+
+    const ctx = fakeBuildContext({
+      projectDir: '/repo',
+      outDir: '/repo/.sh1pt/out',
+      version: '1.2.3',
+      dryRun: false,
+    });
+    const result = await adapter.build(ctx as any, sampleConfig);
+
+    expect(execMock).toHaveBeenNthCalledWith(1, 'npx', ['--yes', 'vsce', '--version'], {
+      log: ctx.log,
+      throwOnNonZero: false,
+    });
+    expect(execMock).toHaveBeenNthCalledWith(2, 'npx', [
+      '--yes',
+      'vsce',
+      'package',
+      '--out',
+      '/repo/.sh1pt/out',
+      '--target',
+      'linux-x64',
+    ], {
+      cwd: '/repo/extensions/sample-extension',
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+    expect(result).toEqual({ artifact: '/repo/.sh1pt/out/sample-extension-1.2.3.vsix' });
+  });
+});

--- a/packages/targets/plugin-vscode/src/index.ts
+++ b/packages/targets/plugin-vscode/src/index.ts
@@ -1,4 +1,5 @@
 import { defineTarget, setupGuide, exec } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 interface Config {
@@ -8,12 +9,46 @@ interface Config {
   target?: string;         // e.g. "linux-x64" for platform-specific packages
 }
 
+function packageDir(ctx: { projectDir: string }, config: Config): string {
+  return config.packageDir ? join(ctx.projectDir, config.packageDir) : ctx.projectDir;
+}
+
+function packageArtifact(ctx: { outDir: string; version: string }, config: Config): string {
+  return join(ctx.outDir, `${config.extensionName}-${ctx.version}.vsix`);
+}
+
+function packageArgs(ctx: { outDir: string }, config: Config): string[] {
+  const args = ['--yes', 'vsce', 'package', '--out', ctx.outDir];
+  if (config.target) args.push('--target', config.target);
+  return args;
+}
+
+function renderPackagePlan(ctx: { projectDir: string; outDir: string; version: string }, config: Config): string {
+  return `${JSON.stringify({
+    provider: 'vscode-marketplace',
+    publisher: config.publisher,
+    extensionName: config.extensionName,
+    version: ctx.version,
+    packageDir: packageDir(ctx, config),
+    artifact: packageArtifact(ctx, config),
+    command: ['npx', ...packageArgs(ctx, config)],
+  }, null, 2)}\n`;
+}
+
 export default defineTarget<Config>({
   id: 'plugin-vscode',
   kind: 'plugin',
   label: 'VS Code Marketplace',
 
   async build(ctx, config) {
+    if (ctx.dryRun) {
+      const planPath = join(ctx.outDir, 'vscode-package.json');
+      ctx.log(`vsce: dry-run package plan for ${config.publisher}.${config.extensionName} v${ctx.version}`);
+      await mkdir(ctx.outDir, { recursive: true });
+      await writeFile(planPath, renderPackagePlan(ctx, config), 'utf-8');
+      return { artifact: planPath };
+    }
+
     ctx.log('vsce: verifying CLI availability');
 
     try {
@@ -25,11 +60,10 @@ export default defineTarget<Config>({
       });
     }
 
-    const pkgDir = config.packageDir ? join(ctx.projectDir, config.packageDir) : ctx.projectDir;
+    const pkgDir = packageDir(ctx, config);
     ctx.log(`vsce: packaging ${config.publisher}.${config.extensionName} v${ctx.version}`);
 
-    const args = ['--yes', 'vsce', 'package', '--out', ctx.outDir];
-    if (config.target) args.push('--target', config.target);
+    const args = packageArgs(ctx, config);
 
     const { stdout } = await exec('npx', args, {
       cwd: pkgDir,
@@ -37,7 +71,7 @@ export default defineTarget<Config>({
       throwOnNonZero: true,
     });
 
-    return { artifact: `${ctx.outDir}/${config.extensionName}-${ctx.version}.vsix` };
+    return { artifact: packageArtifact(ctx, config) };
   },
 
   async ship(ctx, config) {


### PR DESCRIPTION
Closes #156.\n\n## What changed\n- short-circuit `plugin-vscode` builds in `ctx.dryRun` mode before any `vsce`/`npm` exec path\n- write a deterministic `vscode-package.json` plan artifact with the resolved package directory, output artifact, and CLI command\n- keep real builds on the existing `npx --yes vsce package` behavior\n\n## Verification\n- `corepack pnpm vitest run packages/targets/plugin-vscode/src/index.test.ts`\n- `corepack pnpm -r --filter './packages/targets/plugin-vscode' typecheck`\n- `corepack pnpm --filter @profullstack/sh1pt typecheck`\n- `git diff --check`