### PR TITLE
Implement 2Captcha API solving

### DIFF
--- a/packages/captcha/2captcha/src/index.test.ts
+++ b/packages/captcha/2captcha/src/index.test.ts
@@ -1,7 +1,110 @@
 import { contractTestCaptcha } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import captcha from './index.js';
 
 contractTestCaptcha(captcha, {
   sampleConfig: {},
   requiredSecrets: ['TWOCAPTCHA_API_KEY'],
 });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('2Captcha API integration', () => {
+  it('returns balance during connect', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ status: 1, request: '12.34' }));
+
+    await expect(captcha.connect(ctx(), {})).resolves.toEqual({
+      accountId: '2captcha',
+      balanceUsd: 12.34,
+    });
+  });
+
+  it('creates and polls a recaptcha task', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(jsonResponse({ status: 1, request: 'task_123' }))
+      .mockResolvedValueOnce(jsonResponse({ status: 0, request: 'CAPCHA_NOT_READY' }))
+      .mockResolvedValueOnce(jsonResponse({ status: 1, request: 'token_abc' }));
+
+    const result = await captcha.solve(ctx(), {
+      kind: 'recaptcha-v2',
+      pageUrl: 'https://example.com/signup',
+      siteKey: 'site_key',
+    }, {
+      pollIntervalMs: 1,
+      timeoutMs: 100,
+    });
+
+    expect(result).toMatchObject({
+      token: 'token_abc',
+      kind: 'recaptcha-v2',
+    });
+
+    const createRequest = fetchMock.mock.calls[0]!;
+    expect(createRequest[0]).toBe('https://api.2captcha.com/in.php');
+    const createBody = new URLSearchParams(String((createRequest[1] as RequestInit).body));
+    expect(Object.fromEntries(createBody)).toMatchObject({
+      key: 'captcha-key',
+      json: '1',
+      method: 'userrecaptcha',
+      googlekey: 'site_key',
+      pageurl: 'https://example.com/signup',
+    });
+    expect(String(fetchMock.mock.calls[2]![0])).toContain('action=get');
+    expect(String(fetchMock.mock.calls[2]![0])).toContain('id=task_123');
+  });
+
+  it('maps challenge-specific parameters', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(jsonResponse({ status: 1, request: 'task_123' }))
+      .mockResolvedValueOnce(jsonResponse({ status: 1, request: 'token_abc' }));
+
+    await captcha.solve(ctx(), {
+      kind: 'recaptcha-v3',
+      pageUrl: 'https://example.com/signup',
+      siteKey: 'site_key',
+      action: 'signup',
+    }, {
+      pollIntervalMs: 1,
+      timeoutMs: 100,
+    });
+
+    const body = new URLSearchParams(String((fetchMock.mock.calls[0]![1] as RequestInit).body));
+    expect(Object.fromEntries(body)).toMatchObject({
+      method: 'userrecaptcha',
+      version: 'v3',
+      action: 'signup',
+    });
+  });
+
+  it('requires site keys for site-key challenges', async () => {
+    await expect(captcha.solve(ctx(), {
+      kind: 'hcaptcha',
+      pageUrl: 'https://example.com/signup',
+    }, {})).rejects.toThrow('requires challenge.siteKey');
+  });
+
+  it('reads balance with an explicit config API key', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ status: 1, request: '3.21' }));
+
+    await expect(captcha.balance?.({ apiKey: 'explicit-key' })).resolves.toEqual({
+      amount: 3.21,
+      currency: 'USD',
+    });
+  });
+});
+
+function ctx() {
+  return {
+    secret: (key: string) => key === 'TWOCAPTCHA_API_KEY' ? 'captcha-key' : undefined,
+    log: () => {},
+  };
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}

