### PR TITLE
Emit Firefox package dry-run plans

### DIFF
--- a/packages/targets/browser-firefox/src/index.test.ts
+++ b/packages/targets/browser-firefox/src/index.test.ts
@@ -1,4 +1,68 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'browser', requireKind: true });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Firefox browser target', () => {
+  it('writes an inspectable dry-run package plan', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-firefox-'));
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-project-'));
+    tempDirs.push(outDir, projectDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      channel: 'beta',
+      outDir,
+      projectDir,
+      version: '1.2.3',
+    }) as any, {
+      extensionId: '{myext@example.com}',
+      sourceDir: 'web-ext-artifacts',
+      channel: 'unlisted',
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'firefox-package-plan.json'));
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan).toMatchObject({
+      provider: 'firefox-amo',
+      extensionId: '{myext@example.com}',
+      version: '1.2.3',
+      sourceDir: join(projectDir, 'web-ext-artifacts'),
+      channel: 'unlisted',
+      expectedArtifact: join(outDir, '_myext_example.com_-1.2.3.zip'),
+    });
+    expect(plan.command).toEqual([
+      'web-ext',
+      'build',
+      '--source-dir',
+      join(projectDir, 'web-ext-artifacts'),
+      '--artifacts-dir',
+      outDir,
+    ]);
+  });
+
+  it('keeps dry-run shipping side-effect free with resolved metadata', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      projectDir: '/repo',
+      dryRun: true,
+    }) as any, {
+      extensionId: 'myext@example.com',
+      sourceDir: 'dist-firefox',
+    })).resolves.toMatchObject({
+      id: 'dry-run',
+      meta: {
+        channel: 'listed',
+        sourceDir: join('/repo', 'dist-firefox'),
+      },
+    });
+  });
+});

--- a/packages/targets/browser-firefox/src/index.ts
+++ b/packages/targets/browser-firefox/src/index.ts
@@ -1,4 +1,6 @@
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { isAbsolute, join } from 'node:path';
 
 interface Config {
   extensionId: string;       // AMO extension id, e.g. "{some-uuid}" or "myext@example.com"
@@ -6,21 +8,60 @@ interface Config {
   channel?: 'listed' | 'unlisted';
 }
 
+function sourceDir(ctx: { projectDir: string }, config: Config): string {
+  const src = config.sourceDir ?? 'dist/';
+  return isAbsolute(src) ? src : join(ctx.projectDir, src);
+}
+
+function channelFor(config: Config): 'listed' | 'unlisted' {
+  return config.channel ?? 'listed';
+}
+
+function safeExtensionId(extensionId: string): string {
+  return extensionId.replace(/[{}@]/g, '_');
+}
+
+function expectedArtifact(ctx: { outDir: string; version: string }, config: Config): string {
+  return join(ctx.outDir, `${safeExtensionId(config.extensionId)}-${ctx.version}.zip`);
+}
+
+function buildArgs(ctx: { outDir: string; projectDir: string }, config: Config): string[] {
+  return ['build', '--source-dir', sourceDir(ctx, config), '--artifacts-dir', ctx.outDir];
+}
+
+function renderPlan(ctx: { channel: string; outDir: string; projectDir: string; version: string }, config: Config): string {
+  return `${JSON.stringify({
+    provider: 'firefox-amo',
+    extensionId: config.extensionId,
+    version: ctx.version,
+    sourceDir: sourceDir(ctx, config),
+    channel: channelFor(config),
+    expectedArtifact: expectedArtifact(ctx, config),
+    command: ['web-ext', ...buildArgs(ctx, config)],
+  }, null, 2)}\n`;
+}
+
 export default defineTarget<Config>({
   id: 'browser-firefox',
   kind: 'browser-ext',
   label: 'Firefox Add-ons (AMO)',
   async build(ctx, config) {
-    const src = config.sourceDir ?? 'dist/';
+    const src = sourceDir(ctx, config);
+    const planPath = join(ctx.outDir, 'firefox-package-plan.json');
     ctx.log(`pack Firefox extension from ${src} using web-ext build`);
+    if (ctx.dryRun) {
+      await mkdir(ctx.outDir, { recursive: true });
+      await writeFile(planPath, renderPlan(ctx, config), 'utf-8');
+      return { artifact: planPath };
+    }
     // TODO: run `web-ext build --source-dir ${src} --artifacts-dir ${ctx.outDir}`
     // Validates manifest.json (v2 or v3) and zips into ctx.outDir
-    return { artifact: `${ctx.outDir}/${config.extensionId.replace(/[{}@]/g, '_')}-${ctx.version}.zip` };
+    return { artifact: expectedArtifact(ctx, config), meta: { command: ['web-ext', ...buildArgs(ctx, config)] } };
   },
   async ship(ctx, config) {
-    const channel = config.channel ?? 'listed';
+    const channel = channelFor(config);
     ctx.log(`sign + submit ${config.extensionId} to AMO (channel: ${channel})`);
-    if (ctx.dryRun) return { id: 'dry-run' };
+    if (ctx.dryRun) return { id: 'dry-run', meta: { channel, sourceDir: sourceDir(ctx, config) } };
     // TODO: web-ext sign --api-key=${AMO_JWT_ISSUER} --api-secret=${AMO_JWT_SECRET}
     //       --channel=${channel} --source-dir ${config.sourceDir ?? 'dist/'}
     // Or: POST https://addons.mozilla.org/api/v5/addons/<id>/versions/ with JWT auth


### PR DESCRIPTION
Closes #173

/claim #173

## Summary
- write an inspectable `firefox-package-plan.json` artifact for dry-run browser-firefox builds
- record resolved source directory, expected AMO zip artifact, channel, version, extension id, and exact `web-ext build` argv command
- keep dry-run shipping side-effect free while returning resolved source/channel metadata
- preserve the existing real-build artifact path and attach the resolved web-ext command metadata

## Verification
- `pnpm exec vitest run packages/targets/browser-firefox/src/index.test.ts`
- `pnpm --filter @profullstack/sh1pt-target-browser-firefox typecheck`
- `pnpm --filter @profullstack/sh1pt typecheck`
- `git diff --check`