### PR TITLE
Implement Medium legacy API posting

### DIFF
--- a/packages/social/medium/src/index.test.ts
+++ b/packages/social/medium/src/index.test.ts
@@ -1,4 +1,122 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { contractTestSocial, fakeConnectContext } from '@profullstack/sh1pt-core/testing';
 import adapter from './index.js';
 
-smokeTest(adapter, { idPrefix: 'social' });
+contractTestSocial(adapter, {
+  sampleConfig: { mode: 'api-legacy', authorId: 'user_123' },
+  samplePost: { title: 'Hello Medium', body: 'hello from sh1pt contract tests' },
+  requiredSecrets: ['MEDIUM_INTEGRATION_TOKEN'],
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('social-medium legacy API posting', () => {
+  it('creates a draft post for a Medium user', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        data: {
+          id: 'post_123',
+          url: 'https://medium.com/@sh1pt/release-shipped',
+          publishedAt: 1778683200000,
+        },
+      }),
+    } as any);
+
+    const result = await adapter.post(ctx(), {
+      title: 'Release shipped',
+      body: 'Article body',
+      hashtags: ['startup', 'launch', 'automation', 'ignored'],
+      link: 'https://sh1pt.com',
+    }, {
+      mode: 'api-legacy',
+      authorId: 'user_123',
+      canonicalUrl: 'https://example.com/release-shipped',
+      publishStatus: 'draft',
+      notifyFollowers: false,
+    });
+
+    expect(result).toEqual({
+      id: 'post_123',
+      url: 'https://medium.com/@sh1pt/release-shipped',
+      platform: 'medium',
+      publishedAt: '2026-05-13T14:40:00.000Z',
+    });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.medium.com/v1/users/user_123/posts');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).headers).toMatchObject({
+      Authorization: 'Bearer medium-token',
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    });
+    expect(JSON.parse(String((init as RequestInit).body))).toEqual({
+      title: 'Release shipped',
+      contentFormat: 'markdown',
+      content: 'Article body\n\nhttps://sh1pt.com',
+      tags: ['startup', 'launch', 'automation'],
+      publishStatus: 'draft',
+      canonicalUrl: 'https://example.com/release-shipped',
+      notifyFollowers: false,
+    });
+  });
+
+  it('creates publication posts when publicationId is configured', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        data: {
+          id: 'post_pub',
+          url: 'https://medium.com/sh1pt/release-shipped',
+        },
+      }),
+    } as any);
+
+    await adapter.post(ctx(), {
+      title: 'Release shipped',
+      body: 'Article body',
+    }, {
+      mode: 'api-legacy',
+      publicationId: 'publication_123',
+    });
+
+    expect(fetchMock.mock.calls[0]![0]).toBe('https://api.medium.com/v1/publications/publication_123/posts');
+  });
+
+  it('requires an author or publication id for legacy API posting', async () => {
+    await expect(adapter.post(ctx(), {
+      title: 'Release shipped',
+      body: 'Article body',
+    }, {
+      mode: 'api-legacy',
+    })).rejects.toThrow('config.authorId or config.publicationId');
+  });
+
+  it('surfaces Medium API error messages', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      json: async () => ({ errors: [{ message: 'Token was revoked' }] }),
+    } as any);
+
+    await expect(adapter.post(ctx(), {
+      title: 'Release shipped',
+      body: 'Article body',
+    }, {
+      mode: 'api-legacy',
+      authorId: 'user_123',
+    })).rejects.toThrow('Token was revoked');
+  });
+});
+
+function ctx() {
+  return {
+    ...fakeConnectContext({ MEDIUM_INTEGRATION_TOKEN: 'medium-token' }),
+    dryRun: false,
+  } as any;
+}

--- a/packages/social/medium/src/index.ts
+++ b/packages/social/medium/src/index.ts
@@ -1,4 +1,4 @@
-import { defineSocial, oauthSetup } from '@profullstack/sh1pt-core';
+import { defineSocial, oauthSetup, type SocialPost } from '@profullstack/sh1pt-core';
 
 // Medium — the Medium Integration API is deprecated for new apps
 // (as of 2023). Existing integration tokens still work; new accounts
