### PR TITLE
Persist iterate goals

### DIFF
--- a/packages/cli/src/commands/iterate-goals.test.ts
+++ b/packages/cli/src/commands/iterate-goals.test.ts
@@ -1,0 +1,43 @@
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { goalsPath, parseGoalAssignments, readIterateGoals, saveIterateGoals } from './iterate-goals.js';
+
+describe('iterate goals persistence', () => {
+  beforeEach(async () => {
+    process.env.XDG_CONFIG_HOME = await mkdtemp(join(tmpdir(), 'sh1pt-goals-'));
+  });
+
+  it('parses key=value goal assignments', () => {
+    expect(parseGoalAssignments(['conversion=8%', 'cpi=2.00'])).toEqual([
+      { key: 'conversion', value: '8%' },
+      { key: 'cpi', value: '2.00' },
+    ]);
+  });
+
+  it('rejects malformed goal assignments', () => {
+    expect(() => parseGoalAssignments(['conversion'])).toThrow('Use key=value');
+    expect(() => parseGoalAssignments(['=8%'])).toThrow('Use key=value');
+    expect(() => parseGoalAssignments(['bad key=8%'])).toThrow('Malformed goal key');
+    expect(() => parseGoalAssignments(['conversion='])).toThrow('Use key=value');
+  });
+
+  it('saves and reads goals in stable key order', async () => {
+    await saveIterateGoals(parseGoalAssignments(['conversion=8%', 'cpi=2.00']));
+    await saveIterateGoals(parseGoalAssignments(['churn=5%', 'conversion=9%']));
+
+    await expect(readIterateGoals()).resolves.toEqual([
+      { key: 'churn', value: '5%' },
+      { key: 'conversion', value: '9%' },
+      { key: 'cpi', value: '2.00' },
+    ]);
+  });
+
+  it('persists goals in the sh1pt config directory', async () => {
+    await saveIterateGoals(parseGoalAssignments(['conversion=8%']));
+
+    expect(goalsPath()).toContain('/sh1pt/iterate-goals.json');
+    await expect(readFile(goalsPath(), 'utf8')).resolves.toContain('"conversion": "8%"');
+  });
+});

