### PR TITLE
Implement scale status and cost summaries

### DIFF
--- a/packages/cli/src/commands/scale-state.test.ts
+++ b/packages/cli/src/commands/scale-state.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { summarizeScaleCost, summarizeScaleStatus, type ScaleState } from './scale-state.js';
+
+const state: ScaleState = {
+  instances: [
+    { id: 'web-1', provider: 'cloud-fly', status: 'running', publicIp: '203.0.113.10', hourlyRate: 0.03, currency: 'USD' },
+    { id: 'web-2', provider: 'cloud-fly', status: 'stopped', hourlyRate: 0.01, currency: 'USD' },
+    { id: 'gpu-1', provider: 'cloud-runpod', status: 'destroyed', hourlyRate: 2.5, currency: 'USD' },
+    { id: 'db-1', provider: 'cloud-neon', status: 'running', currency: 'USD' },
+  ],
+  dns: [
+    { provider: 'dns-cloudflare', domain: 'api.example.com', ttl: 60, records: [{ type: 'A', name: '@', value: '203.0.113.10' }] },
+  ],
+  autoRules: { min: 1, max: 4, targetCpu: 70, cooldown: 300 },
+};
+
+describe('scale state summaries', () => {
+  it('summarizes active fleet cost and ignores destroyed instances', () => {
+    const summary = summarizeScaleCost(state);
+
+    expect(summary.hourly).toBe(0.04);
+    expect(summary.monthly).toBe(29.2);
+    expect(summary.byProvider['cloud-fly']).toEqual({ hourly: 0.04, monthly: 29.2, instances: 2 });
+    expect(summary.byProvider['cloud-runpod']).toBeUndefined();
+  });
+
+  it('flags stopped paid instances and missing rates', () => {
+    const summary = summarizeScaleCost(state);
+
+    expect(summary.suggestions).toContain('destroy or resize 1 stopped paid instance(s)');
+    expect(summary.suggestions).toContain('add hourlyRate to 1 instance(s) for complete cost reporting');
+  });
+
+  it('summarizes fleet status, DNS, and public IPs', () => {
+    const summary = summarizeScaleStatus(state);
+
+    expect(summary.byStatus).toEqual({ running: 2, stopped: 1, destroyed: 1 });
+    expect(summary.publicIps).toEqual(['203.0.113.10']);
+    expect(summary.dns[0]?.domain).toBe('api.example.com');
+    expect(summary.autoRules?.max).toBe(4);
+  });
+});

