### PR TITLE
feat(cli): implement social post command and persist iterate goals

### DIFF
--- a/packages/cli/src/commands/iterate.ts
+++ b/packages/cli/src/commands/iterate.ts
@@ -1,7 +1,30 @@
 import { Command } from 'commander';
 import kleur from 'kleur';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { configDir } from '@profullstack/sh1pt-core';
 import { describeInput, resolveInput } from '../input.js';
 import { agentsCmd } from './agents.js';
+
+const GOALS_FILE = () => path.join(configDir(), 'iterate-goals.json');
+
+async function loadGoals(): Promise<Record<string, string>> {
+  try {
+    const raw = await fs.readFile(GOALS_FILE(), 'utf8');
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, string>) : {};
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return {};
+    throw err;
+  }
+}
+
+async function saveGoals(goals: Record<string, string>): Promise<void> {
+  await fs.mkdir(configDir(), { recursive: true, mode: 0o700 });
+  const tmp = `${GOALS_FILE()}.tmp`;
+  await fs.writeFile(tmp, JSON.stringify(goals, null, 2) + '\n', { mode: 0o600 });
+  await fs.rename(tmp, GOALS_FILE());
+}
 
 export const iterateCmd = new Command('iterate')
   .description('Observe metrics, have an agent propose changes, ship, measure. Powered by Claude / Codex / Qwen.')
@@ -56,13 +79,58 @@ iterateCmd
   .command('goals')
   .description('Declare the success metrics iterate steers toward')
   .argument('[kv...]', 'e.g. conversion=8% cpi=2.00 churn=5%')
