### PR TITLE
Emit Expo EAS dry-run plans

### DIFF
--- a/packages/targets/mobile-expo/src/index.test.ts
+++ b/packages/targets/mobile-expo/src/index.test.ts
@@ -1,4 +1,80 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'mobile', requireKind: true });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Expo / EAS mobile target', () => {
+  it('writes an inspectable dry-run EAS build plan', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-expo-'));
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-project-'));
+    tempDirs.push(outDir, projectDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      channel: 'stable',
+      outDir,
+      projectDir,
+      version: '1.2.3',
+    }) as any, {
+      appId: 'acme-mobile',
+      platform: 'ios',
+      projectDir: 'apps/mobile',
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'expo-eas-build.json'));
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan).toMatchObject({
+      provider: 'expo-eas',
+      appId: 'acme-mobile',
+      version: '1.2.3',
+      projectDir: join(projectDir, 'apps/mobile'),
+      platform: 'ios',
+      profile: 'production',
+      channel: 'stable',
+    });
+    expect(plan.command).toEqual([
+      'eas',
+      'build',
+      '--platform',
+      'ios',
+      '--profile',
+      'production',
+      '--non-interactive',
+      '--json',
+    ]);
+  });
+
+  it('returns the resolved EAS update command for dry-run ships', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      channel: 'beta',
+      projectDir: '/repo',
+      dryRun: true,
+    }) as any, {
+      appId: 'acme-mobile',
+      projectDir: 'apps/mobile',
+    })).resolves.toMatchObject({
+      id: 'dry-run',
+      meta: {
+        projectDir: join('/repo', 'apps/mobile'),
+        command: ['eas', 'update', '--channel', 'beta', '--non-interactive', '--json'],
+      },
+    });
+  });
+
+  it('requires an Expo token for real builds', async () => {
+    await expect(adapter.build(fakeBuildContext({
+      dryRun: false,
+    }) as any, {
+      appId: 'acme-mobile',
+    })).rejects.toThrow('EXPO_TOKEN not in vault');
+  });
+});