--- a/packages/cli/src/commands/iterate-goals.ts
+++ b/packages/cli/src/commands/iterate-goals.ts
@@ -1,0 +1,72 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { configDir } from '@profullstack/sh1pt-core';
+
+export interface IterateGoal {
+  key: string;
+  value: string;
+}
+
+interface GoalsFile {
+  version: number;
+  goals: Record<string, string>;
+}
+
+const GOALS_VERSION = 1;
+
+export function goalsPath(): string {
+  return path.join(configDir(), 'iterate-goals.json');
+}
+
+export function parseGoalAssignments(assignments: string[]): IterateGoal[] {
+  return assignments.map((assignment) => {
+    const index = assignment.indexOf('=');
+    if (index <= 0 || index === assignment.length - 1) {
+      throw new Error(`Malformed goal assignment "${assignment}". Use key=value.`);
+    }
+    const key = assignment.slice(0, index).trim();
+    const value = assignment.slice(index + 1).trim();
+    if (!/^[A-Za-z][A-Za-z0-9_.-]*$/.test(key)) {
+      throw new Error(`Malformed goal key "${key}". Use letters, numbers, dots, dashes, or underscores.`);
+    }
+    if (value.length === 0) {
+      throw new Error(`Malformed goal assignment "${assignment}". Value cannot be empty.`);
+    }
+    return { key, value };
+  });
+}
+
+export async function readIterateGoals(): Promise<IterateGoal[]> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(goalsPath(), 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  }
+
+  const parsed = JSON.parse(raw) as Partial<GoalsFile>;
+  const goals = parsed.goals && typeof parsed.goals === 'object' ? parsed.goals : {};
+  return sortGoals(Object.entries(goals).map(([key, value]) => ({ key, value: String(value) })));
+}
+
+export async function saveIterateGoals(nextGoals: IterateGoal[]): Promise<IterateGoal[]> {
+  const current = new Map((await readIterateGoals()).map((goal) => [goal.key, goal.value]));
+  for (const goal of nextGoals) current.set(goal.key, goal.value);
+
+  const sorted = sortGoals([...current].map(([key, value]) => ({ key, value })));
+  const file: GoalsFile = {
+    version: GOALS_VERSION,
+    goals: Object.fromEntries(sorted.map((goal) => [goal.key, goal.value])),
+  };
+
+  await fs.mkdir(configDir(), { recursive: true, mode: 0o700 });
+  const tmp = `${goalsPath()}.tmp`;
+  await fs.writeFile(tmp, `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
+  await fs.rename(tmp, goalsPath());
+  return sorted;
+}
+
+function sortGoals(goals: IterateGoal[]): IterateGoal[] {
+  return goals.sort((a, b) => a.key.localeCompare(b.key));
+}

--- a/packages/cli/src/commands/iterate.ts
+++ b/packages/cli/src/commands/iterate.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import kleur from 'kleur';
 import { describeInput, resolveInput } from '../input.js';
 import { agentsCmd } from './agents.js';
+import { parseGoalAssignments, readIterateGoals, saveIterateGoals } from './iterate-goals.js';
 
 export const iterateCmd = new Command('iterate')
   .description('Observe metrics, have an agent propose changes, ship, measure. Powered by Claude / Codex / Qwen.')
@@ -56,13 +57,26 @@ iterateCmd
   .command('goals')
   .description('Declare the success metrics iterate steers toward')
   .argument('[kv...]', 'e.g. conversion=8% cpi=2.00 churn=5%')
-  .action((kv: string[]) => {
-    if (kv.length === 0) {
-      console.log(kleur.dim('[stub] iterate goals — list current goals'));
+  .option('--json', 'print saved goals as JSON')
+  .action(async (kv: string[], opts: { json?: boolean }) => {
+    if (kv[0] === 'set') kv = kv.slice(1);
+    if (kv.length > 0) {
+      const saved = await saveIterateGoals(parseGoalAssignments(kv));
+      if (opts.json) {
+        console.log(JSON.stringify({ goals: saved }, null, 2));
+        return;
+      }
+      console.log(kleur.green(`✓ saved ${kv.length} iterate goal${kv.length === 1 ? '' : 's'}`));
+      printGoals(saved);
       return;
     }
-    console.log(kleur.cyan(`[stub] iterate goals set ${kv.join(' ')}`));
-    // TODO: persist goals; iterate run uses these as the optimization target
+
+    const goals = await readIterateGoals();
+    if (opts.json) {
+      console.log(JSON.stringify({ goals }, null, 2));
+      return;
+    }
+    printGoals(goals);
   });
 
 iterateCmd
@@ -75,6 +89,16 @@ iterateCmd
     console.log(kleur.cyan(`[stub] iterate test "${hypothesis}" ${JSON.stringify(opts)}`));
     // TODO: generate two Ship variants, wire feature flag, schedule analysis at min-sample
   });
+
+function printGoals(goals: { key: string; value: string }[]): void {
+  if (goals.length === 0) {
+    console.log(kleur.dim('No iterate goals saved yet.'));
+    return;
+  }
+  for (const goal of goals) {
+    console.log(`${kleur.cyan(goal.key)}=${goal.value}`);
+  }
+}
 
 iterateCmd
   .command('experiments')


### PR DESCRIPTION
## Summary
- persist iterate goals under the sh1pt config directory
- support the documented goals set key=value form while preserving plain key=value input
- list goals in stable order and add --json output for automation
- fail malformed assignments with clear errors

## Verification
- pnpm exec vitest run packages/cli/src/commands/iterate-goals.test.ts
- XDG_CONFIG_HOME=$tmp pnpm exec tsx packages/cli/src/index.ts iterate goals set conversion=8% cpi=2.00
- XDG_CONFIG_HOME=$tmp pnpm exec tsx packages/cli/src/index.ts iterate goals --json
- XDG_CONFIG_HOME=$tmp pnpm exec tsx packages/cli/src/index.ts iterate goals badassignment
- pnpm --filter @profullstack/sh1pt typecheck
- git diff --check

Closes #152