### PR TITLE
feat(cli): add dry-run to scale mutating commands and --json to list commands

### DIFF
--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -10,10 +10,17 @@ export const agentsCmd = new Command('agents')
 agentsCmd
   .command('list')
   .description('Which agent CLIs are installed on this machine')
-  .action(() => {
+  .option('--json', 'machine-readable output')
+  .action((opts: { json?: boolean }) => {
     const agents = ['claude', 'codex', 'qwen'];
+    // TODO: resolve each adapter, call check() for real installed/authenticated status
+    if (opts.json) {
+      console.log(JSON.stringify({
+        agents: agents.map((id) => ({ id, installed: false, authenticated: false })),
+      }, null, 2));
+      return;
+    }
     for (const a of agents) {
-      // TODO: resolve adapter, call check(), render real status
       console.log(`  ${kleur.gray('○')} ${kleur.bold(a)}  ${kleur.dim('run `sh1pt agents setup --agent ' + a + '`')}`);
     }
   });

--- a/packages/cli/src/commands/scale.ts
+++ b/packages/cli/src/commands/scale.ts
@@ -28,7 +28,16 @@ scaleCmd
   .option('--instances <n>', 'how many to add', Number)
   .option('--provider <id>', 'which cloud provider to add to (default: same as existing fleet)')
   .option('--max-hourly-price <usd>', 'abort if the new instances would push above this total/hr', Number)
-  .action((opts) => {
+  .option('--dry-run', 'show what would be provisioned without spending money')
+  .action((opts: { instances?: number; provider?: string; maxHourlyPrice?: number; dryRun?: boolean }) => {
+    if (opts.dryRun) {
+      console.log(kleur.cyan('dry-run: scale up'));
+      console.log(`  would provision ${opts.instances ?? 1} instance(s)` +
+        (opts.provider ? ` on ${opts.provider}` : ' (same provider as fleet)'));
+      if (opts.maxHourlyPrice) console.log(`  max hourly price cap: $${opts.maxHourlyPrice}/hr`);
+      console.log(kleur.dim('  no instances will be created'));
+      return;
+    }
     console.log(kleur.green(`[stub] scale up ${JSON.stringify(opts)}`));
     // TODO: resolve current fleet, call CloudProvider.provision() × N,
     // then DnsProvider.syncRoundRobin() with the new IP list.
@@ -39,7 +48,15 @@ scaleCmd
   .description('Tear down instances (cheapest / least-healthy first)')
   .option('--instances <n>', 'number of instances to destroy', Number)
   .option('--provider <id>', 'cloud provider id')
-  .action((opts) => {
+  .option('--dry-run', 'show which instances would be destroyed without actually destroying them')
+  .action((opts: { instances?: number; provider?: string; dryRun?: boolean }) => {
+    if (opts.dryRun) {
+      console.log(kleur.cyan('dry-run: scale down'));
+      console.log(`  would destroy ${opts.instances ?? 1} instance(s)` +
+        (opts.provider ? ` on ${opts.provider}` : ''));
+      console.log(kleur.dim('  no instances will be destroyed'));
+      return;
+    }
     console.log(kleur.yellow(`[stub] scale down ${JSON.stringify(opts)}`));
     // TODO: pick N victims, CloudProvider.destroy() each, syncRoundRobin() with remaining IPs
   });
@@ -51,8 +68,16 @@ scaleCmd
   .option('--max <n>', 'maximum instances', Number, 10)
   .option('--target-cpu <percent>', 'target CPU utilization to maintain', Number, 70)
   .option('--cooldown <seconds>', 'minimum time between scale events', Number, 300)
-  .action((opts) => {
-    console.log(kleur.cyan(`[stub] scale auto ${JSON.stringify(opts)}`));
+  .option('--dry-run', 'preview the rule that would be saved without persisting it')
+  .action((opts: { min: number; max: number; targetCpu: number; cooldown: number; dryRun?: boolean }) => {
+    const rule = { min: opts.min, max: opts.max, targetCpu: opts.targetCpu, cooldown: opts.cooldown };
+    if (opts.dryRun) {
+      console.log(kleur.cyan('dry-run: scale auto — rule preview'));
+      console.log(JSON.stringify(rule, null, 2));
+      console.log(kleur.dim('  rule will not be persisted'));
+      return;
+    }
+    console.log(kleur.cyan(`[stub] scale auto ${JSON.stringify(rule)}`));
     // TODO: PUT /v1/scale/rules — sh1pt cloud evaluates periodically
   });
 
@@ -63,7 +88,17 @@ scaleCmd
   .requiredOption('--domain <fqdn>', 'e.g. api.example.com')
   .option('--ttl <seconds>', '', Number, 60)
   .option('--proxied', 'cloudflare only — route through the CF edge (orange cloud)')
-  .action((opts) => {
+  .option('--dry-run', 'show the DNS records that would be created without modifying DNS')
+  .action((opts: { provider: string; domain: string; ttl: number; proxied?: boolean; dryRun?: boolean }) => {
+    if (opts.dryRun) {
+      console.log(kleur.cyan('dry-run: scale dns'));
+      console.log(`  provider: ${opts.provider}`);
+      console.log(`  domain:   ${opts.domain}`);
+      console.log(`  ttl:      ${opts.ttl}s`);
+      if (opts.proxied) console.log('  proxied:  true (cloudflare orange cloud)');
+      console.log(kleur.dim('  DNS records will not be modified'));
+      return;
+    }
     console.log(kleur.cyan(`[stub] scale dns ${JSON.stringify(opts)}`));
     // TODO: resolve fleet IPs, call DnsProvider.syncRoundRobin({ name, ips, ttl, proxied })
   });
@@ -71,13 +106,23 @@ scaleCmd
 scaleCmd
   .command('rollout')
   .description('Stage a new version across the fleet (canary / blue-green)')
-  .requiredOption('--version <id>')
+  // Use --release instead of --version to avoid shadowing Commander's built-in --version flag.
+  .requiredOption('--release <id>', 'the release/version id to roll out')
   .option('--strategy <kind>', 'canary | blue-green | rolling', 'canary')
   .option('--percent <n>', 'canary only — start at N% of traffic', Number, 5)
-  .action((opts) => {
+  .option('--dry-run', 'show the rollout plan without touching the fleet')
+  .action((opts: { release: string; strategy: string; percent: number; dryRun?: boolean }) => {
+    if (opts.dryRun) {
+      console.log(kleur.cyan('dry-run: scale rollout'));
+      console.log(`  release:  ${opts.release}`);
+      console.log(`  strategy: ${opts.strategy}`);
+      if (opts.strategy === 'canary') console.log(`  canary:   ${opts.percent}% of traffic`);
+      console.log(kleur.dim('  fleet will not be modified'));
+      return;
+    }
     console.log(kleur.cyan(`[stub] scale rollout ${JSON.stringify(opts)}`));
     // TODO:
-    //   canary    → provision new instances on 'version', adjust DNS weights/round-robin count
+    //   canary    → provision new instances on 'release', adjust DNS weights/round-robin count
     //   blue-green → full parallel fleet, cut DNS over atomically, destroy old on success
     //   rolling   → replace instances one at a time with the new version
   });

--- a/packages/cli/src/commands/secrets.ts
+++ b/packages/cli/src/commands/secrets.ts
@@ -62,10 +62,18 @@ secretsCmd
 
 secretsCmd
   .command('list')
-  .description('List secret keys (never values)')
-  .action(async () => {
+  .description('List secret keys and metadata (never values)')
+  .option('--json', 'machine-readable output — includes key and updated_at, never secret values')
+  .action(async (opts: { json?: boolean }) => {
     if (!(await requireSignedIn())) return;
     const entries = await listSecretsFromCloud();
+    if (opts.json) {
+      console.log(JSON.stringify(
+        { secrets: entries.map((e) => ({ key: e.key, updatedAt: e.updated_at })) },
+        null, 2,
+      ));
+      return;
+    }
     if (entries.length === 0) {
       console.log(kleur.dim('vault is empty.'));
       return;


### PR DESCRIPTION
Closes #144
Closes #146

## Changes

### Dry-run guardrails for scale commands (#144)

Adds `--dry-run` to all scale commands that mutate live infrastructure:

- `scale up --dry-run` — prints instance count and provider without provisioning
- `scale down --dry-run` — prints which instances would be destroyed
- `scale auto --dry-run` — prints the rule JSON that would be saved
- `scale dns --dry-run` — prints provider, domain, TTL, proxied flag without touching DNS
- `scale rollout --dry-run` — prints release, strategy, canary % without modifying the fleet

Also renames `scale rollout --version` → `--release` to avoid shadowing Commander's built-in `--version` flag, which caused `sh1pt scale rollout --version foo` to print the CLI version instead of running the subcommand.

### JSON output for list commands (#146)

- `sh1pt iterate agents list --json` emits `{ agents: [{id, installed, authenticated}] }` — ready for pipe/CI use
- `sh1pt secret list --json` emits `{ secrets: [{key, updatedAt}] }` — keys only, values are never included