-  .action((kv: string[]) => {
-    if (kv.length === 0) {
-      console.log(kleur.dim('[stub] iterate goals — list current goals'));
+  .option('--clear', 'remove all saved goals')
+  .option('--unset <key>', 'remove a single goal by key')
+  .option('--json', 'machine-readable output')
+  .action(async (kv: string[], opts: { clear?: boolean; unset?: string; json?: boolean }) => {
+    const goals = await loadGoals();
+
+    if (opts.clear) {
+      await saveGoals({});
+      console.log(kleur.yellow('all goals cleared'));
       return;
     }
-    console.log(kleur.cyan(`[stub] iterate goals set ${kv.join(' ')}`));
-    // TODO: persist goals; iterate run uses these as the optimization target
+
+    if (opts.unset) {
+      if (opts.unset in goals) {
+        delete goals[opts.unset];
+        await saveGoals(goals);
+        console.log(kleur.yellow(`unset: ${opts.unset}`));
+      } else {
+        console.log(kleur.dim(`goal "${opts.unset}" not set`));
+      }
+      return;
+    }
+
+    if (kv.length === 0) {
+      if (Object.keys(goals).length === 0) {
+        console.log(kleur.dim('no goals set — pass key=value pairs to set them'));
+        return;
+      }
+      if (opts.json) {
+        console.log(JSON.stringify(goals, null, 2));
+        return;
+      }
+      console.log(kleur.bold('current goals:'));
+      for (const [k, v] of Object.entries(goals)) {
+        console.log(`  ${kleur.cyan(k)} = ${v}`);
+      }
+      return;
+    }
+
+    for (const pair of kv) {
+      const idx = pair.indexOf('=');
+      if (idx === -1) {
+        console.error(kleur.red(`invalid goal "${pair}" — expected key=value`));
+        continue;
+      }
+      const key = pair.slice(0, idx).trim();
+      const value = pair.slice(idx + 1).trim();
+      if (!key) { console.error(kleur.red(`empty key in "${pair}"`)); continue; }
+      goals[key] = value;
+      console.log(kleur.green(`  set ${key} = ${value}`));
+    }
+    await saveGoals(goals);
   });
 
 iterateCmd

--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -1,7 +1,13 @@
 import { Command } from 'commander';
 import kleur from 'kleur';
 import prompts from 'prompts';
-import { runSetup, type AdapterWithSetup } from '@profullstack/sh1pt-core';
+import {
+  runSetup,
+  type AdapterWithSetup,
+  type SocialPlatform,
+  type SocialPost,
+  getAdapterConfig,
+} from '@profullstack/sh1pt-core';
 import { describeInput, resolveInput } from '../input.js';
 import { merchCmd } from './merch.js';
 import { shipCmd as shipSub } from './ship.js';
@@ -265,6 +271,13 @@ function stripSocialPrefix(p: string): string {
   return p.replace(/^social-/, '').toLowerCase();
 }
 
+function inferMediaKind(file: string): 'image' | 'video' | 'gif' {
+  const lower = file.toLowerCase();
+  if (lower.endsWith('.gif')) return 'gif';
+  if (/\.(mp4|mov|avi|webm|mkv)$/.test(lower)) return 'video';
+  return 'image';
+}
+
 socialCmd
   .command('post')
   .description('Cross-post to every connected platform with per-platform adaptation')
@@ -276,8 +289,92 @@ socialCmd
   .option('--platform <id...>', 'subset; default: all connected')
   .option('--schedule <iso>', 'publish at ISO timestamp; omit for now')
   .option('--dry-run')
-  .action((opts) => {
-    console.log(kleur.green(`[stub] social post ${JSON.stringify(opts)}`));
+  .action(async (opts: {
+    body: string;
+    title?: string;
+    hashtags?: string;
+    media?: string[];
+    link?: string;
+    platform?: string[];
+    schedule?: string;
+    dryRun?: boolean;
+  }) => {
+    const post: SocialPost = {
+      body: opts.body,
+      title: opts.title,
+      hashtags: opts.hashtags ? opts.hashtags.split(',').map((h) => h.trim()).filter(Boolean) : undefined,
+      media: opts.media?.map((file) => ({ file, kind: inferMediaKind(file) })),
+      link: opts.link,
+      schedule: opts.schedule ? new Date(opts.schedule) : undefined,
+    };
+
+    const names = (opts.platform ?? SOCIAL_PLATFORMS).map(stripSocialPrefix).filter(Boolean);
+
+    if (opts.dryRun) {
+      console.log(kleur.cyan('dry-run: social post preview\n'));
+      for (const name of names) {
+        const pkg = `@profullstack/sh1pt-social-${name}`;
+        let adapter: SocialPlatform<unknown> | null = null;
+        try {
+          adapter = await loadInstalledPackage<SocialPlatform<unknown>>(pkg);
+        } catch {
+          // not installed — skip
+        }
+        if (!adapter) {
+          console.log(kleur.dim(`  ${name}: not installed — run: sh1pt promote social setup --platform ${name}`));
+          continue;
+        }
+        const max = adapter.requires?.maxBodyChars;
+        const truncated = max && post.body.length > max ? post.body.slice(0, max - 3) + '...' : post.body;
+        console.log(kleur.bold(`  ${adapter.label ?? name}`));
+        console.log(`    body (${truncated.length} chars): ${truncated.slice(0, 80)}${truncated.length > 80 ? '…' : ''}`);
+        if (post.hashtags?.length) console.log(`    hashtags: ${post.hashtags.map((h) => `#${h}`).join(' ')}`);
+        if (post.link) console.log(`    link: ${post.link}`);
+        if (post.schedule) console.log(`    schedule: ${post.schedule.toISOString()}`);
+      }
+      return;
+    }
+
+    let anyPosted = false;
+    for (const name of names) {
+      const pkg = `@profullstack/sh1pt-social-${name}`;
+      let adapter: SocialPlatform<unknown> | null = null;
+      try {
+        adapter = await loadInstalledPackage<SocialPlatform<unknown>>(pkg);
+      } catch {
+        // not installed
+      }
+      if (!adapter) {
+        console.log(kleur.dim(`  ${name}: not installed — skipping`));
+        continue;
+      }
+
+      const adapterConfig = await getAdapterConfig(adapter.id);
+      if (!adapterConfig) {
+        console.log(kleur.yellow(`  ${name}: not configured — run: sh1pt promote social setup --platform ${name}`));
+        continue;
+      }
+
+      const ctx = {
+        secret: (k: string) => process.env[k],
+        log: (m: string) => console.log(kleur.dim(`    [${name}] ${m}`)),
+        dryRun: false,
+      };
+
+      try {
+        console.log(kleur.bold(`  posting to ${adapter.label ?? name}…`));
+        await adapter.connect(ctx, adapterConfig);
+        const result = await adapter.post(ctx, post, adapterConfig);
+        console.log(kleur.green(`  ✓ ${adapter.label ?? name} · ${result.url}`));
+        anyPosted = true;
+      } catch (err) {
+        console.error(kleur.red(`  ✗ ${name}: ${err instanceof Error ? err.message : String(err)}`));
+      }
+    }
+
+    if (!anyPosted) {
+      console.log(kleur.yellow('\nno platforms posted — set up accounts with: sh1pt promote social setup'));
+    }
   });
 
 socialCmd


### PR DESCRIPTION
Closes #151
Closes #152

## Changes

### `sh1pt promote social post` (#151)

Replaces the `[stub]` action with a real adapter fan-out:

- Builds a `SocialPost` from `--body`, `--title`, `--hashtags`, `--media`, `--link`, `--schedule`
- `--platform` selects a subset; defaults to all platforms in `SOCIAL_PLATFORMS`
- `--dry-run` prints a per-platform preview (body length, hashtags, link) without connecting
- Live run: lazy-loads `@profullstack/sh1pt-social-<name>` via `loadInstalledPackage`, reads saved adapter config via `getAdapterConfig`, calls `connect()` then `post()`
- Skips platforms that are not installed or not configured, printing a helpful hint
- Adds `inferMediaKind` helper that infers `image` / `video` / `gif` from file extension

### `sh1pt iterate goals` (#152)

Replaces the `[stub]` with full persistence backed by `~/.config/sh1pt/iterate-goals.json`:

- No args: lists current goals (or prints a hint if none are set)
- `key=value` args: set one or more goals and save
- `--unset <key>`: remove a single goal
- `--clear`: wipe all goals
- `--json`: machine-readable output when listing
- File is written atomically via a `.tmp` + rename pattern, matching `config-store.ts`