### PR TITLE
Implement Cloudflare DNS API provider

### DIFF
--- a/packages/dns/cloudflare/src/index.test.ts
+++ b/packages/dns/cloudflare/src/index.test.ts
@@ -1,4 +1,196 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'dns' });
+
+const ctx = (secrets: Record<string, string> = { CLOUDFLARE_API_TOKEN: 'cf-token' }) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+});
+
+const cfResponse = <T>(result: T, status = 200, resultInfo?: { page?: number; total_pages?: number }) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => ({ result, result_info: resultInfo }),
+  text: async () => JSON.stringify({ result }),
+});
+
+const cfError = (status: number, message: string) => ({
+  ok: false,
+  status,
+  text: async () => message,
+});
+
+function requestBody(call: unknown[]): Record<string, unknown> {
+  const request = call[1] as { body?: string };
+  return JSON.parse(request.body ?? '{}') as Record<string, unknown>;
+}
+
+describe('Cloudflare DNS API', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('requires a Cloudflare API token on connect', async () => {
+    await expect(adapter.connect(ctx({}) as any, {})).rejects.toThrow(/CLOUDFLARE_API_TOKEN/);
+  });
+
+  it('lists zones with optional account filter and pagination', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(cfResponse([{ id: 'zone-1', name: 'example.com' }], 200, { page: 1, total_pages: 2 }))
+      .mockResolvedValueOnce(cfResponse([{ id: 'zone-2', name: 'example.dev' }], 200, { page: 2, total_pages: 2 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.connect(ctx() as any, {});
+    const zones = await adapter.listZones({ accountId: 'acct-1' });
+
+    expect(zones).toEqual([
+      { id: 'zone-1', name: 'example.com' },
+      { id: 'zone-2', name: 'example.dev' },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain('account.id=acct-1');
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain('page=2');
+    expect((fetchMock.mock.calls[0]?.[1] as { headers: Record<string, string> }).headers.authorization).toBe('Bearer cf-token');
+  });
+
+  it('lists DNS records and maps Cloudflare content fields', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(cfResponse([
+      { id: 'rec-1', name: 'api.example.com', type: 'A', content: '1.2.3.4', ttl: 120, proxied: true },
+    ])));
+
+    await adapter.connect(ctx() as any, {});
+    const records = await adapter.listRecords('zone-1', {});
+
+    expect(records).toEqual([
+      { id: 'rec-1', zone: 'zone-1', name: 'api.example.com', type: 'A', value: '1.2.3.4', ttl: 120, proxied: true },
+    ]);
+  });
+
+  it('updates an existing record during upsert', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(cfResponse([
+        { id: 'rec-1', name: 'api.example.com', type: 'A', content: '1.2.3.4', ttl: 120, proxied: false },
+      ]))
+      .mockResolvedValueOnce(cfResponse({
+        id: 'rec-1',
+        name: 'api.example.com',
+        type: 'A',
+        content: '5.6.7.8',
+        ttl: 60,
+        proxied: true,
+      }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.connect(ctx() as any, {});
+    const updated = await adapter.upsertRecord('zone-1', {
+      zone: 'zone-1',
+      name: 'api.example.com',
+      type: 'A',
+      value: '5.6.7.8',
+      ttl: 60,
+      proxied: true,
+    }, {});
+
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('https://api.cloudflare.com/client/v4/zones/zone-1/dns_records/rec-1');
+    expect((fetchMock.mock.calls[1]?.[1] as { method: string }).method).toBe('PATCH');
+    expect(requestBody(fetchMock.mock.calls[1] ?? [])).toEqual({
+      type: 'A',
+      name: 'api.example.com',
+      content: '5.6.7.8',
+      ttl: 60,
+      proxied: true,
+    });
+    expect(updated.value).toBe('5.6.7.8');
+  });
+
+  it('creates a record during upsert when no match exists', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(cfResponse([]))
+      .mockResolvedValueOnce(cfResponse({
+        id: 'rec-new',
+        name: 'www.example.com',
+        type: 'CNAME',
+        content: 'target.example.net',
+        ttl: 300,
+        proxied: false,
+      }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.connect(ctx() as any, {});
+    const created = await adapter.upsertRecord('zone-1', {
+      zone: 'zone-1',
+      name: 'www.example.com',
+      type: 'CNAME',
+      value: 'target.example.net',
+      ttl: 300,
+    }, {});
+
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('https://api.cloudflare.com/client/v4/zones/zone-1/dns_records');
+    expect((fetchMock.mock.calls[1]?.[1] as { method: string }).method).toBe('POST');
+    expect(created.id).toBe('rec-new');
+  });
+
+  it('deletes records and treats missing records as already gone', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(cfResponse({ id: 'rec-1' }))
+      .mockResolvedValueOnce(cfError(404, 'not found'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.connect(ctx() as any, {});
+    await adapter.deleteRecord('zone-1', 'rec-1', {});
+    await adapter.deleteRecord('zone-1', 'already-gone', {});
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect((fetchMock.mock.calls[0]?.[1] as { method: string }).method).toBe('DELETE');
+  });
+
+  it('syncs round-robin A records by updating kept IPs, deleting extras, and creating missing IPs', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(cfResponse([
+        { id: 'keep', name: 'api.example.com', type: 'A', content: '1.1.1.1', ttl: 300, proxied: false },
+        { id: 'delete', name: 'api.example.com', type: 'A', content: '9.9.9.9', ttl: 300, proxied: false },
+        { id: 'txt', name: 'api.example.com', type: 'TXT', content: 'leave-me', ttl: 300 },
+      ]))
+      .mockResolvedValueOnce(cfResponse({
+        id: 'keep',
+        name: 'api.example.com',
+        type: 'A',
+        content: '1.1.1.1',
+        ttl: 60,
+        proxied: true,
+      }))
+      .mockResolvedValueOnce(cfResponse({ id: 'delete' }))
+      .mockResolvedValueOnce(cfResponse({
+        id: 'created',
+        name: 'api.example.com',
+        type: 'A',
+        content: '2.2.2.2',
+        ttl: 60,
+        proxied: true,
+      }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.connect(ctx() as any, {});
+    const records = await adapter.syncRoundRobin({
+      zoneId: 'zone-1',
+      name: 'api.example.com',
+      ips: ['1.1.1.1', '2.2.2.2'],
+      ttl: 60,
+      proxied: true,
+    }, {});
+
+    expect(records.map(record => record.value)).toEqual(['1.1.1.1', '2.2.2.2']);
+    expect((fetchMock.mock.calls[1]?.[1] as { method: string }).method).toBe('PATCH');
+    expect((fetchMock.mock.calls[2]?.[1] as { method: string }).method).toBe('DELETE');
+    expect((fetchMock.mock.calls[3]?.[1] as { method: string }).method).toBe('POST');
+  });
+
+  it('surfaces status and response body on Cloudflare failures', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(cfError(403, 'missing DNS Write')));
+
+    await adapter.connect(ctx() as any, {});
+    await expect(adapter.listRecords('zone-1', {})).rejects.toThrow(/Cloudflare listRecords: 403 missing DNS Write/);
+  });
+});

--- a/packages/dns/cloudflare/src/index.ts
+++ b/packages/dns/cloudflare/src/index.ts
@@ -12,51 +12,214 @@ interface Config {
 }
 
 const API = 'https://api.cloudflare.com/client/v4';
+let _secret: (k: string) => string | undefined = () => undefined;
+
+interface CloudflareZone {
+  id: string;
+  name: string;
+}
+
+interface CloudflareRecord {
+  id: string;
+  name: string;
+  type: string;
+  content: string;
+  ttl: number;
+  proxied?: boolean;
+}
+
+interface CloudflareEnvelope<T> {
+  result: T;
+  errors?: Array<{ code?: number; message?: string }>;
+  result_info?: { page?: number; total_pages?: number };
+}
+
+function authHeaders(): Record<string, string> {
+  return {
+    authorization: `Bearer ${_secret('CLOUDFLARE_API_TOKEN')}`,
+    'content-type': 'application/json',
+  };
+}
+
+function proxiable(type: DnsRecord['type']): boolean {
+  return type === 'A' || type === 'AAAA' || type === 'CNAME';
+}
+
+function recordNameMatches(actual: string, requested: string): boolean {
+  if (actual === requested) return true;
+  if (requested === '@') return false;
+  return !requested.includes('.') && actual.startsWith(`${requested}.`);
+}
+
+function toDnsRecord(zoneId: string, record: CloudflareRecord): DnsRecord {
+  return {
+    id: record.id,
+    zone: zoneId,
+    name: record.name,
+    type: record.type as DnsRecord['type'],
+    value: record.content,
+    ttl: record.ttl,
+    proxied: record.proxied,
+  };
+}
+
+function recordPayload(record: Omit<DnsRecord, 'id'>, config: Config): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    type: record.type,
+    name: record.name,
+    content: record.value,
+    ttl: record.ttl ?? config.defaultTtl ?? 60,
+  };
+  if (proxiable(record.type)) {
+    body.proxied = record.proxied ?? config.defaultProxied ?? false;
+  }
+  return body;
+}
+
+async function readError(operation: string, res: Response): Promise<Error> {
+  const body = (await res.text()).slice(0, 200);
+  return new Error(`Cloudflare ${operation}: ${res.status}${body ? ` ${body}` : ''}`);
+}
+
+async function requestJson<T>(operation: string, path: string, init: RequestInit = {}): Promise<T> {
+  const res = await fetch(`${API}${path}`, {
+    ...init,
+    headers: {
+      ...authHeaders(),
+      ...(init.headers as Record<string, string> | undefined),
+    },
+  });
+  if (!res.ok) throw await readError(operation, res);
+  const data = await res.json() as CloudflareEnvelope<T>;
+  return data.result;
+}
+
+async function requestAll<T>(operation: string, path: string, params = new URLSearchParams()): Promise<T[]> {
+  const items: T[] = [];
+  let page = 1;
+  let totalPages = 1;
+
+  do {
+    params.set('page', String(page));
+    const res = await fetch(`${API}${path}?${params.toString()}`, { headers: authHeaders() });
+    if (!res.ok) throw await readError(operation, res);
+    const data = await res.json() as CloudflareEnvelope<T[]>;
+    items.push(...data.result);
+    totalPages = data.result_info?.total_pages ?? 1;
+    page += 1;
+  } while (page <= totalPages);
+
+  return items;
+}
+
+async function createRecord(zoneId: string, record: Omit<DnsRecord, 'id'>, config: Config): Promise<DnsRecord> {
+  const created = await requestJson<CloudflareRecord>(
+    'createRecord',
+    `/zones/${zoneId}/dns_records`,
+    {
+      method: 'POST',
+      body: JSON.stringify(recordPayload(record, config)),
+    },
+  );
+  return toDnsRecord(zoneId, created);
+}
+
+async function updateRecord(zoneId: string, recordId: string, record: Omit<DnsRecord, 'id'>, config: Config): Promise<DnsRecord> {
+  const updated = await requestJson<CloudflareRecord>(
+    'updateRecord',
+    `/zones/${zoneId}/dns_records/${recordId}`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify(recordPayload(record, config)),
+    },
+  );
+  return toDnsRecord(zoneId, updated);
+}
 
 export default defineDns<Config>({
   id: 'dns-cloudflare',
   label: 'Cloudflare DNS',
 
   async connect(ctx) {
+    _secret = (k) => ctx.secret(k);
     if (!ctx.secret('CLOUDFLARE_API_TOKEN')) throw new Error('CLOUDFLARE_API_TOKEN not set');
     return { accountId: 'cloudflare' };
   },
 
-  async listZones() {
-    // TODO: GET ${API}/zones → { result: [{ id, name }] }
-    return [];
+  async listZones(config) {
+    const params = new URLSearchParams({ per_page: '100' });
+    if (config.accountId) params.set('account.id', config.accountId);
+    const zones = await requestAll<CloudflareZone>('listZones', '/zones', params);
+    return zones.map(zone => ({ id: zone.id, name: zone.name }));
   },
 
   async listRecords(zoneId) {
-    // TODO: GET ${API}/zones/${zoneId}/dns_records
-    return [];
+    const records = await requestAll<CloudflareRecord>(
+      'listRecords',
+      `/zones/${zoneId}/dns_records`,
+      new URLSearchParams({ per_page: '100' }),
+    );
+    return records.map(record => toDnsRecord(zoneId, record));
   },
 
   async upsertRecord(zoneId, record, config) {
-    // TODO: POST ${API}/zones/${zoneId}/dns_records (or PUT /:recordId for update)
-    const proxied = record.proxied ?? config.defaultProxied ?? false;
-    return { id: 'stub', ...record, zone: zoneId, proxied };
+    const existing = (await this.listRecords(zoneId, config)).find(
+      r => r.type === record.type && recordNameMatches(r.name, record.name),
+    );
+    if (existing) return updateRecord(zoneId, existing.id, record, config);
+    return createRecord(zoneId, record, config);
   },
 
   async deleteRecord(zoneId, recordId) {
-    // TODO: DELETE ${API}/zones/${zoneId}/dns_records/${recordId}
+    const res = await fetch(`${API}/zones/${zoneId}/dns_records/${recordId}`, {
+      method: 'DELETE',
+      headers: authHeaders(),
+    });
+    if (!res.ok && res.status !== 404) throw await readError('deleteRecord', res);
   },
 
   async syncRoundRobin({ zoneId, name, ips, ttl, proxied }, config) {
     const ttlFinal = ttl ?? config.defaultTtl ?? 60;
     const proxiedFinal = proxied ?? config.defaultProxied ?? false;
-    // TODO: listRecords() → diff → create missing, delete extras, leave matching.
-    // Orange-cloud mode (proxied=true) makes CF the A record publicly; use only
-    // when backends are sh1pt-deployed VPSes with CF-issued origin certs.
-    return ips.map((ip, i) => ({
-      id: `cf-stub-${i}`,
-      zone: zoneId,
-      name,
-      type: 'A' as const,
-      value: ip,
-      ttl: ttlFinal,
-      proxied: proxiedFinal,
-    })) satisfies DnsRecord[];
+    const targetIps = new Set(ips);
+    const existing = (await this.listRecords(zoneId, config)).filter(
+      r => r.type === 'A' && recordNameMatches(r.name, name),
+    );
+
+    const records: DnsRecord[] = [];
+    for (const record of existing) {
+      if (!targetIps.has(record.value)) {
+        await this.deleteRecord(zoneId, record.id, config);
+        continue;
+      }
+
+      targetIps.delete(record.value);
+      if (record.ttl !== ttlFinal || record.proxied !== proxiedFinal || record.name !== name) {
+        records.push(await updateRecord(zoneId, record.id, {
+          zone: zoneId,
+          name,
+          type: 'A',
+          value: record.value,
+          ttl: ttlFinal,
+          proxied: proxiedFinal,
+        }, config));
+      } else {
+        records.push(record);
+      }
+    }
+
+    for (const ip of targetIps) {
+      records.push(await createRecord(zoneId, {
+        zone: zoneId,
+        name,
+        type: 'A',
+        value: ip,
+        ttl: ttlFinal,
+        proxied: proxiedFinal,
+      }, config));
+    }
+
+    return records;
   },
 
   setup: tokenSetup<Config>({


### PR DESCRIPTION
## Summary
- replace the Cloudflare DNS stub with real Cloudflare API v4 calls for zones, records, upserts, deletes, and round-robin sync
- map Cloudflare response fields into sh1pt DNS records and support account filters, pagination, TTL defaults, and proxied defaults
- add mocked API coverage for auth, pagination, record mapping, create/update/delete, round-robin reconciliation, and API error messages

Related to #6.

## Validation
- corepack pnpm@9.12.0 --filter @profullstack/sh1pt-dns-cloudflare typecheck
- corepack pnpm@9.12.0 exec vitest run packages/dns/cloudflare/src/index.test.ts
- corepack pnpm@9.12.0 --filter @profullstack/sh1pt-dns-cloudflare build
- corepack pnpm@9.12.0 --filter @profullstack/sh1pt typecheck
- git diff --check