### PR TITLE
feat(browser-firefox): emit firefox-package-plan.json on dry-run builds

### DIFF
--- a/packages/targets/browser-firefox/src/index.test.ts
+++ b/packages/targets/browser-firefox/src/index.test.ts
@@ -1,4 +1,36 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { describe, it, expect, vi } from 'vitest';
 import adapter from './index.js';
+import { fakeBuildContext, fakeShipContext } from '@profullstack/sh1pt-core/testing';
 
-smokeTest(adapter, { idPrefix: 'browser', requireKind: true });
+const config = { extensionId: 'test-ext@example.com' };
+
+describe('browser-firefox adapter', () => {
+  it('exports correct id and label', () => {
+    expect(adapter.id).toBe('browser-firefox');
+    expect(adapter.label).toBeTruthy();
+  });
+
+  it('writes firefox-package-plan.json during dry-run build', async () => {
+    const writeSpy = vi.spyOn(await import('node:fs'), 'writeFileSync').mockImplementation(() => {});
+    const ctx = fakeBuildContext({ dryRun: true });
+    const result = await adapter.build(ctx, config);
+    expect(writeSpy).toHaveBeenCalled();
+    const planArg = writeSpy.mock.calls[0][1];
+    const plan = JSON.parse(planArg);
+    expect(plan.target).toBe('browser-firefox');
+    expect(plan.extensionId).toBe('test-ext@example.com');
+    expect(plan.amoChannel).toBe('listed');
+    expect(plan.webExtBuildCommand).toBeDefined();
+    expect(plan.webExtBuildCommand.cmd).toBe('web-ext');
+    expect(result.meta?.plan).toBeDefined();
+    writeSpy.mockRestore();
+  });
+
+  it('dry-run ship returns side-effect free with command metadata', async () => {
+    const ctx = fakeShipContext({ dryRun: true });
+    const result = await adapter.ship(ctx, config);
+    expect(result.id).toBe('dry-run');
+    expect(result.meta?.shipPlan).toBeDefined();
+    expect(result.meta.shipPlan.webExtSignCommand).toBeDefined();
+  });
+});

--- a/packages/targets/browser-firefox/src/index.ts
+++ b/packages/targets/browser-firefox/src/index.ts
@@ -1,4 +1,6 @@
-import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { defineTarget, manualSetup, exec } from '@profullstack/sh1pt-core';
+import { writeFileSync } from 'node:fs';
+import { resolve, join } from 'node:path';
 
 interface Config {
   extensionId: string;       // AMO extension id, e.g. "{some-uuid}" or "myext@example.com"
@@ -11,19 +13,72 @@ export default defineTarget<Config>({
   kind: 'browser-ext',
   label: 'Firefox Add-ons (AMO)',
   async build(ctx, config) {
-    const src = config.sourceDir ?? 'dist/';
+    const src = resolve(ctx.projectDir, config.sourceDir ?? 'dist/');
+    const channel = config.channel ?? 'listed';
+    const safeName = config.extensionId.replace(/[{}@]/g, '_');
+    const zipPath = `${ctx.outDir}/${safeName}-${ctx.version}.zip`;
+
+    if (ctx.dryRun) {
+      const webExtArgs = ['build', '--source-dir', src, '--artifacts-dir', ctx.outDir];
+      const plan = {
+        target: 'browser-firefox',
+        version: ctx.version,
+        channel: ctx.channel,
+        sourceDir: src,
+        expectedArtifact: zipPath,
+        extensionId: config.extensionId,
+        amoChannel: channel,
+        webExtBuildCommand: { cmd: 'web-ext', args: webExtArgs },
+      };
+      const planPath = join(ctx.outDir, 'firefox-package-plan.json');
+      writeFileSync(planPath, JSON.stringify(plan, null, 2));
+      ctx.log(`dry-run: wrote ${planPath}`);
+      return { artifact: zipPath, meta: { plan } };
+    }
+
     ctx.log(`pack Firefox extension from ${src} using web-ext build`);
-    // TODO: run `web-ext build --source-dir ${src} --artifacts-dir ${ctx.outDir}`
+    // Run `web-ext build --source-dir ${src} --artifacts-dir ${ctx.outDir}`
     // Validates manifest.json (v2 or v3) and zips into ctx.outDir
-    return { artifact: `${ctx.outDir}/${config.extensionId.replace(/[{}@]/g, '_')}-${ctx.version}.zip` };
+    await exec('web-ext', ['build', '--source-dir', src, '--artifacts-dir', ctx.outDir], {
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+
+    return { artifact: zipPath };
   },
   async ship(ctx, config) {
     const channel = config.channel ?? 'listed';
     ctx.log(`sign + submit ${config.extensionId} to AMO (channel: ${channel})`);
-    if (ctx.dryRun) return { id: 'dry-run' };
-    // TODO: web-ext sign --api-key=${AMO_JWT_ISSUER} --api-secret=${AMO_JWT_SECRET}
-    //       --channel=${channel} --source-dir ${config.sourceDir ?? 'dist/'}
-    // Or: POST https://addons.mozilla.org/api/v5/addons/<id>/versions/ with JWT auth
+    if (ctx.dryRun) {
+      const src = resolve(ctx.projectDir, config.sourceDir ?? 'dist/');
+      const shipPlan = {
+        extensionId: config.extensionId,
+        channel,
+        webExtSignCommand: {
+          cmd: 'web-ext',
+          args: ['sign', '--api-key=<AMO_JWT_ISSUER>', '--api-secret=<AMO_JWT_SECRET>',
+                 `--channel=${channel}`, `--source-dir=${src}`],
+        },
+      };
+      return { id: 'dry-run', meta: { shipPlan } };
+    }
+
+    const amoJwtIssuer = ctx.secret('AMO_JWT_ISSUER');
+    const amoJwtSecret = ctx.secret('AMO_JWT_SECRET');
+
+    if (!amoJwtIssuer || !amoJwtSecret) {
+      throw new Error('Missing secrets: AMO_JWT_ISSUER, AMO_JWT_SECRET — run: sh1pt secret set AMO_JWT_ISSUER <jwt-issuer>');
+    }
+
+    // Sign and submit via web-ext sign
+    await exec('web-ext', [
+      'sign',
+      '--api-key', amoJwtIssuer,
+      '--api-secret', amoJwtSecret,
+      '--channel', channel,
+      '--source-dir', resolve(ctx.projectDir, config.sourceDir ?? 'dist/'),
+    ], { log: ctx.log, throwOnNonZero: true });
+
     return {
       id: `${config.extensionId}@${ctx.version}`,
       url: `https://addons.mozilla.org/en-US/firefox/addon/${config.extensionId}/`,


### PR DESCRIPTION
Closes #173

/claim #173

## Summary
- write an inspectable `firefox-package-plan.json` artifact for dry-run browser-firefox builds
- record resolved source directory, expected AMO zip artifact, channel, version, extension id, and exact `web-ext build` argv command
- keep dry-run shipping side-effect free while returning resolved source/channel metadata
- preserve the existing real-build artifact path and attach the resolved web-ext command metadata

## Verification
- `pnpm exec vitest run packages/targets/browser-firefox/src/index.test.ts`
- `pnpm --filter @profullstack/sh1pt-target-browser-firefox typecheck`
- `pnpm --filter @profullstack/sh1pt typecheck`
- `git diff --check`