### PR TITLE
Implement Snyk security provider scans

### DIFF
--- a/packages/security/snyk/src/index.test.ts
+++ b/packages/security/snyk/src/index.test.ts
@@ -1,4 +1,103 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'security' });
+
+const tempDirs: string[] = [];
+const oldPath = process.env.PATH;
+
+afterEach(async () => {
+  process.env.PATH = oldPath;
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('security-snyk CLI integration', () => {
+  const ctx = {
+    secret: (key: string) => key === 'SNYK_TOKEN' ? 'snyk-token' : undefined,
+    log: () => {},
+  };
+
+  it('runs dependency scans and maps vulnerabilities to findings', async () => {
+    const { binDir, logPath } = await installFakeSnyk({
+      stdout: JSON.stringify({
+        vulnerabilities: [{
+          id: 'SNYK-JS-LODASH-567746',
+          severity: 'high',
+          title: 'Prototype Pollution',
+          packageName: 'lodash',
+          from: ['demo@1.0.0', 'lodash@4.17.15'],
+        }],
+      }),
+    });
+    process.env.PATH = `${binDir}:${oldPath ?? ''}`;
+
+    const result = await adapter.scan(ctx, { path: '.', kind: 'dependencies' }, { org: 'demo-org' });
+
+    expect(result.findings).toEqual([{
+      id: 'SNYK-JS-LODASH-567746',
+      severity: 'high',
+      title: 'Prototype Pollution',
+      packageName: 'lodash',
+      path: 'demo@1.0.0 > lodash@4.17.15',
+    }]);
+    expect(await readJsonLines(logPath)).toEqual([{
+      args: ['test', '.', '--org=demo-org', '--json'],
+      org: 'demo-org',
+      token: 'snyk-token',
+    }]);
+  });
+
+  it('uses container and iac command families for those scan kinds', async () => {
+    const { binDir, logPath } = await installFakeSnyk({ stdout: '[]' });
+    process.env.PATH = `${binDir}:${oldPath ?? ''}`;
+
+    await adapter.scan(ctx, { path: 'web:latest', kind: 'container' }, {});
+    await adapter.scan(ctx, { path: './infra', kind: 'iac' }, {});
+
+    expect(await readJsonLines(logPath)).toEqual([
+      { args: ['container', 'test', 'web:latest', '--json'], token: 'snyk-token' },
+      { args: ['iac', 'test', './infra', '--json'], token: 'snyk-token' },
+    ]);
+  });
+
+  it('checks auth and account state during connect', async () => {
+    const { binDir, logPath } = await installFakeSnyk({ stdout: '{}' });
+    process.env.PATH = `${binDir}:${oldPath ?? ''}`;
+
+    await expect(adapter.connect(ctx, { org: 'demo-org' })).resolves.toEqual({ accountId: 'demo-org' });
+    expect(await readJsonLines(logPath)).toEqual([
+      { args: ['auth', 'snyk-token'], org: 'demo-org' },
+      { args: ['whoami', '--org=demo-org'], org: 'demo-org' },
+    ]);
+  });
+
+  it('fails with a vault hint when the token is missing', async () => {
+    await expect(adapter.scan({ secret: () => undefined, log: () => {} }, { path: '.' }, {})).rejects.toThrow('SNYK_TOKEN not in vault');
+  });
+});
+
+async function installFakeSnyk(opts: { stdout: string }): Promise<{ binDir: string; logPath: string }> {
+  const binDir = await mkdtemp(join(tmpdir(), 'sh1pt-snyk-bin-'));
+  const logPath = join(binDir, 'snyk-log.jsonl');
+  tempDirs.push(binDir);
+  const script = join(binDir, 'snyk');
+  await writeFile(script, [
+    '#!/usr/bin/env node',
+    "const fs = require('node:fs');",
+    `const logPath = ${JSON.stringify(logPath)};`,
+    "const org = process.env.SNYK_CFG_ORG;",
+    "const body = { args: process.argv.slice(2), ...(org ? { org } : {}), token: process.env.SNYK_TOKEN };",
+    "fs.appendFileSync(logPath, JSON.stringify(body) + '\\n');",
+    `process.stdout.write(${JSON.stringify(opts.stdout)});`,
+  ].join('\n'), 'utf-8');
+  await chmod(script, 0o755);
+  return { binDir, logPath };
+}
+
+async function readJsonLines(path: string): Promise<unknown[]> {
+  return (await readFile(path, 'utf-8')).trim().split('\n').map((line) => JSON.parse(line));
+}

--- a/packages/security/snyk/src/index.ts
+++ b/packages/security/snyk/src/index.ts
@@ -1,7 +1,27 @@
-import { defineSecurityProvider, manualSetup } from '@profullstack/sh1pt-core';
+import { defineSecurityProvider, exec, manualSetup, type SecurityFinding, type SecurityScanRequest } from '@profullstack/sh1pt-core';
 
 interface Config {
   org?: string;
+  tokenKey?: string;
+}
+
+interface SnykVulnerability {
+  id?: string;
+  issueId?: string;
+  severity?: string;
+  title?: string;
+  packageName?: string;
+  name?: string;
+  from?: string[];
+  file?: string;
+  path?: string;
+}
+
+interface SnykJson {
+  vulnerabilities?: SnykVulnerability[];
+  issues?: {
+    vulnerabilities?: SnykVulnerability[];
+  };
 }
 
 export default defineSecurityProvider<Config>({
@@ -9,15 +29,18 @@ export default defineSecurityProvider<Config>({
   label: 'Snyk',
   cli: 'snyk',
   async connect(ctx, config) {
-    if (!ctx.secret('SNYK_TOKEN')) throw new Error('SNYK_TOKEN not in vault');
+    const token = requireToken(ctx, config);
     ctx.log(`snyk auth <token> · org=${config.org ?? 'default'}`);
+    await runSnyk(ctx, ['auth', token], config);
+    await runSnyk(ctx, ['whoami', ...orgArgs(config)], config);
     return { accountId: config.org ?? 'snyk' };
   },
   async scan(ctx, req, config) {
-    const org = config.org ? ` --org=${config.org}` : '';
-    const command = req.kind === 'container' ? 'container test' : req.kind === 'iac' ? 'iac test' : 'test';
-    ctx.log(`snyk ${command} ${req.path}${org} --json`);
-    return { findings: [] };
+    const token = requireToken(ctx, config);
+    const args = scanArgs(req, config);
+    ctx.log(`snyk ${args.join(' ')}`);
+    const result = await runSnyk(ctx, args, config, false, token);
+    return { findings: parseSnykFindings(result.stdout) };
   },
   setup: manualSetup({
     label: 'Snyk CLI',
@@ -29,3 +52,73 @@ export default defineSecurityProvider<Config>({
     ],
   }),
 });
+
+function requireToken(ctx: { secret(k: string): string | undefined }, config: Config): string {
+  const tokenKey = config.tokenKey ?? 'SNYK_TOKEN';
+  const token = ctx.secret(tokenKey);
+  if (!token) throw new Error(`${tokenKey} not in vault`);
+  return token;
+}
+
+function scanArgs(req: SecurityScanRequest, config: Config): string[] {
+  const command = req.kind === 'container'
+    ? ['container', 'test', req.path]
+    : req.kind === 'iac'
+      ? ['iac', 'test', req.path]
+      : ['test', req.path];
+  return [...command, ...orgArgs(config), '--json'];
+}
+
+function orgArgs(config: Config): string[] {
+  return config.org ? [`--org=${config.org}`] : [];
+}
+
+async function runSnyk(
+  ctx: { log(m: string): void },
+  args: string[],
+  config: Config,
+  throwOnNonZero = true,
+  token?: string,
+) {
+  try {
+    return await exec('snyk', args, {
+      log: ctx.log,
+      throwOnNonZero,
+      env: {
+        SNYK_TOKEN: token ?? process.env.SNYK_TOKEN,
+        SNYK_CFG_ORG: config.org,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.startsWith('command not found: snyk')) {
+      throw new Error('security-snyk requires the Snyk CLI on PATH. Install it from https://docs.snyk.io/developer-tools/snyk-cli');
+    }
+    throw error;
+  }
+}
+
+function parseSnykFindings(stdout: string): SecurityFinding[] {
+  if (!stdout.trim()) return [];
+  const data = JSON.parse(stdout) as SnykJson | SnykJson[];
+  const reports = Array.isArray(data) ? data : [data];
+  return reports.flatMap((report) => [
+    ...(report.vulnerabilities ?? []),
+    ...(report.issues?.vulnerabilities ?? []),
+  ]).map(toFinding);
+}
+
+function toFinding(vulnerability: SnykVulnerability): SecurityFinding {
+  return {
+    id: vulnerability.id ?? vulnerability.issueId ?? 'snyk-unknown',
+    severity: normalizeSeverity(vulnerability.severity),
+    title: vulnerability.title ?? vulnerability.id ?? 'Snyk finding',
+    packageName: vulnerability.packageName ?? vulnerability.name,
+    path: vulnerability.path ?? vulnerability.file ?? vulnerability.from?.join(' > '),
+  };
+}
+
+function normalizeSeverity(severity?: string): SecurityFinding['severity'] {
+  if (severity === 'critical' || severity === 'high' || severity === 'medium' || severity === 'low') return severity;
+  return 'low';
+}


### PR DESCRIPTION
Related to #6 and #133.

This upgrades the `security-snyk` adapter from log-only scan stubs to real Snyk CLI-backed security scans.

What changed:
- require `SNYK_TOKEN` (or configurable `tokenKey`) from the vault before connect/scan operations
- verify auth during connect with `snyk auth <token>` and `snyk whoami`
- run dependency, container, and IaC scans through the correct Snyk command families with `--json`
- parse Snyk JSON output into sh1pt `SecurityFinding[]` values
- pass org/token context into the CLI environment and return a clear install hint if `snyk` is missing
- add mocked-CLI tests for dependency/container/IaC scans, connect, and missing-token behavior

Verified:
- `pnpm exec vitest run packages/security/snyk/src/index.test.ts`
- `pnpm --filter @profullstack/sh1pt-security-snyk typecheck`
- `pnpm --filter @profullstack/sh1pt typecheck`
- `git diff --check`
