### PR TITLE
Implement Doppler secret provider CLI operations

### DIFF
--- a/packages/secrets/doppler/src/index.test.ts
+++ b/packages/secrets/doppler/src/index.test.ts
@@ -1,4 +1,102 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'secrets' });
+
+const tempDirs: string[] = [];
+const oldPath = process.env.PATH;
+
+afterEach(async () => {
+  process.env.PATH = oldPath;
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('secrets-doppler CLI integration', () => {
+  const config = { project: 'demo-app', config: 'prd' };
+  const ctx = {
+    secret: (key: string) => key === 'DOPPLER_TOKEN' ? 'dp.st.test' : undefined,
+    log: () => {},
+  };
+
+  it('downloads Doppler secrets as SecretRef values', async () => {
+    const { binDir, logPath } = await installFakeDoppler({
+      stdout: JSON.stringify({
+        API_KEY: { computed: 'live-key' },
+        PLAIN_VALUE: 'plain',
+      }),
+    });
+    process.env.PATH = `${binDir}:${oldPath ?? ''}`;
+
+    const secrets = await adapter.pull(ctx, config);
+
+    expect(secrets).toEqual([
+      { key: 'API_KEY', value: 'live-key', environment: 'prd' },
+      { key: 'PLAIN_VALUE', value: 'plain', environment: 'prd' },
+    ]);
+    expect(await readJsonLines(logPath)).toEqual([{
+      args: ['secrets', 'download', '--no-file', '--format', 'json', '--project', 'demo-app', '--config', 'prd'],
+      token: 'dp.st.test',
+      project: 'demo-app',
+      config: 'prd',
+    }]);
+  });
+
+  it('sets pushed secrets through the Doppler CLI', async () => {
+    const { binDir, logPath } = await installFakeDoppler({ stdout: '{}' });
+    process.env.PATH = `${binDir}:${oldPath ?? ''}`;
+
+    const result = await adapter.push(ctx, [
+      { key: 'API_KEY', value: 'next-key' },
+      { key: 'EMPTY_VALUE' },
+    ], config);
+
+    expect(result).toEqual({ count: 2 });
+    expect(await readJsonLines(logPath)).toEqual([{
+      args: ['secrets', 'set', '--project', 'demo-app', '--config', 'prd', 'API_KEY=next-key', 'EMPTY_VALUE='],
+      token: 'dp.st.test',
+      project: 'demo-app',
+      config: 'prd',
+    }]);
+  });
+
+  it('checks the account with doppler me during connect', async () => {
+    const { binDir, logPath } = await installFakeDoppler({ stdout: '{"name":"demo"}' });
+    process.env.PATH = `${binDir}:${oldPath ?? ''}`;
+
+    await expect(adapter.connect(ctx, config)).resolves.toEqual({ accountId: 'demo-app' });
+    expect(await readJsonLines(logPath)).toEqual([{
+      args: ['me', '--json'],
+      token: 'dp.st.test',
+      project: 'demo-app',
+      config: 'prd',
+    }]);
+  });
+
+  it('fails with a vault hint when the token is missing', async () => {
+    await expect(adapter.pull({ secret: () => undefined, log: () => {} }, config)).rejects.toThrow('DOPPLER_TOKEN not in vault');
+  });
+});
+
+async function installFakeDoppler(opts: { stdout: string }): Promise<{ binDir: string; logPath: string }> {
+  const binDir = await mkdtemp(join(tmpdir(), 'sh1pt-doppler-bin-'));
+  const logPath = join(binDir, 'doppler-log.jsonl');
+  tempDirs.push(binDir);
+  const script = join(binDir, 'doppler');
+  await writeFile(script, [
+    '#!/usr/bin/env node',
+    "const fs = require('node:fs');",
+    `const logPath = ${JSON.stringify(logPath)};`,
+    "fs.appendFileSync(logPath, JSON.stringify({ args: process.argv.slice(2), token: process.env.DOPPLER_TOKEN, project: process.env.DOPPLER_PROJECT, config: process.env.DOPPLER_CONFIG }) + '\\n');",
+    `process.stdout.write(${JSON.stringify(opts.stdout)});`,
+  ].join('\n'), 'utf-8');
+  await chmod(script, 0o755);
+  return { binDir, logPath };
+}
+
+async function readJsonLines(path: string): Promise<unknown[]> {
+  return (await readFile(path, 'utf-8')).trim().split('\n').map((line) => JSON.parse(line));
+}

--- a/packages/secrets/doppler/src/index.ts
+++ b/packages/secrets/doppler/src/index.ts
@@ -1,8 +1,14 @@
-import { defineSecretProvider, manualSetup, type SecretRef } from '@profullstack/sh1pt-core';
+import { defineSecretProvider, exec, manualSetup, type SecretRef } from '@profullstack/sh1pt-core';
 
 interface Config {
   project: string;
   config: string;
+  tokenKey?: string;
+}
+
+interface DopplerSecret {
+  computed?: string | null;
+  raw?: string | null;
 }
 
 export default defineSecretProvider<Config>({
@@ -10,16 +16,43 @@ export default defineSecretProvider<Config>({
   label: 'Doppler',
   cli: 'doppler',
   async connect(ctx, config) {
-    if (!ctx.secret('DOPPLER_TOKEN')) throw new Error('DOPPLER_TOKEN not in vault');
+    const tokenKey = config.tokenKey ?? 'DOPPLER_TOKEN';
+    const token = ctx.secret(tokenKey);
+    if (!token) throw new Error(`${tokenKey} not in vault`);
     ctx.log(`doppler me · project=${config.project} · config=${config.config}`);
+    await runDoppler(ctx, ['me', '--json'], config, token);
     return { accountId: config.project };
   },
   async pull(ctx, config): Promise<SecretRef[]> {
-    ctx.log(`doppler secrets download --no-file --format json --project ${config.project} --config ${config.config}`);
-    return [];
+    const token = requireToken(ctx, config);
+    ctx.log(`doppler secrets download · project=${config.project} · config=${config.config}`);
+    const result = await runDoppler(ctx, [
+      'secrets',
+      'download',
+      '--no-file',
+      '--format',
+      'json',
+      '--project',
+      config.project,
+      '--config',
+      config.config,
+    ], config, token);
+    return parseDopplerSecrets(result.stdout, config.config);
   },
   async push(ctx, secrets, config) {
-    ctx.log(`doppler secrets set <${secrets.length} keys> --project ${config.project} --config ${config.config}`);
+    const token = requireToken(ctx, config);
+    if (secrets.length === 0) return { count: 0 };
+    const args = [
+      'secrets',
+      'set',
+      '--project',
+      config.project,
+      '--config',
+      config.config,
+      ...secrets.map((secret) => `${secret.key}=${secret.value ?? ''}`),
+    ];
+    ctx.log(`doppler secrets set <${secrets.length} keys> · project=${config.project} · config=${config.config}`);
+    await runDoppler(ctx, args, config, token);
     return { count: secrets.length };
   },
   setup: manualSetup({
@@ -32,3 +65,45 @@ export default defineSecretProvider<Config>({
     ],
   }),
 });
+
+function requireToken(ctx: { secret(k: string): string | undefined }, config: Config): string {
+  const tokenKey = config.tokenKey ?? 'DOPPLER_TOKEN';
+  const token = ctx.secret(tokenKey);
+  if (!token) throw new Error(`${tokenKey} not in vault`);
+  return token;
+}
+
+async function runDoppler(
+  ctx: { log(m: string): void },
+  args: string[],
+  config: Config,
+  token: string,
+) {
+  try {
+    return await exec('doppler', args, {
+      log: ctx.log,
+      throwOnNonZero: true,
+      env: {
+        DOPPLER_TOKEN: token,
+        DOPPLER_PROJECT: config.project,
+        DOPPLER_CONFIG: config.config,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.startsWith('command not found: doppler')) {
+      throw new Error('secrets-doppler requires the Doppler CLI on PATH. Install it from https://docs.doppler.com/docs/cli');
+    }
+    throw error;
+  }
+}
+
+function parseDopplerSecrets(stdout: string, environment: string): SecretRef[] {
+  if (!stdout.trim()) return [];
+  const data = JSON.parse(stdout) as Record<string, string | DopplerSecret>;
+  return Object.entries(data).map(([key, value]) => ({
+    key,
+    value: typeof value === 'string' ? value : value.computed ?? value.raw ?? '',
+    environment,
+  }));
+}


### PR DESCRIPTION
Related to #6 and #133.

This turns the `secrets-doppler` adapter from log-only stubs into real Doppler CLI operations while keeping auth in the sh1pt vault.

What changed:
- require `DOPPLER_TOKEN` (or configurable `tokenKey`) from the vault for connect/pull/push
- call `doppler me --json` during connect to verify the CLI/auth path
- implement `pull` with `doppler secrets download --no-file --format json --project <project> --config <config>` and map Doppler JSON into `SecretRef[]`
- implement `push` with `doppler secrets set` for the provided secret refs
- pass project/config/token through environment variables and provide a clear install hint when the CLI is missing
- add mocked-CLI tests for pull, push, connect, and missing-token behavior

Verified:
- `pnpm exec vitest run packages/secrets/doppler/src/index.test.ts`
- `pnpm --filter @profullstack/sh1pt-secrets-doppler typecheck`
- `pnpm --filter @profullstack/sh1pt typecheck`
- `git diff --check`
