### PR TITLE
Implement Lumin document uploads

### DIFF
--- a/packages/docs/lumin/src/index.test.ts
+++ b/packages/docs/lumin/src/index.test.ts
@@ -1,4 +1,138 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'docs', requireSupports: true });
+
+describe('Lumin document creation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('creates a hosted document from a file URL', async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    vi.stubGlobal('fetch', async (url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      return new Response(JSON.stringify({
+        id: 'doc_123',
+        preview_url: 'https://app.luminpdf.com/viewer/doc_123',
+      }), { status: 201, headers: { 'content-type': 'application/json' } });
+    });
+
+    const result = await adapter.generate(ctx(), {
+      kind: 'one-pager',
+      title: 'Investor One Pager',
+      format: 'pdf',
+    }, {
+      baseUrl: 'https://api-sandbox.luminpdf.com/v1',
+      fileUrl: 'https://files.example.com/one-pager.pdf',
+      workspaceId: 'workspace_1',
+      folderId: 'folder_1',
+    });
+
+    expect(result).toEqual({
+      id: 'doc_123',
+      format: 'pdf',
+      url: 'https://app.luminpdf.com/viewer/doc_123',
+    });
+    expect(calls[0]!.url).toBe('https://api-sandbox.luminpdf.com/v1/documents');
+    expect(calls[0]!.init.headers).toMatchObject({
+      'X-API-Key': 'lumin_key',
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    });
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      method: 'file-upload',
+      document_name: 'Investor One Pager',
+      location: {
+        type: 'workspace',
+        workspace_id: 'workspace_1',
+        folder_id: 'folder_1',
+      },
+      document_data: {
+        file_url: 'https://files.example.com/one-pager.pdf',
+      },
+    });
+  });
+
+  it('creates a document from a PDF template with variables', async () => {
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      expect(JSON.parse(init.body as string)).toEqual({
+        method: 'template',
+        document_name: 'NDA',
+        location: {
+          type: 'space',
+          space_id: 'space_1',
+        },
+        document_data: {
+          template_id: 'pdf_template_123',
+          fields: {
+            'Client.Name': 'Acme Corp',
+          },
+        },
+      });
+      return new Response(JSON.stringify({ document_id: 'doc_template' }), {
+        status: 201,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+
+    await expect(adapter.generate(ctx(), {
+      kind: 'contract',
+      title: 'NDA',
+      format: 'pdf',
+      templateId: 'pdf_template_123',
+      variables: {
+        'Client.Name': 'Acme Corp',
+      },
+    }, {
+      spaceId: 'space_1',
+    })).resolves.toMatchObject({ id: 'doc_template', format: 'pdf' });
+  });
+
+  it('uploads a local PDF as multipart form data', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'sh1pt-lumin-'));
+    const pdfPath = join(dir, 'deck.pdf');
+    await writeFile(pdfPath, '%PDF-1.4\n');
+
+    vi.stubGlobal('fetch', async (_url: string, init: RequestInit) => {
+      expect(init.headers).toEqual({ 'X-API-Key': 'lumin_key' });
+      expect(init.body).toBeInstanceOf(FormData);
+      const body = init.body as FormData;
+      expect(body.get('method')).toBe('file-upload');
+      expect(body.get('document_name')).toBe('Pitch Deck');
+      expect(body.get('file')).toBeInstanceOf(File);
+      return new Response(JSON.stringify({ id: 'doc_file' }), {
+        status: 201,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+
+    await expect(adapter.generate(ctx(), {
+      kind: 'pitch-deck',
+      title: 'Pitch Deck',
+      format: 'pdf',
+    }, {
+      localPath: pdfPath,
+    })).resolves.toMatchObject({ id: 'doc_file', format: 'pdf' });
+  });
+
+  it('requires a source document or template', async () => {
+    await expect(adapter.generate(ctx(), {
+      kind: 'one-pager',
+      title: 'One Pager',
+      format: 'pdf',
+    }, {})).rejects.toThrow('config.fileUrl, config.localPath, or spec.templateId');
+  });
+});
+
+function ctx() {
+  return {
+    secret: (key: string) => key === 'LUMIN_API_KEY' ? 'lumin_key' : undefined,
+    log: () => {},
+    dryRun: false,
+  };
+}

--- a/packages/docs/lumin/src/index.ts
+++ b/packages/docs/lumin/src/index.ts
@@ -1,28 +1,51 @@
-import { defineDocs, tokenSetup } from '@profullstack/sh1pt-core';
+import { readFile } from 'node:fs/promises';
+import { basename } from 'node:path';
+import { defineDocs, tokenSetup, type DocSpec } from '@profullstack/sh1pt-core';
 
 // LuminPDF — PDF editor + hosting. API supports upload, signature
 // flows, form fill, and branded viewer links. NOT a presentation
 // generator — use it to host/edit a pitch deck PDF that docs-marp or
 // docs-gslides produces. Pair adapters on generate() → convert() → upload.
 interface Config {
+  baseUrl?: string;
   workspaceId?: string;
+  spaceId?: string;
+  folderId?: string;
+  fileUrl?: string;
+  localPath?: string;
 }
+
+interface LuminDocumentSummary {
+  id?: string;
+  document_id?: string;
+  name?: string;
+  preview_url?: string;
+  url?: string;
+}
+
+const DEFAULT_BASE_URL = 'https://api.luminpdf.com/v1';
+const LUMIN_TOKEN_SECRET = 'LUMIN_API_KEY';
 
 export default defineDocs<Config>({
   id: 'docs-lumin',
   label: 'LuminPDF (PDF hosting + edit)',
   supports: ['pdf'],
 
-  async generate(ctx, spec) {
-    if (!ctx.secret('LUMIN_API_KEY')) throw new Error('LUMIN_API_KEY not in vault');
+  async generate(ctx, spec, config) {
+    const token = ctx.secret(LUMIN_TOKEN_SECRET);
+    if (!token) throw new Error(`${LUMIN_TOKEN_SECRET} not in vault`);
     if (spec.format !== 'pdf') {
       throw new Error(`docs-lumin only hosts PDFs — generate with docs-marp / docs-gslides first, then upload here`);
     }
-    ctx.log(`lumin upload · "${spec.title}"`);
+    ctx.log(`lumin document create · "${spec.title}"`);
     if (ctx.dryRun) return { id: 'dry-run', format: 'pdf', url: 'https://app.luminpdf.com/viewer/stub' };
-    // TODO: POST /api/v1/documents with multipart/form-data (file + metadata)
-    // Returns a viewer URL you can share with investors / customers.
-    return { id: `lumin_${Date.now()}`, format: 'pdf', url: 'https://app.luminpdf.com/viewer/stub' };
+
+    const created = await createDocument(token, spec, config);
+    return {
+      id: created.id ?? created.document_id ?? spec.title,
+      format: 'pdf',
+      url: created.preview_url ?? created.url,
+    };
   },
 
   setup: tokenSetup({
@@ -35,3 +58,86 @@ export default defineDocs<Config>({
     ],
   }),
 });
+
+async function createDocument(token: string, spec: DocSpec, config: Config): Promise<LuminDocumentSummary> {
+  const response = await fetch(endpoint(config, '/documents'), await requestInit(token, spec, config));
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Lumin API request failed (${response.status}): ${text.slice(0, 300)}`);
+  }
+  return await response.json() as LuminDocumentSummary;
+}
+
+async function requestInit(token: string, spec: DocSpec, config: Config): Promise<RequestInit> {
+  const location = documentLocation(config);
+  if (config.localPath) {
+    const file = new Blob([await readFile(config.localPath)], { type: 'application/pdf' });
+    const form = new FormData();
+    form.set('method', 'file-upload');
+    form.set('document_name', spec.title);
+    if (location) form.set('location', JSON.stringify(location));
+    form.set('file', file, basename(config.localPath));
+    return {
+      method: 'POST',
+      headers: { 'X-API-Key': token },
+      body: form,
+    };
+  }
+
+  return {
+    method: 'POST',
+    headers: {
+      'X-API-Key': token,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify(documentPayload(spec, config, location)),
+  };
+}
+
+function documentPayload(spec: DocSpec, config: Config, location: Record<string, string> | undefined) {
+  if (spec.templateId) {
+    return {
+      method: 'template',
+      document_name: spec.title,
+      ...(location ? { location } : {}),
+      document_data: {
+        template_id: spec.templateId,
+        fields: spec.variables ?? {},
+      },
+    };
+  }
+
+  if (config.fileUrl) {
+    return {
+      method: 'file-upload',
+      document_name: spec.title,
+      ...(location ? { location } : {}),
+      document_data: { file_url: config.fileUrl },
+    };
+  }
+
+  throw new Error('docs-lumin requires config.fileUrl, config.localPath, or spec.templateId');
+}
+
+function documentLocation(config: Config): Record<string, string> | undefined {
+  if (config.spaceId) {
+    return {
+      type: 'space',
+      space_id: config.spaceId,
+      ...(config.folderId ? { folder_id: config.folderId } : {}),
+    };
+  }
+  if (config.workspaceId || config.folderId) {
+    return {
+      type: 'workspace',
+      ...(config.workspaceId ? { workspace_id: config.workspaceId } : {}),
+      ...(config.folderId ? { folder_id: config.folderId } : {}),
+    };
+  }
+  return undefined;
+}
+
+function endpoint(config: Config, path: string): string {
+  return `${(config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, '')}${path}`;
+}


### PR DESCRIPTION
## Summary
- replace the docs-lumin stub with real Lumin /documents creation
- support file URL imports, local multipart PDF uploads, and PDF template generation
- map workspace/space/folder destinations and return Lumin preview URLs

## Verification
- pnpm exec vitest run packages/docs/lumin/src/index.test.ts
- pnpm --filter @profullstack/sh1pt-docs-lumin typecheck
- pnpm --filter @profullstack/sh1pt typecheck
- git diff --check