### PR TITLE
Implement Kimi chat completions adapter

### DIFF
--- a/packages/ai/kimi/src/index.test.ts
+++ b/packages/ai/kimi/src/index.test.ts
@@ -1,4 +1,80 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { MOONSHOT_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Kimi OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ MOONSHOT_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'kimi-k2.6' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from kimi' } }],
+        model: 'kimi-k2-thinking',
+        usage: { prompt_tokens: 9, completion_tokens: 4 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'kimi-k2-thinking',
+      system: 'be brief',
+      maxTokens: 24,
+      temperature: 0.2,
+      extra: { top_p: 0.95 },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.moonshot.ai/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'kimi-k2-thinking',
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 24,
+      temperature: 0.2,
+      top_p: 0.95,
+    });
+    expect(result).toEqual({
+      text: 'hi from kimi',
+      model: 'kimi-k2-thinking',
+      inputTokens: 9,
+      outputTokens: 4,
+    });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => 'invalid key'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/Kimi 401: invalid key/);
+  });
+});

--- a/packages/ai/kimi/src/index.ts
+++ b/packages/ai/kimi/src/index.ts
@@ -4,27 +4,86 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.moonshot.ai/v1';
+const DEFAULT_MODEL = 'kimi-k2.6';
+
 export default defineAi<Config>({
   id: 'ai-kimi',
   label: 'Kimi (Moonshot)',
-  defaultModel: 'kimi-k2-0905-preview',
-  models: ['kimi-k2-0905-preview'],
+  defaultModel: DEFAULT_MODEL,
+  models: [
+    DEFAULT_MODEL,
+    'kimi-k2.5',
+    'kimi-k2-thinking',
+    'kimi-k2-turbo-preview',
+    'kimi-k2-0905-preview',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('MOONSHOT_API_KEY');
-    if (!apiKey) throw new Error('MOONSHOT_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-kimi · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-kimi integration not yet implemented]', model: 'kimi-k2-0905-preview' };
+    if (!apiKey) throw new Error('MOONSHOT_API_KEY not in vault');
+    const model = opts.model ?? DEFAULT_MODEL;
+    ctx.log(`kimi · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: KimiMessage[] = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Kimi ${res.status}: ${(await res.text()).slice(0, 200)}`);
+
+    const data = await res.json() as KimiChatResponse;
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'MOONSHOT_API_KEY',
     label: 'Kimi (Moonshot)',
-    vendorDocUrl: 'https://platform.moonshot.ai',
+    vendorDocUrl: 'https://platform.kimi.ai/docs/api/chat',
     steps: [
-      'Sign in at https://platform.moonshot.ai and create an API key',
+      'Sign in at https://platform.moonshot.ai/console/api-keys and create an API key',
       'Copy the key — usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],
   }),
 });
+
+type KimiRole = 'system' | 'user' | 'assistant' | 'tool';
+
+interface KimiMessage {
+  role: KimiRole;
+  content: string;
+}
+
+interface KimiChatResponse {
+  model: string;
+  choices: Array<{
+    message?: {
+      content?: string;
+      reasoning_content?: string;
+    };
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+  };
+}


### PR DESCRIPTION
## Summary
- replace the Kimi AI stub with a real Moonshot/Kimi chat-completions request
- keep dry-run behavior network-free
- map provider usage tokens and status/body error excerpts
- add focused mocked-fetch coverage for dry-run, request payloads, usage mapping, and errors

Related to #6.

## Validation
- corepack pnpm@9.12.0 --filter @profullstack/sh1pt-ai-kimi typecheck
- corepack pnpm@9.12.0 exec vitest run packages/ai/kimi/src/index.test.ts
- corepack pnpm@9.12.0 --filter @profullstack/sh1pt-ai-kimi build
- corepack pnpm@9.12.0 --filter @profullstack/sh1pt typecheck
- git diff --check