### PR TITLE
Keep VS Code plugin dry-run builds side-effect free

### DIFF
--- a/packages/targets/plugin-vscode/src/index.test.ts
+++ b/packages/targets/plugin-vscode/src/index.test.ts
@@ -1,4 +1,83 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'plugin', requireKind: true });
+
+const execMock = vi.hoisted(() => vi.fn(async () => ({ exitCode: 0, stdout: '', stderr: '' })));
+
+vi.mock('@profullstack/sh1pt-core', async () => {
+  const actual = await vi.importActual<typeof import('@profullstack/sh1pt-core')>('@profullstack/sh1pt-core');
+  return {
+    ...actual,
+    exec: execMock,
+  };
+});
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  execMock.mockClear();
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('VS Code plugin target', () => {
+  it('writes a deterministic dry-run package plan without invoking vsce', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-vscode-'));
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-project-'));
+    tempDirs.push(outDir, projectDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      projectDir,
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      publisher: 'acme',
+      extensionName: 'tools',
+      packageDir: 'extensions/tools',
+      target: 'linux-x64',
+    });
+
+    expect(execMock).not.toHaveBeenCalled();
+    expect(result.artifact).toBe(join(outDir, 'vscode-package-plan.json'));
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan).toEqual({
+      provider: 'vscode-marketplace',
+      extensionId: 'acme.tools',
+      version: '1.2.3',
+      packageDir: join(projectDir, 'extensions/tools'),
+      target: 'linux-x64',
+      expectedArtifact: join(outDir, 'tools-1.2.3.vsix'),
+      command: ['npx', '--yes', 'vsce', 'package', '--out', outDir, '--target', 'linux-x64'],
+    });
+  });
+
+  it('keeps real builds on the existing vsce package path', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-vscode-'));
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-project-'));
+    tempDirs.push(outDir, projectDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      projectDir,
+      version: '1.2.3',
+      dryRun: false,
+    }) as any, {
+      publisher: 'acme',
+      extensionName: 'tools',
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'tools-1.2.3.vsix'));
+    expect(execMock).toHaveBeenCalledWith('npx', ['--yes', 'vsce', '--version'], expect.objectContaining({
+      throwOnNonZero: false,
+    }));
+    expect(execMock).toHaveBeenCalledWith('npx', ['--yes', 'vsce', 'package', '--out', outDir], expect.objectContaining({
+      cwd: projectDir,
+      throwOnNonZero: true,
+    }));
+  });
+});

--- a/packages/targets/plugin-vscode/src/index.ts
+++ b/packages/targets/plugin-vscode/src/index.ts
@@ -1,4 +1,5 @@
 import { defineTarget, setupGuide, exec } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 interface Config {
@@ -8,12 +9,45 @@ interface Config {
   target?: string;         // e.g. "linux-x64" for platform-specific packages
 }
 
+function packageDir(ctx: { projectDir: string }, config: Config): string {
+  return config.packageDir ? join(ctx.projectDir, config.packageDir) : ctx.projectDir;
+}
+
+function artifactPath(ctx: { outDir: string; version: string }, config: Config): string {
+  return join(ctx.outDir, `${config.extensionName}-${ctx.version}.vsix`);
+}
+
+function packageArgs(ctx: { outDir: string }, config: Config): string[] {
+  const args = ['--yes', 'vsce', 'package', '--out', ctx.outDir];
+  if (config.target) args.push('--target', config.target);
+  return args;
+}
+
+function renderPlan(ctx: { outDir: string; projectDir: string; version: string }, config: Config): string {
+  return `${JSON.stringify({
+    provider: 'vscode-marketplace',
+    extensionId: `${config.publisher}.${config.extensionName}`,
+    version: ctx.version,
+    packageDir: packageDir(ctx, config),
+    target: config.target ?? null,
+    expectedArtifact: artifactPath(ctx, config),
+    command: ['npx', ...packageArgs(ctx, config)],
+  }, null, 2)}\n`;
+}
+
 export default defineTarget<Config>({
   id: 'plugin-vscode',
   kind: 'plugin',
   label: 'VS Code Marketplace',
 
   async build(ctx, config) {
+    if (ctx.dryRun) {
+      const planPath = join(ctx.outDir, 'vscode-package-plan.json');
+      await mkdir(ctx.outDir, { recursive: true });
+      await writeFile(planPath, renderPlan(ctx, config), 'utf-8');
+      return { artifact: planPath };
+    }
+
     ctx.log('vsce: verifying CLI availability');
 
     try {
@@ -25,19 +59,16 @@ export default defineTarget<Config>({
       });
     }
 
-    const pkgDir = config.packageDir ? join(ctx.projectDir, config.packageDir) : ctx.projectDir;
+    const pkgDir = packageDir(ctx, config);
     ctx.log(`vsce: packaging ${config.publisher}.${config.extensionName} v${ctx.version}`);
 
-    const args = ['--yes', 'vsce', 'package', '--out', ctx.outDir];
-    if (config.target) args.push('--target', config.target);
-
-    const { stdout } = await exec('npx', args, {
+    await exec('npx', packageArgs(ctx, config), {
       cwd: pkgDir,
       log: ctx.log,
       throwOnNonZero: true,
     });
 
-    return { artifact: `${ctx.outDir}/${config.extensionName}-${ctx.version}.vsix` };
+    return { artifact: artifactPath(ctx, config) };
   },
 
   async ship(ctx, config) {


### PR DESCRIPTION
Closes #156

/claim #156

## Summary
- short-circuit plugin-vscode dry-run builds before any `vsce`/npm exec checks
- write a deterministic `vscode-package-plan.json` artifact with package dir, target, expected VSIX, and command
- keep real builds on the existing `npx --yes vsce package` path
- add tests proving dry-runs skip exec and real builds still invoke vsce packaging

## Verification
- `pnpm exec vitest run packages/targets/plugin-vscode/src/index.test.ts`
- `pnpm --filter @profullstack/sh1pt-target-plugin-vscode typecheck`
- `pnpm --filter @profullstack/sh1pt typecheck`
- `git diff --check`