--- a/packages/targets/mobile-expo/src/index.ts
+++ b/packages/targets/mobile-expo/src/index.ts
@@ -1,10 +1,70 @@
-import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { defineTarget, exec, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { isAbsolute, join } from 'node:path';
 
 interface Config {
   appId: string;
   platform?: 'ios' | 'android' | 'all';
   profile?: string;
   submit?: boolean;
+  projectDir?: string;
+}
+
+function resolvedProjectDir(ctx: { projectDir: string }, config: Config): string {
+  if (!config.projectDir) return ctx.projectDir;
+  return isAbsolute(config.projectDir) ? config.projectDir : join(ctx.projectDir, config.projectDir);
+}
+
+function profileFor(ctx: { channel: string }, config: Config): string {
+  return config.profile ?? (ctx.channel === 'stable' ? 'production' : 'preview');
+}
+
+function platformFor(config: Config): 'ios' | 'android' | 'all' {
+  return config.platform ?? 'all';
+}
+
+function buildArgs(ctx: { channel: string }, config: Config): string[] {
+  return ['build', '--platform', platformFor(config), '--profile', profileFor(ctx, config), '--non-interactive', '--json'];
+}
+
+function shipArgs(ctx: { channel: string }, config: Config): string[] {
+  if (config.submit) {
+    return ['submit', '--platform', platformFor(config), '--profile', profileFor(ctx, config), '--non-interactive', '--json'];
+  }
+  return ['update', '--channel', ctx.channel, '--non-interactive', '--json'];
+}
+
+function renderPlan(ctx: { channel: string; projectDir: string; version: string }, config: Config): string {
+  const command = ['eas', ...buildArgs(ctx, config)];
+  return `${JSON.stringify({
+    provider: 'expo-eas',
+    appId: config.appId,
+    version: ctx.version,
+    projectDir: resolvedProjectDir(ctx, config),
+    platform: platformFor(config),
+    profile: profileFor(ctx, config),
+    channel: ctx.channel,
+    command,
+  }, null, 2)}\n`;
+}
+
+function parseEasBuild(stdout: string): { id?: string; url?: string } {
+  try {
+    const data = JSON.parse(stdout) as unknown;
+    const builds = Array.isArray(data) ? data : [data];
+    const first = builds.find((entry): entry is Record<string, unknown> => Boolean(entry && typeof entry === 'object'));
+    if (!first) return {};
+    return {
+      id: typeof first.id === 'string' ? first.id : undefined,
+      url: typeof first.buildUrl === 'string'
+        ? first.buildUrl
+        : typeof first.url === 'string'
+          ? first.url
+          : undefined,
+    };
+  } catch {
+    return {};
+  }
 }
 
 export default defineTarget<Config>({
@@ -12,16 +72,50 @@ export default defineTarget<Config>({
   kind: 'mobile',
   label: 'Expo / EAS',
   async build(ctx, config) {
-    const platform = config.platform ?? 'all';
-    const profile = config.profile ?? (ctx.channel === 'stable' ? 'production' : 'preview');
-    ctx.log(`eas build --platform ${platform} --profile ${profile}`);
-    return { artifact: `${ctx.outDir}/expo-eas-build` };
+    const planPath = join(ctx.outDir, 'expo-eas-build.json');
+    ctx.log(`eas build --platform ${platformFor(config)} --profile ${profileFor(ctx, config)}`);
+
+    if (ctx.dryRun) {
+      await mkdir(ctx.outDir, { recursive: true });
+      await writeFile(planPath, renderPlan(ctx, config), 'utf-8');
+      return { artifact: planPath };
+    }
+
+    const token = ctx.secret('EXPO_TOKEN');
+    if (!token) {
+      throw new Error('EXPO_TOKEN not in vault — run: sh1pt secret set EXPO_TOKEN <token>');
+    }
+
+    const result = await exec('eas', buildArgs(ctx, config), {
+      cwd: resolvedProjectDir(ctx, config),
+      env: { ...ctx.env, EXPO_TOKEN: token },
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+    const build = parseEasBuild(result.stdout);
+    return {
+      artifact: build.url ?? planPath,
+      meta: { buildId: build.id, command: ['eas', ...buildArgs(ctx, config)] },
+    };
   },
   async ship(ctx, config) {
-    const platform = config.platform ?? 'all';
-    const profile = config.profile ?? (ctx.channel === 'stable' ? 'production' : 'preview');
-    ctx.log(config.submit ? `eas submit --platform ${platform} --profile ${profile}` : `eas update --channel ${ctx.channel}`);
-    if (ctx.dryRun) return { id: 'dry-run' };
+    const command = ['eas', ...shipArgs(ctx, config)];
+    ctx.log(config.submit
+      ? `eas submit --platform ${platformFor(config)} --profile ${profileFor(ctx, config)}`
+      : `eas update --channel ${ctx.channel}`);
+    if (ctx.dryRun) return { id: 'dry-run', meta: { command, projectDir: resolvedProjectDir(ctx, config) } };
+
+    const token = ctx.secret('EXPO_TOKEN');
+    if (!token) {
+      throw new Error('EXPO_TOKEN not in vault — run: sh1pt secret set EXPO_TOKEN <token>');
+    }
+
+    await exec('eas', shipArgs(ctx, config), {
+      cwd: resolvedProjectDir(ctx, config),
+      env: { ...ctx.env, EXPO_TOKEN: token },
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
     return { id: `${config.appId}@${ctx.version}`, url: `https://expo.dev/accounts/${config.appId}` };
   },
   setup: manualSetup({


### PR DESCRIPTION
Closes #176

/claim #176

## Summary
- write an inspectable `expo-eas-build.json` artifact for dry-run mobile-expo builds
- record resolved platform, profile, channel, project directory, version, and EAS argv command in the plan
- run real EAS build/update/submit commands with argv arrays and `EXPO_TOKEN` from the vault
- expose resolved EAS ship commands in dry-run metadata

## Verification
- `pnpm exec vitest run packages/targets/mobile-expo/src/index.test.ts`
- `pnpm --filter @profullstack/sh1pt-target-mobile-expo typecheck`
- `pnpm --filter @profullstack/sh1pt typecheck`
- `git diff --check`