### PR TITLE
Emit Windows package dry-run plans

### DIFF
--- a/packages/targets/desktop-win/src/index.test.ts
+++ b/packages/targets/desktop-win/src/index.test.ts
@@ -1,4 +1,78 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'desktop', requireKind: true });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Windows desktop target', () => {
+  it('writes a dry-run package plan for Store and MSI artifacts', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-win-'));
+    tempDirs.push(outDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      version: '1.2.3',
+    }) as any, {
+      appId: 'Acme.MyApp',
+      publisherId: 'CN=12345678-90ab-cdef-1234-567890abcdef',
+      distribution: 'both',
+      architectures: ['x64'],
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'windows-package-plan.json'));
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan).toMatchObject({
+      provider: 'windows-desktop',
+      appId: 'Acme.MyApp',
+      publisherId: 'CN=12345678-90ab-cdef-1234-567890abcdef',
+      version: '1.2.3',
+      distribution: 'both',
+      architectures: ['x64'],
+      artifacts: [
+        { kind: 'msixbundle', path: join(outDir, 'app.msixbundle') },
+        { kind: 'msi', path: join(outDir, 'app.msi') },
+      ],
+      followUp: ['signingCertThumbprint is required before signing Windows artifacts'],
+    });
+    expect(plan.commands).toEqual([
+      ['makeappx', 'pack', '/d', join(outDir, 'windows-unpacked'), '/p', join(outDir, 'app.msixbundle')],
+      ['wix', 'build', join(outDir, 'windows-unpacked', 'Product.wxs'), '-out', join(outDir, 'app.msi')],
+    ]);
+  });
+
+  it('includes signtool commands when a signing certificate thumbprint is configured', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-win-'));
+    tempDirs.push(outDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      version: '1.2.3',
+    }) as any, {
+      appId: 'Acme.MyApp',
+      publisherId: 'CN=12345678-90ab-cdef-1234-567890abcdef',
+      distribution: 'msstore',
+      signingCertThumbprint: 'ABC123',
+    });
+
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan.followUp).toEqual([]);
+    expect(plan.commands).toContainEqual([
+      'signtool',
+      'sign',
+      '/sha1',
+      'ABC123',
+      '/fd',
+      'SHA256',
+      join(outDir, 'app.msixbundle'),
+    ]);
+  });
+});

--- a/packages/targets/desktop-win/src/index.ts
+++ b/packages/targets/desktop-win/src/index.ts
@@ -1,4 +1,6 @@
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 interface Config {
   appId: string;             // Partner Center app identity (e.g. Acme.MyApp)
@@ -9,13 +11,71 @@ interface Config {
   architectures?: ('x64' | 'arm64' | 'x86')[];
 }
 
+type ArtifactKind = 'msixbundle' | 'msi';
+
+function architecturesFor(config: Config): Array<'x64' | 'arm64' | 'x86'> {
+  return config.architectures ?? ['x64', 'arm64'];
+}
+
+function artifactKinds(distribution: Config['distribution']): ArtifactKind[] {
+  if (distribution === 'both') return ['msixbundle', 'msi'];
+  return distribution === 'msi' ? ['msi'] : ['msixbundle'];
+}
+
+function artifactPath(ctx: { outDir: string }, kind: ArtifactKind): string {
+  return join(ctx.outDir, kind === 'msi' ? 'app.msi' : 'app.msixbundle');
+}
+
+function packageCommands(ctx: { outDir: string }, config: Config): string[][] {
+  const commands: string[][] = [];
+  const sourceDir = join(ctx.outDir, 'windows-unpacked');
+  if (config.distribution !== 'msi') {
+    commands.push(['makeappx', 'pack', '/d', sourceDir, '/p', artifactPath(ctx, 'msixbundle')]);
+  }
+  if (config.distribution !== 'msstore') {
+    commands.push(['wix', 'build', join(sourceDir, 'Product.wxs'), '-out', artifactPath(ctx, 'msi')]);
+  }
+  if (config.signingCertThumbprint) {
+    for (const kind of artifactKinds(config.distribution)) {
+      commands.push(['signtool', 'sign', '/sha1', config.signingCertThumbprint, '/fd', 'SHA256', artifactPath(ctx, kind)]);
+    }
+  }
+  return commands;
+}
+
+function renderPlan(ctx: { outDir: string; version: string }, config: Config): string {
+  const artifacts = artifactKinds(config.distribution).map((kind) => ({
+    kind,
+    path: artifactPath(ctx, kind),
+  }));
+  return `${JSON.stringify({
+    provider: 'windows-desktop',
+    appId: config.appId,
+    publisherId: config.publisherId,
+    version: ctx.version,
+    distribution: config.distribution,
+    architectures: architecturesFor(config),
+    artifacts,
+    commands: packageCommands(ctx, config),
+    followUp: config.signingCertThumbprint
+      ? []
+      : ['signingCertThumbprint is required before signing Windows artifacts'],
+  }, null, 2)}\n`;
+}
+
 export default defineTarget<Config>({
   id: 'desktop-win',
   kind: 'desktop',
   label: 'Windows (Microsoft Store / MSIX / MSI)',
   async build(ctx, config) {
-    const arches = config.architectures ?? ['x64', 'arm64'];
+    const arches = architecturesFor(config);
     ctx.log(`build ${config.distribution} · arches=${arches.join(',')}`);
+    if (ctx.dryRun) {
+      const planPath = join(ctx.outDir, 'windows-package-plan.json');
+      await mkdir(ctx.outDir, { recursive: true });
+      await writeFile(planPath, renderPlan(ctx, config), 'utf-8');
+      return { artifact: planPath };
+    }
     // TODO:
     //  - MSIX: makeappx pack + signtool sign using signingCertThumbprint
     //  - MSI: WiX toolset → .msi → signtool sign


### PR DESCRIPTION
Closes #169

/claim #169

## Summary
- write `windows-package-plan.json` during dry-run desktop-win builds
- include MSIX/MSI artifact paths for `msstore`, `msi`, and `both` distributions
- include planned `makeappx`, WiX, and `signtool` argv commands without executing Windows-only tooling
- surface missing signing certificate thumbprint as follow-up data in the plan

## Verification
- `pnpm exec vitest run packages/targets/desktop-win/src/index.test.ts`
- `pnpm --filter @profullstack/sh1pt-target-desktop-win typecheck`
- `pnpm --filter @profullstack/sh1pt typecheck`
- `git diff --check`