### PR TITLE
Implement offline build --from planning

### DIFF
--- a/packages/cli/src/build-planner.test.ts
+++ b/packages/cli/src/build-planner.test.ts
@@ -1,0 +1,88 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { planBuildFrom } from './build-planner.js';
+import { resolveInput } from './input.js';
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('planBuildFrom', () => {
+  it('infers targets from local project manifests without running scripts', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'sh1pt-plan-'));
+    tempDirs.push(root);
+    await writeFile(join(root, 'package.json'), JSON.stringify({
+      scripts: {
+        build: 'vite build',
+      },
+      dependencies: {
+        expo: '^54.0.0',
+        electron: '^39.0.0',
+      },
+      devDependencies: {
+        '@vscode/vsce': '^3.0.0',
+      },
+    }), 'utf-8');
+    await writeFile(join(root, 'Dockerfile'), 'FROM node:22\n', 'utf-8');
+    await writeFile(join(root, 'vercel.json'), '{}\n', 'utf-8');
+
+    const plan = planBuildFrom(resolveInput(root));
+
+    expect(plan.mode).toBe('offline');
+    expect(plan.targets).toEqual([
+      'deploy-vercel',
+      'desktop-linux',
+      'desktop-mac',
+      'desktop-win',
+      'mobile-expo',
+      'pkg-docker',
+      'pkg-npm',
+      'plugin-vscode',
+      'web-static',
+    ]);
+    expect(plan.evidence).toEqual(expect.arrayContaining(['package.json', 'Dockerfile/docker-compose', 'vercel.json']));
+  });
+
+  it('classifies remote inputs without fetching them', () => {
+    const plan = planBuildFrom(resolveInput('https://github.com/profullstack/sh1pt'));
+
+    expect(plan.targets).toEqual([]);
+    expect(plan.evidence).toEqual(['remote inputs are classified only; no network access was performed']);
+    expect(plan.nextSteps[0]).toContain('Clone the repository locally');
+  });
+
+  it('infers targets from manifest documents when present', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'sh1pt-plan-'));
+    tempDirs.push(root);
+    const manifest = join(root, 'sh1pt.yml');
+    await writeFile(manifest, 'targets:\n  - deploy-vercel\n  - mobile-expo\n  - pkg-docker\n', 'utf-8');
+
+    const plan = planBuildFrom(resolveInput(manifest));
+
+    expect(plan.targets).toEqual(['deploy-vercel', 'mobile-expo', 'pkg-docker']);
+    expect(plan.evidence).toEqual([`manifest document: ${manifest}`]);
+  });
+
+  it('reports missing paths without probing anything else', () => {
+    const plan = planBuildFrom(resolveInput('/tmp/sh1pt-missing-project-never'));
+
+    expect(plan.targets).toEqual([]);
+    expect(plan.evidence).toEqual(['local path does not exist']);
+  });
+
+  it('infers Expo config even without package dependencies', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'sh1pt-plan-'));
+    tempDirs.push(root);
+    await mkdir(join(root, 'apps'), { recursive: true });
+    await writeFile(join(root, 'app.config.ts'), 'export default {};\n', 'utf-8');
+
+    const plan = planBuildFrom(resolveInput(root));
+
+    expect(plan.targets).toContain('mobile-expo');
+    expect(plan.evidence).toContain('Expo app/eas config');
+  });
+});