@@ -6,8 +6,20 @@ import { defineSocial, oauthSetup } from '@profullstack/sh1pt-core';
 // legacy API if a user still has one.
 interface Config {
   mode: 'api-legacy' | 'browser';
+  authorId?: string;
   publicationId?: string;
   canonicalUrl?: string;
+  publishStatus?: 'public' | 'draft' | 'unlisted';
+  notifyFollowers?: boolean;
+}
+
+interface MediumPostResponse {
+  data?: {
+    id?: string;
+    url?: string;
+    publishedAt?: number;
+  };
+  errors?: Array<{ message?: string }>;
 }
 
 export default defineSocial<Config>({
@@ -28,9 +40,23 @@ export default defineSocial<Config>({
     if (!post.title) throw new Error('Medium requires a title');
     ctx.log(`medium post · ${config.mode} · "${post.title}"`);
     if (ctx.dryRun) return { id: 'dry-run', url: 'https://medium.com/', platform: 'medium', publishedAt: new Date().toISOString() };
-    // TODO: api-legacy → POST /v1/users/:id/posts (or /publications/:id/posts)
-    //       browser      → Playwright compose flow
-    return { id: `med_${Date.now()}`, url: 'https://medium.com/', platform: 'medium', publishedAt: new Date().toISOString() };
+    if (config.mode !== 'api-legacy') {
+      throw new Error('Medium browser mode is not implemented yet; use mode=api-legacy with an existing integration token');
+    }
+
+    const token = ctx.secret('MEDIUM_INTEGRATION_TOKEN');
+    if (!token) throw new Error('MEDIUM_INTEGRATION_TOKEN not in vault (legacy-only; new tokens no longer issued)');
+    const endpoint = mediumPostEndpoint(config);
+    const result = await mediumPost(token, endpoint, post, config);
+    const created = result.data;
+    if (!created?.id || !created.url) throw new Error('Medium post response did not include a post id and URL');
+
+    return {
+      id: created.id,
+      url: created.url,
+      platform: 'medium',
+      publishedAt: created.publishedAt ? new Date(created.publishedAt).toISOString() : new Date().toISOString(),
+    };
   },
 
   setup: oauthSetup({
@@ -44,3 +70,44 @@ export default defineSocial<Config>({
     ],
   }),
 });
+
+function mediumPostEndpoint(config: Config): string {
+  if (config.publicationId) return `https://api.medium.com/v1/publications/${config.publicationId}/posts`;
+  if (config.authorId) return `https://api.medium.com/v1/users/${config.authorId}/posts`;
+  throw new Error('Medium api-legacy mode requires config.authorId or config.publicationId');
+}
+
+async function mediumPost(token: string, endpoint: string, post: SocialPost, config: Config): Promise<MediumPostResponse> {
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      Authorization: token.toLowerCase().startsWith('bearer ') ? token : `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify(formatMediumPost(post, config)),
+  });
+  const data = await readMediumResponse(res);
+  if (!res.ok) throw new Error(data.errors?.find((error) => error.message)?.message ?? res.statusText);
+  return data;
+}
+
+function formatMediumPost(post: SocialPost, config: Config): Record<string, unknown> {
+  return {
+    title: post.title,
+    contentFormat: 'markdown',
+    content: post.link ? `${post.body}\n\n${post.link}` : post.body,
+    tags: (post.hashtags ?? []).slice(0, 3),
+    publishStatus: config.publishStatus ?? 'draft',
+    ...(config.canonicalUrl ? { canonicalUrl: config.canonicalUrl } : {}),
+    ...(config.notifyFollowers !== undefined ? { notifyFollowers: config.notifyFollowers } : {}),
+  };
+}
+
+async function readMediumResponse(res: Response): Promise<MediumPostResponse> {
+  try {
+    return await res.json() as MediumPostResponse;
+  } catch {
+    return { errors: [{ message: res.statusText }] };
+  }
+}


### PR DESCRIPTION
## Summary
- replace the social-medium stub for api-legacy mode with real Medium REST API posting
- support author and publication post endpoints
- send markdown content, tags, canonical URL, publish status, and notifyFollowers options
- surface Medium API errors and keep browser mode explicitly unsupported

## Verification
- pnpm exec vitest run packages/social/medium/src/index.test.ts
- pnpm --filter @profullstack/sh1pt-social-medium typecheck
- pnpm --filter @profullstack/sh1pt typecheck
- git diff --check