### PR TITLE
feat(cli): add build and ship manifest planning

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { spawnSync } from 'node:child_process';
 import kleur from 'kleur';
 import { describeInput, resolveInput } from '../input.js';
+import { loadManifest, resolveTargets } from '../manifest.js';
 import { entityCmd } from './entity.js';
 
 function run(argv: string[], env?: Record<string, string>): number {
@@ -20,19 +21,63 @@ export const buildCmd = new Command('build')
   .option('-t, --target <id...>', 'target ids to build (default: all enabled)')
   .option('-c, --channel <name>', 'release channel', 'stable')
   .option('--cloud', 'run build in sh1pt cloud instead of locally')
+  .option('--dry-run', 'resolve and validate the build plan without invoking target adapters')
+  .option('--json', 'emit the resolved build plan as JSON')
   .option('--from <input>', 'existing git repo, live url, local path, or manifest doc to build from')
-  .action((opts: { target?: string[]; channel: string; cloud?: boolean; from?: string }) => {
-    const targets = opts.target?.join(', ') ?? 'all enabled';
+  .action(async (opts: { target?: string[]; channel: string; cloud?: boolean; dryRun?: boolean; json?: boolean; from?: string }) => {
     const where = opts.cloud ? 'cloud' : 'local';
     if (opts.from) {
       const input = resolveInput(opts.from);
-      console.log(kleur.cyan(`[stub] build (${where}) · channel=${opts.channel} · from=${describeInput(input)}`));
-      // TODO: kind==='git' → clone and detect stack; kind==='path' → load manifest;
-      // kind==='doc' → parse manifest; kind==='url' → HEAD/fetch to infer stack.
+      const plan = {
+        command: 'build',
+        mode: where,
+        channel: opts.channel,
+        from: input,
+        dryRun: opts.dryRun ?? true,
+      };
+      if (opts.json) {
+        console.log(JSON.stringify(plan, null, 2));
+      } else {
+        console.log(kleur.cyan(`${opts.dryRun ? '[dry-run] ' : ''}build (${where}) · channel=${opts.channel} · from=${describeInput(input)}`));
+        console.log(kleur.dim('No project manifest was loaded because --from points at an external input.'));
+      }
       return;
     }
-    console.log(kleur.cyan(`[stub] build (${where}) · channel=${opts.channel} · targets=${targets}`));
-    // TODO: load manifest, resolve targets, invoke Target.build(), stream logs
+
+    const { manifest, path } = await loadManifest();
+    if (!manifest.channels.includes(opts.channel)) {
+      throw new Error(`Unknown channel "${opts.channel}". Available channels: ${manifest.channels.join(', ')}`);
+    }
+
+    const targets = resolveTargets(manifest, opts.target);
+    const plan = {
+      command: 'build',
+      project: manifest.name,
+      version: manifest.version,
+      config: path,
+      mode: where,
+      channel: opts.channel,
+      dryRun: opts.dryRun ?? true,
+      targets: targets.map(({ id, spec }) => ({ id, use: spec.use, distribute: spec.distribute ?? [] })),
+    };
+
+    if (opts.json) {
+      console.log(JSON.stringify(plan, null, 2));
+      return;
+    }
+
+    const tag = opts.dryRun ? kleur.yellow('[dry-run]') : kleur.green('[plan]');
+    console.log(`${tag} build · ${manifest.name}@${manifest.version} · ${where} · channel=${opts.channel}`);
+    console.log(kleur.dim(`config: ${path}`));
+    if (targets.length === 0) {
+      console.log(kleur.yellow('No enabled targets found. Add one with sh1pt promote ship target add <id>.'));
+      return;
+    }
+    for (const { id, spec } of targets) {
+      const fanout = spec.distribute?.length ? kleur.dim(` → ${spec.distribute.join(', ')}`) : '';
+      console.log(`  ${kleur.cyan(id)} ${kleur.dim(spec.use)}${fanout}`);
+    }
+    console.log(kleur.dim('Target adapter execution is intentionally gated behind the next implementation slice.'));
   });
 
 // Entity-ops lives under `build` — an entity (certificate, bylaws, filing

--- a/packages/cli/src/commands/ship.ts
+++ b/packages/cli/src/commands/ship.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import kleur from 'kleur';
 import prompts from 'prompts';
 import { lint } from '@profullstack/sh1pt-policy';
-import type { Manifest } from '@profullstack/sh1pt-core';
+import { loadManifest } from '../manifest.js';
 
 const CONFIG_TEMPLATE = (name: string) => `import { defineConfig } from '@profullstack/sh1pt-core';
 
@@ -16,11 +16,6 @@ export default defineConfig({
   },
 });
 `;
-
-async function loadManifest(): Promise<Manifest> {
-  // Stub — real impl dynamic-imports ./sh1pt.config.ts
-  return { name: 'stub', version: '0.0.0', channels: ['stable', 'beta', 'canary'], targets: {} };
-}
 
 export const shipCmd = new Command('ship')
   .description('Publish built artifacts to their target stores and registries')
@@ -104,7 +99,7 @@ shipCmd
   .option('--strict', 'exit non-zero on warnings as well as errors')
   .option('--json')
   .action(async (opts: { strict?: boolean; json?: boolean }) => {
-    const manifest = await loadManifest();
+    const { manifest } = await loadManifest();
     const result = await lint({ manifest, projectDir: process.cwd() });
     if (opts.json) {
       console.log(JSON.stringify(result, null, 2));

--- a/packages/cli/src/commands/ship.ts
+++ b/packages/cli/src/commands/ship.ts
@@ -17,21 +17,79 @@ export default defineConfig({
 });
 `;
 
+function optionWithParents(command: Command): Record<string, unknown> {
+  const chain: Command[] = [];
+  for (let current: Command | null = command; current; current = current.parent) chain.unshift(current);
+  return Object.assign({}, ...chain.map((current) => current.opts()));
+}
+
+function manifestTargetSummary(manifest: Awaited<ReturnType<typeof loadManifest>>['manifest'], requested?: string[]) {
+  return Object.entries(manifest.targets ?? {})
+    .filter(([id, spec]) => spec.enabled !== false && (!requested?.length || requested.includes(id)))
+    .map(([id, spec]) => ({
+      id,
+      use: spec.use,
+      distribute: spec.distribute ?? [],
+      enabled: spec.enabled !== false,
+    }));
+}
+
 export const shipCmd = new Command('ship')
   .description('Publish built artifacts to their target stores and registries')
   .option('-t, --target <id...>', 'target ids to ship (default: all enabled)')
   .option('-c, --channel <name>', 'release channel', 'stable')
   .option('--dry-run', 'simulate without uploading')
   .option('--skip-lint', 'skip the pre-ship policy linter (not recommended)')
-  .action(async (opts: { target?: string[]; channel: string; dryRun?: boolean; skipLint?: boolean }) => {
-    const targets = opts.target?.join(', ') ?? 'all enabled';
-    const tag = opts.dryRun ? kleur.yellow('[dry-run]') : kleur.green('[live]');
-    if (!opts.skipLint) {
-      console.log(kleur.dim('running pre-ship policy linter…'));
-      // TODO: load manifest, call lint(ctx) — abort on errors unless --skip-lint
+  .option('--json', 'emit the resolved ship plan as JSON')
+  .action(async (opts: { target?: string[]; channel: string; dryRun?: boolean; skipLint?: boolean; json?: boolean }) => {
+    const { manifest, path } = await loadManifest();
+    if (!manifest.channels.includes(opts.channel)) {
+      throw new Error(`Unknown channel "${opts.channel}". Available channels: ${manifest.channels.join(', ')}`);
     }
-    console.log(`${tag} ship · channel=${opts.channel} · targets=${targets}`);
-    // TODO: load manifest, resolve latest build, invoke Target.ship(), record release
+
+    const selected = manifestTargetSummary(manifest, opts.target);
+    if (opts.target?.length) {
+      const known = new Set(selected.map((target) => target.id));
+      const missing = opts.target.filter((id) => !known.has(id));
+      if (missing.length) throw new Error(`Unknown or disabled target(s): ${missing.join(', ')}`);
+    }
+
+    const policyResult = opts.skipLint ? null : await lint({ manifest, projectDir: process.cwd() });
+    const plan = {
+      command: 'ship',
+      project: manifest.name,
+      version: manifest.version,
+      config: path,
+      channel: opts.channel,
+      dryRun: opts.dryRun ?? true,
+      lint: policyResult ? { errors: policyResult.errors, warnings: policyResult.warnings } : { skipped: true },
+      targets: selected,
+    };
+
+    if (opts.json) {
+      console.log(JSON.stringify(plan, null, 2));
+      return;
+    }
+
+    const tag = opts.dryRun ? kleur.yellow('[dry-run]') : kleur.green('[plan]');
+    console.log(`${tag} ship · ${manifest.name}@${manifest.version} · channel=${opts.channel}`);
+    console.log(kleur.dim(`config: ${path}`));
+    if (policyResult) {
+      console.log(kleur.dim(`policy: ${policyResult.errors} error(s), ${policyResult.warnings} warning(s)`));
+      if (policyResult.errors > 0) {
+        console.log(kleur.red('Policy errors block live shipping. Re-run sh1pt promote ship lint for details.'));
+        process.exit(1);
+      }
+    }
+    if (selected.length === 0) {
+      console.log(kleur.yellow('No enabled targets found. Add one with sh1pt promote ship target add <id>.'));
+      return;
+    }
+    for (const target of selected) {
+      const fanout = target.distribute.length ? kleur.dim(` → ${target.distribute.join(', ')}`) : '';
+      console.log(`  ${kleur.cyan(target.id)} ${kleur.dim(target.use)}${fanout}`);
+    }
+    console.log(kleur.dim('Target upload/release execution is intentionally gated behind adapter credentials and the next implementation slice.'));
   });
 
 shipCmd
@@ -74,13 +132,31 @@ shipCmd
   .description('Current release status across targets')
   .option('-t, --target <id>')
   .option('--json')
-  .action((opts: { target?: string; json?: boolean }) => {
+  .action(async (_opts: { target?: string; json?: boolean }, cmd: Command) => {
+    const opts = optionWithParents(cmd) as { target?: string; json?: boolean };
+    const { manifest, path } = await loadManifest();
+    const targets = manifestTargetSummary(manifest, opts.target ? [opts.target] : undefined);
+    if (opts.target && targets.length === 0) throw new Error(`Unknown or disabled target: ${opts.target}`);
+    const status = {
+      project: manifest.name,
+      version: manifest.version,
+      config: path,
+      targets: targets.map((target) => ({
+        ...target,
+        release: 'not-connected',
+        note: 'No cloud release record is configured in this local workspace yet.',
+      })),
+    };
     if (opts.json) {
-      console.log(JSON.stringify({ releases: [], live: {}, inReview: {} }, null, 2));
+      console.log(JSON.stringify(status, null, 2));
       return;
     }
-    console.log(kleur.dim(`[stub] ship status · target=${opts.target ?? 'all'}`));
-    // TODO: fetch per-target live state from cloud
+    console.log(kleur.cyan(`ship status · ${manifest.name}@${manifest.version}`));
+    console.log(kleur.dim(`config: ${path}`));
+    for (const target of status.targets) {
+      console.log(`  ${kleur.cyan(target.id)} ${kleur.dim(target.use)} — ${kleur.yellow(target.release)}`);
+      console.log(`    ${kleur.dim(target.note)}`);
+    }
   });
 
 shipCmd
@@ -144,13 +220,51 @@ targetSubCmd
 targetSubCmd
   .command('list')
   .description('List enabled targets for this project')
-  .action(() => {
-    console.log(kleur.dim('[stub] target list — read sh1pt.config.ts'));
+  .option('--json')
+  .action(async (_opts: { json?: boolean }, cmd: Command) => {
+    const opts = optionWithParents(cmd) as { json?: boolean };
+    const { manifest, path } = await loadManifest();
+    const targets = manifestTargetSummary(manifest);
+    if (opts.json) {
+      console.log(JSON.stringify({ project: manifest.name, config: path, targets }, null, 2));
+      return;
+    }
+    console.log(kleur.cyan(`targets · ${manifest.name}`));
+    console.log(kleur.dim(`config: ${path}`));
+    if (targets.length === 0) {
+      console.log(kleur.yellow('No enabled targets found.'));
+      return;
+    }
+    for (const target of targets) {
+      const fanout = target.distribute.length ? kleur.dim(` → ${target.distribute.join(', ')}`) : '';
+      console.log(`  ${kleur.cyan(target.id)} ${kleur.dim(target.use)}${fanout}`);
+    }
   });
+
+const AVAILABLE_TARGETS = [
+  { id: 'pkg-npm', use: 'target-pkg-npm', kind: 'package', status: 'implemented' },
+  { id: 'web-vercel', use: 'target-web-vercel', kind: 'web', status: 'adapter-required' },
+  { id: 'web-netlify', use: 'target-web-netlify', kind: 'web', status: 'adapter-required' },
+  { id: 'mobile-android', use: 'target-mobile-android', kind: 'mobile', status: 'adapter-required' },
+  { id: 'mobile-ios', use: 'target-mobile-ios', kind: 'mobile', status: 'adapter-required' },
+  { id: 'cdn-jsdelivr', use: 'target-cdn-jsdelivr', kind: 'cdn', status: 'implemented' },
+  { id: 'firebase', use: 'target-firebase', kind: 'cloud', status: 'implemented' },
+  { id: 'deno-land', use: 'target-deno-land', kind: 'package', status: 'implemented' },
+] as const;
 
 targetSubCmd
   .command('available')
   .description('List every target adapter available to install')
-  .action(() => {
-    console.log(kleur.dim('[stub] target available — fetch from registry'));
+  .option('--json')
+  .action((_opts: { json?: boolean }, cmd: Command) => {
+    const opts = optionWithParents(cmd) as { json?: boolean };
+    if (opts.json) {
+      console.log(JSON.stringify({ targets: AVAILABLE_TARGETS }, null, 2));
+      return;
+    }
+    console.log(kleur.cyan('available target adapters'));
+    for (const target of AVAILABLE_TARGETS) {
+      const color = target.status === 'implemented' ? kleur.green : kleur.yellow;
+      console.log(`  ${kleur.cyan(target.id)} ${kleur.dim(target.use)} ${kleur.dim(target.kind)} ${color(target.status)}`);
+    }
   });

--- a/packages/cli/src/manifest.test.ts
+++ b/packages/cli/src/manifest.test.ts
@@ -1,0 +1,41 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it } from 'vitest';
+import { findManifestPath, loadManifest, resolveTargets } from './manifest.js';
+
+async function tempProject(config: object) {
+  const dir = await mkdtemp(join(tmpdir(), 'sh1pt-cli-manifest-'));
+  await writeFile(join(dir, 'sh1pt.config.json'), JSON.stringify(config), 'utf8');
+  return dir;
+}
+
+describe('manifest helpers', () => {
+  it('loads and validates a JSON sh1pt config', async () => {
+    const dir = await tempProject({
+      name: 'demo',
+      version: '1.0.0',
+      targets: { npm: { use: 'target-pkg-npm', config: {} } },
+    });
+
+    expect(await findManifestPath(dir)).toBe(join(dir, 'sh1pt.config.json'));
+    const { manifest } = await loadManifest(dir);
+    expect(manifest.channels).toEqual(['stable', 'beta', 'canary']);
+    expect(manifest.targets.npm?.use).toBe('target-pkg-npm');
+  });
+
+  it('resolves only enabled targets and rejects unknown requested targets', () => {
+    const manifest = {
+      name: 'demo',
+      version: '1.0.0',
+      channels: ['stable'],
+      targets: {
+        npm: { use: 'target-pkg-npm', enabled: true, config: {} },
+        play: { use: 'target-mobile-android', enabled: false, config: {} },
+      },
+    };
+
+    expect(resolveTargets(manifest, undefined).map((target) => target.id)).toEqual(['npm']);
+    expect(() => resolveTargets(manifest, ['play'])).toThrow('Unknown or disabled target');
+  });
+});

--- a/packages/cli/src/manifest.ts
+++ b/packages/cli/src/manifest.ts
@@ -1,0 +1,66 @@
+import { access, readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { manifestSchema, type Manifest, type TargetSpec } from '@profullstack/sh1pt-core';
+
+export const CONFIG_FILENAMES = [
+  'sh1pt.config.ts',
+  'sh1pt.config.mts',
+  'sh1pt.config.js',
+  'sh1pt.config.mjs',
+  'sh1pt.config.cjs',
+  'sh1pt.config.json',
+];
+
+export interface LoadedManifest {
+  manifest: Manifest;
+  path: string;
+}
+
+export interface ResolvedTarget {
+  id: string;
+  spec: TargetSpec;
+}
+
+export async function findManifestPath(projectDir = process.cwd()): Promise<string | null> {
+  for (const name of CONFIG_FILENAMES) {
+    const candidate = resolve(projectDir, name);
+    try {
+      await access(candidate);
+      return candidate;
+    } catch {
+      // keep looking
+    }
+  }
+  return null;
+}
+
+export async function loadManifest(projectDir = process.cwd()): Promise<LoadedManifest> {
+  const path = await findManifestPath(projectDir);
+  if (!path) {
+    throw new Error(`No sh1pt config found in ${projectDir}. Run sh1pt promote ship init first.`);
+  }
+
+  const raw = path.endsWith('.json')
+    ? JSON.parse(await readFile(path, 'utf8'))
+    : await import(pathToFileURL(path).href + `?t=${Date.now()}`).then((mod) => mod.default ?? mod.config ?? mod.manifest);
+
+  return { manifest: manifestSchema.parse(raw), path };
+}
+
+export function resolveTargets(manifest: Manifest, requested?: string[]): ResolvedTarget[] {
+  const entries = Object.entries(manifest.targets ?? {}).filter(([, spec]) => spec.enabled !== false);
+  const selected = requested?.length
+    ? entries.filter(([id]) => requested.includes(id))
+    : entries;
+
+  if (requested?.length) {
+    const known = new Set(entries.map(([id]) => id));
+    const missing = requested.filter((id) => !known.has(id));
+    if (missing.length) {
+      throw new Error(`Unknown or disabled target(s): ${missing.join(', ')}`);
+    }
+  }
+
+  return selected.map(([id, spec]) => ({ id, spec }));
+}


### PR DESCRIPTION
Part of #133.

## Summary
- add reusable CLI manifest loading for sh1pt.config.* and JSON configs
- make `sh1pt build` resolve config, validate channel, filter enabled/requested targets, and emit human/JSON build plans
- make `promote ship` use the real manifest instead of stub-only output for plan/lint/status/target list/available targets

## Tests
- `pnpm --filter ./packages/cli typecheck`
- `pnpm test -- packages/cli/src/input.test.ts packages/cli/src/manifest.test.ts --run`
- manual temp-config `sh1pt build --json --target pkg-npm --channel beta`