--- a/packages/cli/src/commands/scale-state.ts
+++ b/packages/cli/src/commands/scale-state.ts
@@ -1,0 +1,163 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+export type ScaleInstanceStatus = 'provisioning' | 'running' | 'stopped' | 'failed' | 'destroyed';
+
+export interface ScaleInstance {
+  id: string;
+  provider?: string;
+  status: ScaleInstanceStatus;
+  publicIp?: string;
+  privateIp?: string;
+  region?: string;
+  sku?: string;
+  hourlyRate?: number;
+  currency?: string;
+  tags?: string[];
+}
+
+export interface ScaleDnsRecord {
+  type?: string;
+  name: string;
+  value: string;
+  weight?: number;
+}
+
+export interface ScaleDnsEntry {
+  provider?: string;
+  domain: string;
+  ttl?: number;
+  records?: ScaleDnsRecord[];
+}
+
+export interface ScaleAutoRule {
+  min: number;
+  max: number;
+  targetCpu?: number;
+  cooldown?: number;
+}
+
+export interface ScaleState {
+  instances: ScaleInstance[];
+  dns: ScaleDnsEntry[];
+  autoRules: ScaleAutoRule | null;
+}
+
+export interface ScaleCostSummary {
+  hourly: number;
+  monthly: number;
+  currency: string;
+  byProvider: Record<string, { hourly: number; monthly: number; instances: number }>;
+  suggestions: string[];
+}
+
+const DEFAULT_SCALE_STATE = '.sh1pt/scale.json';
+const HOURS_PER_MONTH = 730;
+
+export async function loadScaleState(path = DEFAULT_SCALE_STATE): Promise<ScaleState> {
+  try {
+    const raw = await readFile(resolve(process.cwd(), path), 'utf8');
+    const parsed = JSON.parse(raw) as Partial<ScaleState>;
+    return normalizeScaleState(parsed);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return { instances: [], dns: [], autoRules: null };
+    throw error;
+  }
+}
+
+export function summarizeScaleCost(state: ScaleState): ScaleCostSummary {
+  const active = state.instances.filter((instance) => !['destroyed', 'failed'].includes(instance.status));
+  const currencies = new Set(active.map((instance) => instance.currency ?? 'USD'));
+  const currency = currencies.size === 1 ? ([...currencies][0] ?? 'USD') : 'MIXED';
+  const byProvider: ScaleCostSummary['byProvider'] = {};
+  let hourly = 0;
+
+  for (const instance of active) {
+    const provider = instance.provider ?? 'unknown';
+    const rate = instance.hourlyRate ?? 0;
+    hourly += rate;
+    byProvider[provider] ??= { hourly: 0, monthly: 0, instances: 0 };
+    byProvider[provider].hourly += rate;
+    byProvider[provider].monthly = roundMoney(byProvider[provider].hourly * HOURS_PER_MONTH);
+    byProvider[provider].instances += 1;
+  }
+
+  const suggestions: string[] = [];
+  const stoppedPaid = active.filter((instance) => instance.status === 'stopped' && (instance.hourlyRate ?? 0) > 0);
+  if (stoppedPaid.length > 0) {
+    suggestions.push(`destroy or resize ${stoppedPaid.length} stopped paid instance(s)`);
+  }
+  const missingRates = active.filter((instance) => instance.hourlyRate === undefined);
+  if (missingRates.length > 0) {
+    suggestions.push(`add hourlyRate to ${missingRates.length} instance(s) for complete cost reporting`);
+  }
+  if (currency === 'MIXED') {
+    suggestions.push('normalize instance currencies before comparing total spend');
+  }
+
+  return {
+    hourly: roundMoney(hourly),
+    monthly: roundMoney(hourly * HOURS_PER_MONTH),
+    currency,
+    byProvider,
+    suggestions,
+  };
+}
+
+export function summarizeScaleStatus(state: ScaleState) {
+  const byStatus = state.instances.reduce<Record<string, number>>((counts, instance) => {
+    counts[instance.status] = (counts[instance.status] ?? 0) + 1;
+    return counts;
+  }, {});
+  const publicIps = state.instances.flatMap((instance) => instance.publicIp ? [instance.publicIp] : []);
+
+  return {
+    instances: state.instances,
+    byStatus,
+    publicIps,
+    dns: state.dns,
+    autoRules: state.autoRules,
+  };
+}
+
+function normalizeScaleState(input: Partial<ScaleState>): ScaleState {
+  return {
+    instances: Array.isArray(input.instances) ? input.instances.map(normalizeInstance) : [],
+    dns: Array.isArray(input.dns) ? input.dns.map(normalizeDnsEntry) : [],
+    autoRules: input.autoRules ?? null,
+  };
+}
+
+function normalizeInstance(input: Partial<ScaleInstance>): ScaleInstance {
+  return {
+    id: String(input.id ?? 'unknown'),
+    provider: input.provider,
+    status: input.status ?? 'running',
+    publicIp: input.publicIp,
+    privateIp: input.privateIp,
+    region: input.region,
+    sku: input.sku,
+    hourlyRate: typeof input.hourlyRate === 'number' ? input.hourlyRate : undefined,
+    currency: input.currency,
+    tags: input.tags,
+  };
+}
+
+function normalizeDnsEntry(input: Partial<ScaleDnsEntry>): ScaleDnsEntry {
+  return {
+    provider: input.provider,
+    domain: String(input.domain ?? 'unknown'),
+    ttl: input.ttl,
+    records: Array.isArray(input.records) ? input.records.map((record) => ({
+      type: record.type,
+      name: record.name,
+      value: record.value,
+      weight: record.weight,
+    })) : [],
+  };
+}
+
+function roundMoney(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/packages/cli/src/commands/scale.ts
+++ b/packages/cli/src/commands/scale.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import kleur from 'kleur';
 import { describeInput, resolveInput } from '../input.js';
 import { deployCmd } from './deploy.js';
+import { loadScaleState, summarizeScaleCost, summarizeScaleStatus } from './scale-state.js';
 
 export const scaleCmd = new Command('scale')
   .description('Provision + scale cloud infra. DNS round-robin, rollouts, rightsizing — all the capacity ops.')
@@ -85,25 +86,62 @@ scaleCmd
 scaleCmd
   .command('cost')
   .description('Current spend, per-provider breakdown, and rightsizing suggestions')
+  .option('--state <path>', 'scale state file to read', '.sh1pt/scale.json')
   .option('--json')
-  .action((opts: { json?: boolean }) => {
+  .action(async (opts: { state?: string; json?: boolean }) => {
+    const state = await loadScaleState(opts.state);
+    const summary = summarizeScaleCost(state);
     if (opts.json) {
-      console.log(JSON.stringify({ hourly: 0, monthly: 0, byProvider: {}, suggestions: [] }, null, 2));
+      console.log(JSON.stringify(summary, null, 2));
       return;
     }
-    console.log(kleur.dim('[stub] scale cost — hourly/monthly + rightsizing hints'));
-    // TODO: aggregate Instance.hourlyRate across fleet; compare utilization
-    // vs SKU size; suggest downsizing underused boxes or moving to spot/reserved.
+    console.log(kleur.cyan(`scale cost · ${summary.currency}`));
+    console.log(`  hourly:  ${summary.hourly.toFixed(2)}`);
+    console.log(`  monthly: ${summary.monthly.toFixed(2)} ${kleur.dim('(730h estimate)')}`);
+    const providers = Object.entries(summary.byProvider);
+    if (providers.length > 0) {
+      console.log('\nproviders:');
+      for (const [provider, cost] of providers) {
+        console.log(`  ${provider}: ${cost.hourly.toFixed(2)}/hr · ${cost.monthly.toFixed(2)}/mo · ${cost.instances} instance(s)`);
+      }
+    }
+    if (summary.suggestions.length > 0) {
+      console.log('\nsuggestions:');
+      for (const suggestion of summary.suggestions) console.log(`  - ${suggestion}`);
+    }
   });
 
 scaleCmd
   .command('status')
   .description('Current fleet: instance count, DNS records, load distribution')
+  .option('--state <path>', 'scale state file to read', '.sh1pt/scale.json')
   .option('--json')
-  .action((opts: { json?: boolean }) => {
+  .action(async (opts: { state?: string; json?: boolean }) => {
+    const state = await loadScaleState(opts.state);
+    const summary = summarizeScaleStatus(state);
     if (opts.json) {
-      console.log(JSON.stringify({ instances: [], dns: [], autoRules: null }, null, 2));
+      console.log(JSON.stringify(summary, null, 2));
       return;
     }
-    console.log(kleur.dim('[stub] scale status'));
+    console.log(kleur.cyan(`scale status · ${summary.instances.length} instance(s)`));
+    const statuses = Object.entries(summary.byStatus).map(([status, count]) => `${status}=${count}`).join(' ');
+    if (statuses) console.log(`  ${statuses}`);
+    if (summary.publicIps.length > 0) console.log(`  public IPs: ${summary.publicIps.join(', ')}`);
+    if (summary.dns.length > 0) {
+      console.log('\ndns:');
+      for (const entry of summary.dns) {
+        const provider = entry.provider ? ` · ${entry.provider}` : '';
+        const ttl = entry.ttl ? ` · ttl=${entry.ttl}` : '';
+        console.log(`  ${entry.domain}${provider}${ttl}`);
+        for (const record of entry.records ?? []) {
+          const weight = record.weight === undefined ? '' : ` · weight=${record.weight}`;
+          console.log(`    ${record.type ?? 'A'} ${record.name} -> ${record.value}${weight}`);
+        }
+      }
+    }
+    if (summary.autoRules) {
+      console.log(`\nauto: min=${summary.autoRules.min} max=${summary.autoRules.max}` +
+        `${summary.autoRules.targetCpu ? ` targetCpu=${summary.autoRules.targetCpu}%` : ''}` +
+        `${summary.autoRules.cooldown ? ` cooldown=${summary.autoRules.cooldown}s` : ''}`);
+    }
   });


### PR DESCRIPTION
Related to #133.

This turns two read-only `scale` subcommands into useful local planning commands instead of stub output.

What changed:
- added a `.sh1pt/scale.json` state reader for local fleet/DNS/autoscale snapshots
- implemented `sh1pt scale status` human and JSON summaries with instance status counts, public IPs, DNS records, and auto rules
- implemented `sh1pt scale cost` human and JSON summaries with hourly/monthly totals, provider breakdowns, and simple rightsizing data-quality suggestions
- kept the commands read-only and credential-free so they are safe to run before live provider integrations are wired
- added focused unit coverage for cost/status summary behavior

Verified:
- `pnpm vitest run packages/cli/src/commands/scale-state.test.ts`
- `pnpm --filter @profullstack/sh1pt typecheck`
- `git diff --check`
- smoke-tested `scale status --json` and `scale cost` through `tsx packages/cli/src/index.ts` against a temporary `.sh1pt/scale.json`
