### PR TITLE
Generate browser-firefox dry-run package plans

### DIFF
--- a/packages/targets/browser-firefox/src/index.test.ts
+++ b/packages/targets/browser-firefox/src/index.test.ts
@@ -1,4 +1,109 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { execMock } = vi.hoisted(() => ({
+  execMock: vi.fn(),
+}));
+
+vi.mock('@profullstack/sh1pt-core', async () => ({
+  ...await vi.importActual<typeof import('@profullstack/sh1pt-core')>('@profullstack/sh1pt-core'),
+  exec: execMock,
+}));
+
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'browser', requireKind: true });
+
+const tempDirs: string[] = [];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('browser-firefox target adapter', () => {
+  it('writes a package plan without touching the source directory in dry-run builds', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-firefox-out-'));
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-firefox-project-'));
+    tempDirs.push(outDir, projectDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      projectDir,
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      extensionId: 'myext@example.com',
+      sourceDir: 'extension-dist',
+      channel: 'unlisted',
+    });
+
+    expect(execMock).not.toHaveBeenCalled();
+    expect(result.artifact).toBe(join(outDir, 'myext-example.com-1.2.3.firefox-plan.json'));
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan).toEqual({
+      provider: 'mozilla-addons',
+      extensionId: 'myext@example.com',
+      version: '1.2.3',
+      sourceDir: join(projectDir, 'extension-dist'),
+      artifact: join(outDir, 'myext-example.com-1.2.3.zip'),
+      channel: 'unlisted',
+      build: {
+        command: 'web-ext',
+        args: [
+          'build',
+          '--source-dir',
+          join(projectDir, 'extension-dist'),
+          '--artifacts-dir',
+          outDir,
+          '--filename',
+          'myext-example.com-1.2.3.zip',
+        ],
+        cwd: projectDir,
+      },
+    });
+  });
+
+  it('packages the project-relative source directory with web-ext for real builds', async () => {
+    execMock.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-firefox-out-'));
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-firefox-project-'));
+    const sourceDir = join(projectDir, 'dist');
+    tempDirs.push(outDir, projectDir);
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(join(sourceDir, 'manifest.json'), JSON.stringify({ manifest_version: 3 }), 'utf-8');
+
+    const ctx = fakeBuildContext({
+      outDir,
+      projectDir,
+      version: '1.2.3',
+      dryRun: false,
+    });
+    const result = await adapter.build(ctx as any, {
+      extensionId: '{firefox-addon}',
+    });
+
+    const artifact = join(outDir, 'firefox-addon-1.2.3.zip');
+    expect(execMock).toHaveBeenCalledWith('web-ext', [
+      'build',
+      '--source-dir',
+      sourceDir,
+      '--artifacts-dir',
+      outDir,
+      '--filename',
+      'firefox-addon-1.2.3.zip',
+    ], {
+      cwd: projectDir,
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+    expect(result).toEqual({ artifact });
+  });
+});

