### PR TITLE
Implement 1Password secret provider CLI operations

### DIFF
--- a/packages/secrets/onepassword/src/index.test.ts
+++ b/packages/secrets/onepassword/src/index.test.ts
@@ -1,4 +1,94 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'secrets' });
+
+const tempDirs: string[] = [];
+const oldPath = process.env.PATH;
+
+afterEach(async () => {
+  process.env.PATH = oldPath;
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('secrets-onepassword CLI integration', () => {
+  const config = { vault: 'Engineering', item: 'Production API' };
+  const ctx = { secret: () => undefined, log: () => {} };
+
+  it('pulls item fields as SecretRef values', async () => {
+    const { binDir, logPath } = await installFakeOp({
+      stdout: JSON.stringify({
+        id: 'item-id',
+        title: 'Production API',
+        fields: [
+          { id: 'username', label: 'API_USER', type: 'STRING', value: 'robot' },
+          { id: 'password', label: 'API_KEY', type: 'CONCEALED', value: 'secret' },
+          { id: 'notesPlain', label: 'notes', type: 'MENU', value: 'ignore-me' },
+        ],
+      }),
+    });
+    process.env.PATH = `${binDir}:${oldPath ?? ''}`;
+
+    const secrets = await adapter.pull(ctx, config);
+
+    expect(secrets).toEqual([
+      { key: 'API_USER', value: 'robot', path: 'Production API', environment: 'Engineering' },
+      { key: 'API_KEY', value: 'secret', path: 'Production API', environment: 'Engineering' },
+    ]);
+    expect(await readJsonLines(logPath)).toEqual([{
+      args: ['item', 'get', 'Production API', '--vault', 'Engineering', '--format', 'json'],
+    }]);
+  });
+
+  it('pushes SecretRef values with op item edit', async () => {
+    const { binDir, logPath } = await installFakeOp({ stdout: '{}' });
+    process.env.PATH = `${binDir}:${oldPath ?? ''}`;
+
+    const result = await adapter.push(ctx, [
+      { key: 'API_KEY', value: 'next' },
+      { key: 'EMPTY_VALUE' },
+    ], config);
+
+    expect(result).toEqual({ count: 2 });
+    expect(await readJsonLines(logPath)).toEqual([{
+      args: ['item', 'edit', 'Production API', '--vault', 'Engineering', 'API_KEY=next', 'EMPTY_VALUE='],
+    }]);
+  });
+
+  it('checks the signed-in account during connect', async () => {
+    const { binDir, logPath } = await installFakeOp({ stdout: '{"account_uuid":"acct"}' });
+    process.env.PATH = `${binDir}:${oldPath ?? ''}`;
+
+    await expect(adapter.connect(ctx, config)).resolves.toEqual({ accountId: 'Engineering' });
+    expect(await readJsonLines(logPath)).toEqual([{ args: ['whoami', '--format', 'json'] }]);
+  });
+
+  it('requires an item for pull and push operations', async () => {
+    await expect(adapter.pull(ctx, { vault: 'Engineering' })).rejects.toThrow('secrets-onepassword requires config.item');
+    await expect(adapter.push(ctx, [{ key: 'API_KEY', value: 'next' }], { vault: 'Engineering' })).rejects.toThrow('secrets-onepassword requires config.item');
+  });
+});
+
+async function installFakeOp(opts: { stdout: string }): Promise<{ binDir: string; logPath: string }> {
+  const binDir = await mkdtemp(join(tmpdir(), 'sh1pt-op-bin-'));
+  const logPath = join(binDir, 'op-log.jsonl');
+  tempDirs.push(binDir);
+  const script = join(binDir, 'op');
+  await writeFile(script, [
+    '#!/usr/bin/env node',
+    "const fs = require('node:fs');",
+    `const logPath = ${JSON.stringify(logPath)};`,
+    "fs.appendFileSync(logPath, JSON.stringify({ args: process.argv.slice(2) }) + '\\n');",
+    `process.stdout.write(${JSON.stringify(opts.stdout)});`,
+  ].join('\n'), 'utf-8');
+  await chmod(script, 0o755);
+  return { binDir, logPath };
+}
+
+async function readJsonLines(path: string): Promise<unknown[]> {
+  return (await readFile(path, 'utf-8')).trim().split('\n').map((line) => JSON.parse(line));
+}

--- a/packages/secrets/onepassword/src/index.ts
+++ b/packages/secrets/onepassword/src/index.ts
@@ -1,8 +1,21 @@
-import { defineSecretProvider, manualSetup, type SecretRef } from '@profullstack/sh1pt-core';
+import { defineSecretProvider, exec, manualSetup, type SecretRef } from '@profullstack/sh1pt-core';
 
 interface Config {
   vault: string;
   item?: string;
+}
+
+interface OnePasswordField {
+  id?: string;
+  label?: string;
+  value?: string;
+  type?: string;
+}
+
+interface OnePasswordItem {
+  id?: string;
+  title?: string;
+  fields?: OnePasswordField[];
 }
 
 export default defineSecretProvider<Config>({
@@ -11,14 +24,27 @@ export default defineSecretProvider<Config>({
   cli: 'op',
   async connect(ctx, config) {
     ctx.log(`op whoami · vault=${config.vault}`);
+    await runOp(ctx, ['whoami', '--format', 'json']);
     return { accountId: config.vault };
   },
   async pull(ctx, config): Promise<SecretRef[]> {
-    ctx.log(`op item get ${config.item ?? '<item>'} --vault ${config.vault} --format json`);
-    return [];
+    const item = requireItem(config);
+    ctx.log(`op item get ${item} --vault ${config.vault} --format json`);
+    const result = await runOp(ctx, ['item', 'get', item, '--vault', config.vault, '--format', 'json']);
+    return parseOnePasswordItem(result.stdout, config.vault);
   },
   async push(ctx, secrets, config) {
-    ctx.log(`op item edit ${config.item ?? '<item>'} <${secrets.length} fields> --vault ${config.vault}`);
+    const item = requireItem(config);
+    if (secrets.length === 0) return { count: 0 };
+    ctx.log(`op item edit ${item} <${secrets.length} fields> --vault ${config.vault}`);
+    await runOp(ctx, [
+      'item',
+      'edit',
+      item,
+      '--vault',
+      config.vault,
+      ...secrets.map((secret) => `${secret.key}=${secret.value ?? ''}`),
+    ]);
     return { count: secrets.length };
   },
   setup: manualSetup({
@@ -31,3 +57,37 @@ export default defineSecretProvider<Config>({
     ],
   }),
 });
+
+function requireItem(config: Config): string {
+  if (!config.item) throw new Error('secrets-onepassword requires config.item');
+  return config.item;
+}
+
+async function runOp(ctx: { log(m: string): void }, args: string[]) {
+  try {
+    return await exec('op', args, { log: ctx.log, throwOnNonZero: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.startsWith('command not found: op')) {
+      throw new Error('secrets-onepassword requires the 1Password CLI on PATH. Install it from https://developer.1password.com/docs/cli/');
+    }
+    throw error;
+  }
+}
+
+function parseOnePasswordItem(stdout: string, vault: string): SecretRef[] {
+  if (!stdout.trim()) return [];
+  const item = JSON.parse(stdout) as OnePasswordItem;
+  return (item.fields ?? [])
+    .filter((field) => field.value !== undefined && isSecretField(field))
+    .map((field) => ({
+      key: field.label ?? field.id ?? 'field',
+      value: field.value,
+      path: item.title ?? item.id,
+      environment: vault,
+    }));
+}
+
+function isSecretField(field: OnePasswordField): boolean {
+  return field.type === undefined || ['STRING', 'CONCEALED', 'EMAIL', 'URL', 'OTP'].includes(field.type);
+}


### PR DESCRIPTION
Related to #6 and #133.

This upgrades `secrets-onepassword` from log-only stubs to real 1Password CLI-backed secret pull/push behavior.

What changed:
- verify the signed-in account path with `op whoami --format json` during connect
- implement `pull` via `op item get <item> --vault <vault> --format json`
- map 1Password item fields into sh1pt `SecretRef[]` values with vault/item metadata
- implement `push` via `op item edit <item> --vault <vault> KEY=value ...`
- require `config.item` for pull/push so commands do not silently target a placeholder
- add mocked-CLI tests for pull, push, connect, and missing item behavior

Verified:
- `pnpm exec vitest run packages/secrets/onepassword/src/index.test.ts`
- `pnpm --filter @profullstack/sh1pt-secrets-onepassword typecheck`
- `pnpm --filter @profullstack/sh1pt typecheck`
- `git diff --check`
