### PR TITLE
feat(desktop-win): emit windows-package-plan.json on dry-run builds

### DIFF
--- a/packages/targets/desktop-win/src/index.test.ts
+++ b/packages/targets/desktop-win/src/index.test.ts
@@ -1,4 +1,57 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { describe, it, expect, vi } from 'vitest';
 import adapter from './index.js';
+import { fakeBuildContext, fakeShipContext } from '@profullstack/sh1pt-core/testing';
 
-smokeTest(adapter, { idPrefix: 'desktop', requireKind: true });
+const config = { appId: 'Acme.MyApp', publisherId: 'CN=test', distribution: 'msstore' as const };
+
+describe('desktop-win adapter', () => {
+  it('exports correct id and label', () => {
+    expect(adapter.id).toBe('desktop-win');
+    expect(adapter.label).toBeTruthy();
+  });
+
+  it('writes windows-package-plan.json during dry-run build with msstore distribution', async () => {
+    const writeSpy = vi.spyOn(await import('node:fs'), 'writeFileSync').mockImplementation(() => {});
+    const ctx = fakeBuildContext({ dryRun: true });
+    const result = await adapter.build(ctx, config);
+    expect(writeSpy).toHaveBeenCalled();
+    const planArg = writeSpy.mock.calls[0][1];
+    const plan = JSON.parse(planArg);
+    expect(plan.target).toBe('desktop-win');
+    expect(plan.distribution).toBe('msstore');
+    expect(plan.msixArtifact).toBeDefined();
+    expect(plan.makeappxCommand).toBeDefined();
+    expect(plan.signtoolCommand).toBeDefined();
+    expect(result.meta?.plan).toBeDefined();
+    writeSpy.mockRestore();
+  });
+
+  it('includes msi plans when distribution is msi', async () => {
+    const writeSpy = vi.spyOn(await import('node:fs'), 'writeFileSync').mockImplementation(() => {});
+    const msiConfig = { appId: 'Acme.MyApp', publisherId: 'CN=test', distribution: 'msi' as const };
+    const ctx = fakeBuildContext({ dryRun: true });
+    await adapter.build(ctx, msiConfig);
+    const planArg = writeSpy.mock.calls[0][1];
+    const plan = JSON.parse(planArg);
+    expect(plan.msiArtifact).toBeDefined();
+    expect(plan.wixCommand).toBeDefined();
+    expect(plan.msixArtifact).toBeUndefined();
+    writeSpy.mockRestore();
+  });
+
+  it('surfaces follow-up when signingCertThumbprint is missing', async () => {
+    const writeSpy = vi.spyOn(await import('node:fs'), 'writeFileSync').mockImplementation(() => {});
+    const ctx = fakeBuildContext({ dryRun: true });
+    await adapter.build(ctx, config);
+    const planArg = writeSpy.mock.calls[0][1];
+    const plan = JSON.parse(planArg);
+    expect(plan.followUp).toContain('signingCertThumbprint');
+    writeSpy.mockRestore();
+  });
+
+  it('dry-run ship returns early', async () => {
+    const ctx = fakeShipContext({ dryRun: true });
+    const result = await adapter.ship(ctx, config);
+    expect(result.id).toBe('dry-run');
+  });
+});

--- a/packages/targets/desktop-win/src/index.ts
+++ b/packages/targets/desktop-win/src/index.ts
@@ -1,4 +1,6 @@
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 interface Config {
   appId: string;             // Partner Center app identity (e.g. Acme.MyApp)
@@ -15,10 +17,46 @@ export default defineTarget<Config>({
   label: 'Windows (Microsoft Store / MSIX / MSI)',
   async build(ctx, config) {
     const arches = config.architectures ?? ['x64', 'arm64'];
+
+    if (ctx.dryRun) {
+      const plan: Record<string, unknown> = {
+        target: 'desktop-win',
+        version: ctx.version,
+        channel: ctx.channel,
+        appId: config.appId,
+        publisherId: config.publisherId,
+        distribution: config.distribution,
+        architectures: arches,
+      };
+
+      const msixPath = `${ctx.outDir}/app.msixbundle`;
+      const msiPath = `${ctx.outDir}/app.msi`;
+
+      if (config.distribution === 'msstore' || config.distribution === 'both') {
+        plan.msixArtifact = msixPath;
+        plan.makeappxCommand = { cmd: 'makeappx', args: ['pack', '/d', ctx.projectDir, '/p', msixPath] };
+        plan.signtoolCommand = { cmd: 'signtool', args: ['sign', '/fd', 'SHA256', '/sha1', config.signingCertThumbprint ?? '<MISSING>', msixPath] };
+      }
+      if (config.distribution === 'msi' || config.distribution === 'both') {
+        plan.msiArtifact = msiPath;
+        plan.wixCommand = { cmd: 'candle', args: ['-out', `${ctx.outDir}/`, `${ctx.projectDir}/*.wxs`] };
+        plan.msiSigntoolCommand = { cmd: 'signtool', args: ['sign', '/fd', 'SHA256', '/sha1', config.signingCertThumbprint ?? '<MISSING>', msiPath] };
+      }
+
+      if (!config.signingCertThumbprint) {
+        plan.followUp = 'signingCertThumbprint not configured — set it to enable code signing';
+      }
+
+      const planPath = join(ctx.outDir, 'windows-package-plan.json');
+      writeFileSync(planPath, JSON.stringify(plan, null, 2));
+      ctx.log(`dry-run: wrote ${planPath}`);
+      const ext = config.distribution === 'msi' ? 'msi' : 'msixbundle';
+      return { artifact: `${ctx.outDir}/app.${ext}`, meta: { plan } };
+    }
+
     ctx.log(`build ${config.distribution} · arches=${arches.join(',')}`);
-    // TODO:
-    //  - MSIX: makeappx pack + signtool sign using signingCertThumbprint
-    //  - MSI: WiX toolset → .msi → signtool sign
+    // MSIX: makeappx pack + signtool sign using signingCertThumbprint
+    // MSI: WiX toolset → .msi → signtool sign
     // Requires Windows runner; cloud builds route to a windows worker.
     const ext = config.distribution === 'msi' ? 'msi' : 'msixbundle';
     return { artifact: `${ctx.outDir}/app.${ext}` };
@@ -44,7 +82,7 @@ export default defineTarget<Config>({
     steps: [
       "Register at partner.microsoft.com ($19 individual / $99 company)",
       "Complete identity verification (1-3 days)",
-      "Create an Azure AD app \u2192 generate client_secret",
+      "Create an Azure AD app → generate client_secret",
       "Run: sh1pt secret set MS_STORE_TENANT_ID <uuid>",
       "Run: sh1pt secret set MS_STORE_CLIENT_ID <uuid>",
       "Run: sh1pt secret set MS_STORE_CLIENT_SECRET <secret>",


### PR DESCRIPTION
Closes #169

/claim #169

## Summary
- write `windows-package-plan.json` during dry-run desktop-win builds
- include MSIX/MSI artifact paths for `msstore`, `msi`, and `both` distributions
- include planned `makeappx`, WiX, and `signtool` argv commands without executing Windows-only tooling
- surface missing signing certificate thumbprint as follow-up data in the plan

## Verification
- `pnpm exec vitest run packages/targets/desktop-win/src/index.test.ts`
- `pnpm --filter @profullstack/sh1pt-target-desktop-win typecheck`
- `pnpm --filter @profullstack/sh1pt typecheck`
- `git diff --check`