--- a/packages/targets/browser-firefox/src/index.ts
+++ b/packages/targets/browser-firefox/src/index.ts
@@ -1,4 +1,6 @@
-import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { defineTarget, exec, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { isAbsolute, join } from 'node:path';
 
 interface Config {
   extensionId: string;       // AMO extension id, e.g. "{some-uuid}" or "myext@example.com"
@@ -6,16 +8,97 @@ interface Config {
   channel?: 'listed' | 'unlisted';
 }
 
+interface FirefoxPackagePlan {
+  provider: 'mozilla-addons';
+  extensionId: string;
+  version: string;
+  sourceDir: string;
+  artifact: string;
+  channel: 'listed' | 'unlisted';
+  build: {
+    command: 'web-ext';
+    args: string[];
+    cwd: string;
+  };
+}
+
+function sourceDir(ctx: { projectDir: string }, config: Config): string {
+  const dir = config.sourceDir ?? 'dist';
+  return isAbsolute(dir) ? dir : join(ctx.projectDir, dir);
+}
+
+function safeFileStem(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-|-$/g, '') || 'firefox-extension';
+}
+
+function artifactName(ctx: { version: string }, config: Config): string {
+  return `${safeFileStem(config.extensionId)}-${safeFileStem(ctx.version)}.zip`;
+}
+
+function artifactPath(ctx: { outDir: string; version: string }, config: Config): string {
+  return join(ctx.outDir, artifactName(ctx, config));
+}
+
+function packagePlan(
+  ctx: { projectDir: string; outDir: string; version: string },
+  config: Config,
+): FirefoxPackagePlan {
+  const src = sourceDir(ctx, config);
+  const filename = artifactName(ctx, config);
+  return {
+    provider: 'mozilla-addons',
+    extensionId: config.extensionId,
+    version: ctx.version,
+    sourceDir: src,
+    artifact: join(ctx.outDir, filename),
+    channel: config.channel ?? 'listed',
+    build: {
+      command: 'web-ext',
+      args: ['build', '--source-dir', src, '--artifacts-dir', ctx.outDir, '--filename', filename],
+      cwd: ctx.projectDir,
+    },
+  };
+}
+
+function parseSubmittedId(id: string): string {
+  const marker = id.lastIndexOf('@');
+  return marker <= 0 ? id : id.slice(0, marker);
+}
+
 export default defineTarget<Config>({
   id: 'browser-firefox',
   kind: 'browser-ext',
   label: 'Firefox Add-ons (AMO)',
   async build(ctx, config) {
-    const src = config.sourceDir ?? 'dist/';
-    ctx.log(`pack Firefox extension from ${src} using web-ext build`);
-    // TODO: run `web-ext build --source-dir ${src} --artifacts-dir ${ctx.outDir}`
-    // Validates manifest.json (v2 or v3) and zips into ctx.outDir
-    return { artifact: `${ctx.outDir}/${config.extensionId.replace(/[{}@]/g, '_')}-${ctx.version}.zip` };
+    const plan = packagePlan(ctx, config);
+    ctx.log(`pack Firefox extension from ${plan.sourceDir} using web-ext build`);
+    await mkdir(ctx.outDir, { recursive: true });
+
+    if (ctx.dryRun) {
+      const planPath = join(ctx.outDir, `${safeFileStem(config.extensionId)}-${safeFileStem(ctx.version)}.firefox-plan.json`);
+      await writeFile(planPath, `${JSON.stringify(plan, null, 2)}\n`, 'utf-8');
+      return { artifact: planPath, meta: { artifact: plan.artifact, command: plan.build } };
+    }
+
+    const manifestPath = join(plan.sourceDir, 'manifest.json');
+    let manifestText: string;
+    try {
+      manifestText = await readFile(manifestPath, 'utf-8');
+    } catch {
+      throw new Error(`manifest.json not found at ${manifestPath} — run a build step first`);
+    }
+    const manifest = JSON.parse(manifestText) as { manifest_version?: number };
+    if (manifest.manifest_version !== 2 && manifest.manifest_version !== 3) {
+      ctx.log(`manifest_version is ${manifest.manifest_version ?? 'missing'}, Firefox expects v2 or v3`, 'warn');
+    }
+
+    await exec(plan.build.command, plan.build.args, {
+      cwd: plan.build.cwd,
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+
+    return { artifact: artifactPath(ctx, config) };
   },
   async ship(ctx, config) {
     const channel = config.channel ?? 'listed';
@@ -30,7 +113,7 @@ export default defineTarget<Config>({
     };
   },
   async status(id) {
-    const [extId] = id.split('@');
+    const extId = parseSubmittedId(id);
     return { state: 'live', url: `https://addons.mozilla.org/en-US/firefox/addon/${extId}/` };
   },
 


### PR DESCRIPTION
## Summary
- add a Firefox package-plan artifact for dry-run builds with the resolved source dir, AMO channel, expected zip artifact, and exact `web-ext build` command
- keep real Firefox builds path-safe by invoking `web-ext` with argv args after validating `manifest.json`
- preserve extension IDs containing `@` when deriving Firefox status URLs

## Tests
- `corepack pnpm vitest run packages/targets/browser-firefox/src/index.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt-target-browser-firefox typecheck`
- `corepack pnpm --filter @profullstack/sh1pt-target-browser-firefox build`
- `git diff --check`

Closes #173