--- a/packages/captcha/2captcha/src/index.ts
+++ b/packages/captcha/2captcha/src/index.ts
@@ -1,4 +1,4 @@
-import { defineCaptcha, tokenSetup, type CaptchaSolution } from '@profullstack/sh1pt-core';
+import { defineCaptcha, tokenSetup, type CaptchaChallenge, type CaptchaSolution } from '@profullstack/sh1pt-core';
 
 // 2Captcha (2captcha.com) — human + AI-assisted CAPTCHA solving. ~$1
 // per 1k image challenges, ~$2 per 1k reCAPTCHAs. Used ONLY as a last
@@ -7,11 +7,14 @@ import { defineCaptcha, tokenSetup, type CaptchaSolution } from '@profullstack/s
 interface Config {
   // key stored in sh1pt secrets vault — NOT in .env. Prompt on setup.
   //   sh1pt secret set TWOCAPTCHA_API_KEY
+  apiKey?: string;
   pollIntervalMs?: number;
   timeoutMs?: number;
 }
 
 const API = 'https://api.2captcha.com';
+const DEFAULT_POLL_INTERVAL_MS = 5000;
+const DEFAULT_TIMEOUT_MS = 120_000;
 
 export default defineCaptcha<Config>({
   id: 'captcha-twocaptcha',
@@ -25,25 +28,24 @@ export default defineCaptcha<Config>({
   async connect(ctx) {
     const key = ctx.secret('TWOCAPTCHA_API_KEY');
     if (!key) throw new Error('TWOCAPTCHA_API_KEY not in vault — run `sh1pt secret set TWOCAPTCHA_API_KEY`');
-    // TODO: GET /res.php?action=getbalance&key=... → response balance
     ctx.log('2captcha connected');
-    return { accountId: '2captcha' };
+    const balance = await getBalance(key);
+    return { accountId: '2captcha', balanceUsd: balance };
   },
 
-  async solve(ctx, challenge) {
+  async solve(ctx, challenge, config) {
     const key = ctx.secret('TWOCAPTCHA_API_KEY');
     if (!key) throw new Error('TWOCAPTCHA_API_KEY not in vault');
     ctx.log(`2captcha solve · ${challenge.kind}`);
-    // TODO:
-    //  1. POST /in.php with { key, method, googlekey|sitekey, pageurl, … } → captchaId
-    //  2. Poll /res.php?action=get&id=<captchaId> every pollIntervalMs until OK|<token>
-    //  3. Return { token, kind, solvedInMs, cost }
-    return { token: 'stub-token', kind: challenge.kind, solvedInMs: 0 } satisfies CaptchaSolution;
+    const startedAt = Date.now();
+    const captchaId = await createTask(key, challenge);
+    const token = await pollResult(key, captchaId, configWithDefaults(config), ctx.signal);
+    return { token, kind: challenge.kind, solvedInMs: Date.now() - startedAt } satisfies CaptchaSolution;
   },
 
-  async balance() {
-    // TODO: GET /res.php?action=getbalance&key=...
-    return { amount: 0, currency: 'USD' };
+  async balance(config) {
+    if (!config.apiKey) throw new Error('captcha-twocaptcha balance requires config.apiKey');
+    return { amount: await getBalance(config.apiKey), currency: 'USD' };
   },
 
   setup: tokenSetup<Config>({
@@ -57,3 +59,121 @@ export default defineCaptcha<Config>({
     ],
   }),
 });
+
+type TwoCaptchaParams = Record<string, string | number>;
+
+interface RuntimeConfig extends Config {
+  pollIntervalMs: number;
+  timeoutMs: number;
+}
+
+async function createTask(key: string, challenge: CaptchaChallenge): Promise<string> {
+  const params = new URLSearchParams({
+    key,
+    json: '1',
+    ...taskParams(challenge),
+  });
+  const res = await fetch(`${API}/in.php`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: params,
+  });
+  const data = await readTwoCaptchaResponse(res);
+  if (data.status !== 1 || !data.request) {
+    throw new Error(`2Captcha task creation failed: ${data.request ?? res.statusText}`);
+  }
+  return String(data.request);
+}
+
+async function pollResult(key: string, captchaId: string, config: RuntimeConfig, signal: AbortSignal | undefined): Promise<string> {
+  const deadline = Date.now() + config.timeoutMs;
+  while (Date.now() < deadline) {
+    if (signal?.aborted) throw new Error('2Captcha solve aborted');
+    await sleep(config.pollIntervalMs);
+    const url = `${API}/res.php?${new URLSearchParams({
+      key,
+      action: 'get',
+      id: captchaId,
+      json: '1',
+    })}`;
+    const res = await fetch(url);
+    const data = await readTwoCaptchaResponse(res);
+    if (data.status === 1 && data.request) return String(data.request);
+    if (data.request !== 'CAPCHA_NOT_READY') {
+      throw new Error(`2Captcha solve failed: ${data.request ?? res.statusText}`);
+    }
+  }
+  throw new Error(`2Captcha solve timed out after ${config.timeoutMs}ms`);
+}
+
+async function getBalance(key: string): Promise<number> {
+  const url = `${API}/res.php?${new URLSearchParams({
+    key,
+    action: 'getbalance',
+    json: '1',
+  })}`;
+  const res = await fetch(url);
+  const data = await readTwoCaptchaResponse(res);
+  if (data.status !== 1 || data.request === undefined) {
+    throw new Error(`2Captcha balance failed: ${data.request ?? res.statusText}`);
+  }
+  return Number(data.request);
+}
+
+function taskParams(challenge: CaptchaChallenge): TwoCaptchaParams {
+  switch (challenge.kind) {
+    case 'recaptcha-v2':
+    case 'recaptcha-v2-invisible':
+      return siteKeyParams('userrecaptcha', challenge, {
+        ...(challenge.kind === 'recaptcha-v2-invisible' ? { invisible: 1 } : {}),
+      });
+    case 'recaptcha-v3':
+      return siteKeyParams('userrecaptcha', challenge, {
+        version: 'v3',
+        ...(challenge.action ? { action: challenge.action } : {}),
+      });
+    case 'hcaptcha':
+      return siteKeyParams('hcaptcha', challenge);
+    case 'turnstile':
+      return siteKeyParams('turnstile', challenge);
+    case 'funcaptcha':
+      return siteKeyParams('funcaptcha', challenge);
+    case 'text-image':
+    case 'image-select':
+      if (!challenge.imageUrl) throw new Error(`${challenge.kind} requires challenge.imageUrl`);
+      return {
+        method: 'base64',
+        body: challenge.imageUrl,
+        ...(challenge.instruction ? { textinstructions: challenge.instruction } : {}),
+      };
+  }
+}
+
+function siteKeyParams(method: string, challenge: CaptchaChallenge, extra: TwoCaptchaParams = {}): TwoCaptchaParams {
+  if (!challenge.siteKey) throw new Error(`${challenge.kind} requires challenge.siteKey`);
+  return {
+    method,
+    googlekey: challenge.siteKey,
+    pageurl: challenge.pageUrl,
+    ...extra,
+  };
+}
+
+function configWithDefaults(config: Config): RuntimeConfig {
+  return {
+    ...config,
+    pollIntervalMs: config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+    timeoutMs: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+  };
+}
+
+async function readTwoCaptchaResponse(res: Response): Promise<{ status?: number; request?: string | number }> {
+  const data = await res.json().catch(() => undefined) as { status?: number; request?: string | number } | undefined;
+  if (!data) throw new Error(`2Captcha API returned non-JSON response (${res.status})`);
+  if (!res.ok) throw new Error(`2Captcha API request failed (${res.status}): ${data.request ?? res.statusText}`);
+  return data;
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary
- replace the 2Captcha fake token stub with real create-task and polling calls
- support balance checks during connect and explicit balance reads
- map supported site-key CAPTCHA kinds to 2Captcha request parameters
- validate required site keys/image URLs and support timeout/abort handling

## Verification
- pnpm exec vitest run packages/captcha/2captcha/src/index.test.ts
- pnpm --filter @profullstack/sh1pt-captcha-2captcha typecheck
- pnpm --filter @profullstack/sh1pt typecheck
- git diff --check