--- a/packages/cli/src/build-planner.ts
+++ b/packages/cli/src/build-planner.ts
@@ -1,0 +1,168 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { ResolvedInput } from './input.js';
+
+export interface BuildPlan {
+  input: ResolvedInput;
+  mode: 'offline';
+  targets: string[];
+  evidence: string[];
+  nextSteps: string[];
+}
+
+interface PackageJson {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  scripts?: Record<string, string>;
+  engines?: Record<string, string>;
+  contributes?: unknown;
+}
+
+export function planBuildFrom(input: ResolvedInput): BuildPlan {
+  if (input.kind === 'git') {
+    return remotePlan(input, 'Clone the repository locally, then rerun `sh1pt build --from <path>` to inspect manifests offline.');
+  }
+  if (input.kind === 'url') {
+    return remotePlan(input, 'Create or point to a local project checkout; sh1pt does not fetch or probe live URLs during planning.');
+  }
+  if (input.kind === 'doc') {
+    return planDoc(input);
+  }
+  return planPath(input);
+}
+
+function remotePlan(input: ResolvedInput, nextStep: string): BuildPlan {
+  return {
+    input,
+    mode: 'offline',
+    targets: [],
+    evidence: ['remote inputs are classified only; no network access was performed'],
+    nextSteps: [nextStep],
+  };
+}
+
+function planDoc(input: ResolvedInput): BuildPlan {
+  const evidence = [input.exists === false ? 'manifest document is missing on disk' : `manifest document: ${input.value}`];
+  const targets = new Set<string>();
+  if (input.exists) {
+    const lower = readText(input.value).toLowerCase();
+    if (lower.includes('vercel')) targets.add('deploy-vercel');
+    if (lower.includes('netlify')) targets.add('deploy-netlify');
+    if (lower.includes('expo') || lower.includes('eas')) targets.add('mobile-expo');
+    if (lower.includes('npm')) targets.add('pkg-npm');
+    if (lower.includes('docker')) targets.add('pkg-docker');
+  }
+  return {
+    input,
+    mode: 'offline',
+    targets: [...targets],
+    evidence,
+    nextSteps: targets.size ? ['Review the inferred targets and run `sh1pt build --target <id>` when ready.'] : ['Add target metadata to the manifest or pass a local project directory.'],
+  };
+}
+
+function planPath(input: ResolvedInput): BuildPlan {
+  if (input.exists === false || !existsSync(input.value)) {
+    return {
+      input,
+      mode: 'offline',
+      targets: [],
+      evidence: ['local path does not exist'],
+      nextSteps: ['Create the project path or pass an existing checkout.'],
+    };
+  }
+
+  const root = statSync(input.value).isDirectory() ? input.value : dirname(input.value);
+  const targets = new Set<string>();
+  const evidence: string[] = [];
+
+  const packageJson = readJson(join(root, 'package.json'));
+  if (packageJson) {
+    evidence.push('package.json');
+    targets.add('pkg-npm');
+    const deps = depsOf(packageJson);
+    const scripts = scriptsOf(packageJson);
+    if (deps.has('expo') || deps.has('expo-router') || hasScript(scripts, 'eas ')) targets.add('mobile-expo');
+    if (deps.has('electron') || deps.has('tauri') || hasScript(scripts, 'electron') || hasScript(scripts, 'tauri')) {
+      targets.add('desktop-mac');
+      targets.add('desktop-win');
+      targets.add('desktop-linux');
+    }
+    if (deps.has('@vscode/vsce') || packageJson.engines?.vscode || packageJson.contributes) targets.add('plugin-vscode');
+    if (hasScript(scripts, 'vite') || hasScript(scripts, 'next') || deps.has('vite') || deps.has('next')) targets.add('web-static');
+  }
+
+  if (existsSync(join(root, 'Dockerfile')) || existsSync(join(root, 'docker-compose.yml'))) {
+    evidence.push('Dockerfile/docker-compose');
+    targets.add('pkg-docker');
+  }
+  if (existsSync(join(root, 'vercel.json'))) {
+    evidence.push('vercel.json');
+    targets.add('deploy-vercel');
+  }
+  if (existsSync(join(root, 'netlify.toml'))) {
+    evidence.push('netlify.toml');
+    targets.add('deploy-netlify');
+  }
+  if (existsSync(join(root, 'eas.json')) || existsSync(join(root, 'app.json')) || existsSync(join(root, 'app.config.ts'))) {
+    evidence.push('Expo app/eas config');
+    targets.add('mobile-expo');
+  }
+  if (existsSync(join(root, 'tauri.conf.json')) || existsSync(join(root, 'src-tauri'))) {
+    evidence.push('Tauri config');
+    targets.add('desktop-mac');
+    targets.add('desktop-win');
+    targets.add('desktop-linux');
+  }
+  if (hasAny(root, ['Cargo.toml', 'pyproject.toml', 'go.mod'])) {
+    evidence.push('language/package manifest');
+  }
+
+  return {
+    input,
+    mode: 'offline',
+    targets: [...targets].sort(),
+    evidence,
+    nextSteps: targets.size
+      ? ['Review the inferred targets and run `sh1pt build --target <id>` when ready.']
+      : ['No supported targets inferred; add sh1pt target config or pass a more specific manifest.'],
+  };
+}
+
+function readJson(path: string): PackageJson | null {
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as PackageJson;
+  } catch {
+    return null;
+  }
+}
+
+function readText(path: string): string {
+  try {
+    return readFileSync(path, 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+function depsOf(pkg: PackageJson): Set<string> {
+  return new Set([
+    ...Object.keys(pkg.dependencies ?? {}),
+    ...Object.keys(pkg.devDependencies ?? {}),
+    ...Object.keys(pkg.peerDependencies ?? {}),
+  ]);
+}
+
+function scriptsOf(pkg: PackageJson): Record<string, string> {
+  return pkg.scripts && typeof pkg.scripts === 'object' ? pkg.scripts : {};
+}
+
+function hasScript(scripts: Record<string, string>, token: string): boolean {
+  return Object.values(scripts).some((script) => script.includes(token));
+}
+
+function hasAny(root: string, names: string[]): boolean {
+  const entries = new Set(readdirSync(root));
+  return names.some((name) => entries.has(name));
+}

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import { spawnSync } from 'node:child_process';
 import kleur from 'kleur';
+import { planBuildFrom } from '../build-planner.js';
 import { describeInput, resolveInput } from '../input.js';
 import { entityCmd } from './entity.js';
 
@@ -21,14 +22,22 @@ export const buildCmd = new Command('build')
   .option('-c, --channel <name>', 'release channel', 'stable')
   .option('--cloud', 'run build in sh1pt cloud instead of locally')
   .option('--from <input>', 'existing git repo, live url, local path, or manifest doc to build from')
-  .action((opts: { target?: string[]; channel: string; cloud?: boolean; from?: string }) => {
+  .option('--json', 'print the inferred build plan as JSON')
+  .action((opts: { target?: string[]; channel: string; cloud?: boolean; from?: string; json?: boolean }) => {
     const targets = opts.target?.join(', ') ?? 'all enabled';
     const where = opts.cloud ? 'cloud' : 'local';
     if (opts.from) {
       const input = resolveInput(opts.from);
-      console.log(kleur.cyan(`[stub] build (${where}) · channel=${opts.channel} · from=${describeInput(input)}`));
-      // TODO: kind==='git' → clone and detect stack; kind==='path' → load manifest;
-      // kind==='doc' → parse manifest; kind==='url' → HEAD/fetch to infer stack.
+      const plan = planBuildFrom(input);
+      if (opts.json) {
+        console.log(JSON.stringify({ ...plan, channel: opts.channel, where }, null, 2));
+        return;
+      }
+      console.log(kleur.cyan(`build (${where}) · channel=${opts.channel} · from=${describeInput(input)}`));
+      console.log(`mode: ${plan.mode}`);
+      console.log(`targets: ${plan.targets.length ? plan.targets.join(', ') : '(none inferred)'}`);
+      if (plan.evidence.length) console.log(`evidence: ${plan.evidence.join(', ')}`);
+      for (const step of plan.nextSteps) console.log(`next: ${step}`);
       return;
     }
     console.log(kleur.cyan(`[stub] build (${where}) · channel=${opts.channel} · targets=${targets}`));


### PR DESCRIPTION
Closes #154

/claim #154

## Summary
- replace the `build --from` stub with an offline planner for local paths and manifest docs
- classify remote git/URL inputs safely without fetching or probing network resources
- infer likely targets from package/deploy/language manifests including web-static, pkg-npm, pkg-docker, deploy-vercel, deploy-netlify, mobile-expo, desktop targets, and plugin-vscode
- add `--json` output for automation while keeping human-readable output for the default path

## Verification
- `pnpm exec vitest run packages/cli/src/build-planner.test.ts packages/cli/src/input.test.ts`
- `pnpm --filter @profullstack/sh1pt typecheck`
- `git diff --check`