### PR TITLE
Implement Route 53 DNS API provider

### DIFF
--- a/packages/dns/route53/src/index.test.ts
+++ b/packages/dns/route53/src/index.test.ts
@@ -1,7 +1,204 @@
-import { contractTestDns } from '@profullstack/sh1pt-core/testing';
+import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import dns from './index.js';
 
-contractTestDns(dns, {
-  sampleConfig: {},
-  requiredSecrets: ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'],
+smokeTest(dns, { idPrefix: 'dns' });
+
+const ctx = (secrets: Record<string, string> = {
+  AWS_ACCESS_KEY_ID: 'AKIDEXAMPLE',
+  AWS_SECRET_ACCESS_KEY: 'secret',
+}) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+});
+
+const route53Response = (xml: string, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  text: async () => xml,
+});
+
+const zonePage = (zones: Array<{ id: string; name: string }>, nextMarker?: string) => `
+<ListHostedZonesResponse>
+  <HostedZones>
+    ${zones.map(zone => `<HostedZone><Id>/hostedzone/${zone.id}</Id><Name>${zone.name}.</Name></HostedZone>`).join('')}
+  </HostedZones>
+  <IsTruncated>${nextMarker ? 'true' : 'false'}</IsTruncated>
+  ${nextMarker ? `<NextMarker>${nextMarker}</NextMarker>` : ''}
+</ListHostedZonesResponse>`;
+
+const recordPage = (sets: string[], next?: { name: string; type: string }) => `
+<ListResourceRecordSetsResponse>
+  <ResourceRecordSets>${sets.join('')}</ResourceRecordSets>
+  <IsTruncated>${next ? 'true' : 'false'}</IsTruncated>
+  ${next ? `<NextRecordName>${next.name}</NextRecordName><NextRecordType>${next.type}</NextRecordType>` : ''}
+</ListResourceRecordSetsResponse>`;
+
+const rrset = (name: string, type: string, ttl: number, values: string[]) => `
+<ResourceRecordSet>
+  <Name>${name}</Name>
+  <Type>${type}</Type>
+  <TTL>${ttl}</TTL>
+  <ResourceRecords>
+    ${values.map(value => `<ResourceRecord><Value>${value}</Value></ResourceRecord>`).join('')}
+  </ResourceRecords>
+</ResourceRecordSet>`;
+
+const aliasSet = (name: string, dnsName: string) => `
+<ResourceRecordSet>
+  <Name>${name}</Name>
+  <Type>A</Type>
+  <AliasTarget><DNSName>${dnsName}</DNSName></AliasTarget>
+</ResourceRecordSet>`;
+
+function request(index: number, fetchMock: ReturnType<typeof vi.fn>): { url: string; init: RequestInit; body: string } {
+  const [url, init] = fetchMock.mock.calls[index] as [string, RequestInit];
+  return { url, init, body: String(init.body ?? '') };
+}
+
+describe('AWS Route 53 DNS API', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('requires AWS credentials on connect', async () => {
+    await expect(dns.connect(ctx({}) as any, {})).rejects.toThrow(/AWS_ACCESS_KEY_ID/);
+  });
+
+  it('lists hosted zones with SigV4 auth and pagination', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(route53Response(zonePage([{ id: 'Z1', name: 'example.com' }], 'next-page')))
+      .mockResolvedValueOnce(route53Response(zonePage([{ id: 'Z2', name: 'example.dev' }])));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await dns.connect(ctx() as any, {});
+    const zones = await dns.listZones({});
+
+    expect(zones).toEqual([
+      { id: 'Z1', name: 'example.com' },
+      { id: 'Z2', name: 'example.dev' },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(request(0, fetchMock).url).toBe('https://route53.amazonaws.com/2013-04-01/hostedzone?maxitems=100');
+    expect(request(1, fetchMock).url).toContain('marker=next-page');
+    const headers = request(0, fetchMock).init.headers as Record<string, string>;
+    expect(headers.authorization).toContain('Credential=AKIDEXAMPLE/');
+    expect(headers.authorization).toContain('SignedHeaders=host;x-amz-content-sha256;x-amz-date');
+    expect(headers['x-amz-date']).toMatch(/^\d{8}T\d{6}Z$/);
+  });
+
+  it('lists supported DNS records and maps aliases to CNAME-like entries', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(route53Response(recordPage([
+      rrset('api.example.com.', 'A', 60, ['1.1.1.1', '2.2.2.2']),
+      rrset('example.com.', 'NS', 172800, ['ns-1.awsdns.com.']),
+      aliasSet('cdn.example.com.', 'target.cloudfront.net.'),
+    ]))));
+
+    await dns.connect(ctx() as any, {});
+    const records = await dns.listRecords('Z1', {});
+
+    expect(records).toEqual([
+      expect.objectContaining({ zone: 'Z1', name: 'api.example.com', type: 'A', value: '1.1.1.1', ttl: 60 }),
+      expect.objectContaining({ zone: 'Z1', name: 'api.example.com', type: 'A', value: '2.2.2.2', ttl: 60 }),
+      expect.objectContaining({ zone: 'Z1', name: 'cdn.example.com', type: 'CNAME', value: 'target.cloudfront.net', ttl: 0 }),
+    ]);
+    expect(records).toHaveLength(3);
+  });
+
+  it('upserts records by preserving existing same-name values', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(route53Response(recordPage([
+        rrset('api.example.com.', 'A', 60, ['1.1.1.1']),
+      ])))
+      .mockResolvedValueOnce(route53Response('<ChangeResourceRecordSetsResponse />'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await dns.connect(ctx() as any, {});
+    const result = await dns.upsertRecord('Z1', {
+      zone: 'Z1',
+      name: 'api.example.com',
+      type: 'A',
+      value: '2.2.2.2',
+      ttl: 120,
+    }, {});
+
+    const change = request(1, fetchMock);
+    expect(change.url).toBe('https://route53.amazonaws.com/2013-04-01/hostedzone/Z1/rrset');
+    expect(change.init.method).toBe('POST');
+    expect(change.body).toContain('<Action>UPSERT</Action>');
+    expect(change.body).toContain('<TTL>120</TTL>');
+    expect(change.body).toContain('<Value>1.1.1.1</Value>');
+    expect(change.body).toContain('<Value>2.2.2.2</Value>');
+    expect(result).toMatchObject({ name: 'api.example.com', type: 'A', value: '2.2.2.2', ttl: 120 });
+  });
+
+  it('deletes a single value from a multi-value RRSet via UPSERT', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(route53Response(recordPage([
+        rrset('api.example.com.', 'A', 60, ['1.1.1.1', '2.2.2.2']),
+      ])))
+      .mockResolvedValueOnce(route53Response(recordPage([
+        rrset('api.example.com.', 'A', 60, ['1.1.1.1', '2.2.2.2']),
+      ])))
+      .mockResolvedValueOnce(route53Response('<ChangeResourceRecordSetsResponse />'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await dns.connect(ctx() as any, {});
+    const record = (await dns.listRecords('Z1', {}))[0]!;
+    await dns.deleteRecord('Z1', record.id, {});
+
+    const change = request(2, fetchMock);
+    expect(change.body).toContain('<Action>UPSERT</Action>');
+    expect(change.body).not.toContain('<Value>1.1.1.1</Value>');
+    expect(change.body).toContain('<Value>2.2.2.2</Value>');
+  });
+
+  it('deletes the whole RRSet when the last value is removed', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(route53Response(recordPage([
+        rrset('api.example.com.', 'A', 60, ['1.1.1.1']),
+      ])))
+      .mockResolvedValueOnce(route53Response(recordPage([
+        rrset('api.example.com.', 'A', 60, ['1.1.1.1']),
+      ])))
+      .mockResolvedValueOnce(route53Response('<ChangeResourceRecordSetsResponse />'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await dns.connect(ctx() as any, {});
+    const record = (await dns.listRecords('Z1', {}))[0]!;
+    await dns.deleteRecord('Z1', record.id, {});
+
+    const change = request(2, fetchMock);
+    expect(change.body).toContain('<Action>DELETE</Action>');
+    expect(change.body).toContain('<Value>1.1.1.1</Value>');
+  });
+
+  it('syncs round-robin A records with one Route 53 UPSERT', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(route53Response('<ChangeResourceRecordSetsResponse />'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await dns.connect(ctx() as any, {});
+    const records = await dns.syncRoundRobin({
+      zoneId: 'Z1',
+      name: 'api.example.com',
+      ips: ['1.1.1.1', '1.1.1.1', '2.2.2.2'],
+      ttl: 30,
+    }, {});
+
+    expect(records.map(record => record.value)).toEqual(['1.1.1.1', '2.2.2.2']);
+    const change = request(0, fetchMock);
+    expect(change.body).toContain('<Action>UPSERT</Action>');
+    expect(change.body).toContain('<TTL>30</TTL>');
+    expect(change.body).toContain('<Name>api.example.com.</Name>');
+    expect(change.body).toContain('<Value>1.1.1.1</Value>');
+    expect(change.body).toContain('<Value>2.2.2.2</Value>');
+  });
+
+  it('surfaces Route 53 API failures with status and response body', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(route53Response('<Error><Message>denied</Message></Error>', 403)));
+
+    await dns.connect(ctx() as any, {});
+    await expect(dns.listZones({})).rejects.toThrow(/Route53 listZones: 403/);
+    await expect(dns.listZones({})).rejects.toThrow(/denied/);
+  });
 });

--- a/packages/dns/route53/src/index.ts
+++ b/packages/dns/route53/src/index.ts
@@ -1,9 +1,8 @@
+import { createHash, createHmac } from 'node:crypto';
 import { defineDns, type DnsRecord } from '@profullstack/sh1pt-core';
 
 // AWS Route 53 DNS. Auth: AWS IAM credentials (Access Key + Secret).
-// sh1pt uses the AWS SDK v3 @aws-sdk/client-route-53 under the hood
-// but exposes only the credentials — no SDK runtime is bundled here.
-// REST wire format for reference only; real calls go through the SDK.
+// Uses the Route 53 REST API directly so the provider stays dependency-free.
 //
 // Key concepts:
 //   - Hosted Zone ID (e.g. Z1234567890) identifies a domain
@@ -15,7 +14,290 @@ interface Config {
   defaultTtl?: number;
 }
 
+const API = 'https://route53.amazonaws.com';
+const API_VERSION = '2013-04-01';
 let _secret: (k: string) => string | undefined = () => undefined;
+
+interface HostedZone {
+  id: string;
+  name: string;
+}
+
+interface RecordId {
+  name: string;
+  type: DnsRecord['type'];
+  value: string;
+}
+
+interface ListRecordSetsResult {
+  records: DnsRecord[];
+  isTruncated: boolean;
+  nextRecordName?: string;
+  nextRecordType?: string;
+  nextRecordIdentifier?: string;
+}
+
+function awsRegion(config: Config): string {
+  return config.region ?? 'us-east-1';
+}
+
+function requiredSecret(key: string): string {
+  const value = _secret(key);
+  if (!value) throw new Error(`${key} not set`);
+  return value;
+}
+
+function sha256Hex(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function hmac(key: string | Buffer, value: string): Buffer {
+  return createHmac('sha256', key).update(value).digest();
+}
+
+function hmacHex(key: Buffer, value: string): string {
+  return createHmac('sha256', key).update(value).digest('hex');
+}
+
+function encodeRfc3986(value: string): string {
+  return encodeURIComponent(value).replace(/[!'()*]/g, char =>
+    `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+function canonicalQuery(params: URLSearchParams): string {
+  return [...params.entries()]
+    .sort(([aKey, aValue], [bKey, bValue]) => aKey.localeCompare(bKey) || aValue.localeCompare(bValue))
+    .map(([key, value]) => `${encodeRfc3986(key)}=${encodeRfc3986(value)}`)
+    .join('&');
+}
+
+function amzDates(now = new Date()): { amzDate: string; dateStamp: string } {
+  const iso = now.toISOString().replace(/[:-]|\.\d{3}/g, '');
+  return { amzDate: iso, dateStamp: iso.slice(0, 8) };
+}
+
+function signRequest(method: string, path: string, params: URLSearchParams, body: string, config: Config): Record<string, string> {
+  const accessKey = requiredSecret('AWS_ACCESS_KEY_ID');
+  const secretKey = requiredSecret('AWS_SECRET_ACCESS_KEY');
+  const sessionToken = _secret('AWS_SESSION_TOKEN');
+  const { amzDate, dateStamp } = amzDates();
+  const region = awsRegion(config);
+  const payloadHash = sha256Hex(body);
+  const signingHeaders: Record<string, string> = {
+    host: 'route53.amazonaws.com',
+    'x-amz-content-sha256': payloadHash,
+    'x-amz-date': amzDate,
+  };
+
+  if (sessionToken) signingHeaders['x-amz-security-token'] = sessionToken;
+  if (method !== 'GET') signingHeaders['content-type'] = 'application/xml';
+
+  const signedHeaderNames = Object.keys(signingHeaders).sort();
+  const canonicalHeaders = signedHeaderNames.map(name => `${name}:${signingHeaders[name]}\n`).join('');
+  const signedHeaders = signedHeaderNames.join(';');
+  const canonicalRequest = [
+    method,
+    path,
+    canonicalQuery(params),
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join('\n');
+
+  const scope = `${dateStamp}/${region}/route53/aws4_request`;
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    amzDate,
+    scope,
+    sha256Hex(canonicalRequest),
+  ].join('\n');
+  const signingKey = hmac(hmac(hmac(hmac(`AWS4${secretKey}`, dateStamp), region), 'route53'), 'aws4_request');
+  const signature = hmacHex(signingKey, stringToSign);
+  const requestHeaders = { ...signingHeaders };
+  delete requestHeaders.host;
+  requestHeaders.authorization = `AWS4-HMAC-SHA256 Credential=${accessKey}/${scope}, SignedHeaders=${signedHeaders}, Signature=${signature}`;
+  return requestHeaders;
+}
+
+function normalizeZoneId(zoneId: string): string {
+  return zoneId.replace(/^\/hostedzone\//, '').replace(/^\//, '');
+}
+
+function stripTrailingDot(value: string): string {
+  return value.endsWith('.') ? value.slice(0, -1) : value;
+}
+
+function awsRecordName(name: string): string {
+  return name.endsWith('.') ? name : `${name}.`;
+}
+
+function xmlEscape(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function xmlDecode(value: string): string {
+  return value
+    .replace(/&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&gt;/g, '>')
+    .replace(/&lt;/g, '<')
+    .replace(/&amp;/g, '&');
+}
+
+function tagBlocks(xml: string, tag: string): string[] {
+  const blocks: string[] = [];
+  const re = new RegExp(`<${tag}(?:\\s[^>]*)?>([\\s\\S]*?)</${tag}>`, 'gi');
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(xml)) !== null) {
+    blocks.push(match[1] ?? '');
+  }
+  return blocks;
+}
+
+function tagValue(xml: string, tag: string): string | undefined {
+  const block = tagBlocks(xml, tag)[0];
+  return block === undefined ? undefined : xmlDecode(block.trim());
+}
+
+function supportedType(type: string): type is DnsRecord['type'] {
+  return type === 'A' || type === 'AAAA' || type === 'CNAME' || type === 'TXT' || type === 'MX';
+}
+
+function encodeRecordId(record: RecordId): string {
+  return encodeURIComponent(JSON.stringify(record));
+}
+
+function decodeRecordId(id: string): RecordId | undefined {
+  try {
+    const parsed = JSON.parse(decodeURIComponent(id)) as Partial<RecordId>;
+    if (typeof parsed.name === 'string' && typeof parsed.type === 'string' && supportedType(parsed.type) && typeof parsed.value === 'string') {
+      return { name: parsed.name, type: parsed.type, value: parsed.value };
+    }
+  } catch {
+    // fall through to undefined
+  }
+  return undefined;
+}
+
+function recordNameMatches(actual: string, requested: string): boolean {
+  const normalizedActual = stripTrailingDot(actual);
+  const normalizedRequested = stripTrailingDot(requested);
+  if (normalizedActual === normalizedRequested) return true;
+  return !normalizedRequested.includes('.') && normalizedActual.startsWith(`${normalizedRequested}.`);
+}
+
+function toDnsRecord(zoneId: string, name: string, type: DnsRecord['type'], value: string, ttl: number): DnsRecord {
+  return {
+    id: encodeRecordId({ name, type, value }),
+    zone: zoneId,
+    name,
+    type,
+    value,
+    ttl,
+  };
+}
+
+function parseHostedZones(xml: string): { zones: HostedZone[]; isTruncated: boolean; nextMarker?: string } {
+  return {
+    zones: tagBlocks(xml, 'HostedZone').map(zoneXml => ({
+      id: normalizeZoneId(tagValue(zoneXml, 'Id') ?? ''),
+      name: stripTrailingDot(tagValue(zoneXml, 'Name') ?? ''),
+    })).filter(zone => zone.id && zone.name),
+    isTruncated: tagValue(xml, 'IsTruncated') === 'true',
+    nextMarker: tagValue(xml, 'NextMarker'),
+  };
+}
+
+function parseRecordSets(zoneId: string, xml: string): ListRecordSetsResult {
+  const records: DnsRecord[] = [];
+
+  for (const recordSetXml of tagBlocks(xml, 'ResourceRecordSet')) {
+    const name = stripTrailingDot(tagValue(recordSetXml, 'Name') ?? '');
+    const rawType = tagValue(recordSetXml, 'Type') ?? '';
+    if (!name) continue;
+
+    const aliasTarget = tagBlocks(recordSetXml, 'AliasTarget')[0];
+    if (aliasTarget) {
+      const value = stripTrailingDot(tagValue(aliasTarget, 'DNSName') ?? '');
+      if (value) records.push(toDnsRecord(zoneId, name, 'CNAME', value, 0));
+      continue;
+    }
+
+    if (!supportedType(rawType)) continue;
+    const ttl = Number(tagValue(recordSetXml, 'TTL') ?? 300);
+    for (const rr of tagBlocks(recordSetXml, 'ResourceRecord')) {
+      const value = tagValue(rr, 'Value');
+      if (value) records.push(toDnsRecord(zoneId, name, rawType, value, ttl));
+    }
+  }
+
+  return {
+    records,
+    isTruncated: tagValue(xml, 'IsTruncated') === 'true',
+    nextRecordName: tagValue(xml, 'NextRecordName'),
+    nextRecordType: tagValue(xml, 'NextRecordType'),
+    nextRecordIdentifier: tagValue(xml, 'NextRecordIdentifier'),
+  };
+}
+
+async function route53Request(operation: string, method: string, path: string, params: URLSearchParams, body: string, config: Config): Promise<string> {
+  const query = canonicalQuery(params);
+  const headers = signRequest(method, path, params, body, config);
+  const res = await fetch(`${API}${path}${query ? `?${query}` : ''}`, {
+    method,
+    headers,
+    body: method === 'GET' ? undefined : body,
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`Route53 ${operation}: ${res.status}${text ? ` ${text.slice(0, 200)}` : ''}`);
+  return text;
+}
+
+function recordSetXml(name: string, type: DnsRecord['type'], ttl: number, values: string[]): string {
+  return [
+    '<ResourceRecordSet>',
+    `<Name>${xmlEscape(awsRecordName(name))}</Name>`,
+    `<Type>${type}</Type>`,
+    `<TTL>${ttl}</TTL>`,
+    '<ResourceRecords>',
+    ...values.map(value => `<ResourceRecord><Value>${xmlEscape(value)}</Value></ResourceRecord>`),
+    '</ResourceRecords>',
+    '</ResourceRecordSet>',
+  ].join('');
+}
+
+async function changeRecordSet(
+  zoneId: string,
+  action: 'DELETE' | 'UPSERT',
+  name: string,
+  type: DnsRecord['type'],
+  ttl: number,
+  values: string[],
+  config: Config,
+): Promise<void> {
+  const body = [
+    `<ChangeResourceRecordSetsRequest xmlns="https://route53.amazonaws.com/doc/${API_VERSION}/">`,
+    '<ChangeBatch><Changes><Change>',
+    `<Action>${action}</Action>`,
+    recordSetXml(name, type, ttl, values),
+    '</Change></Changes></ChangeBatch>',
+    '</ChangeResourceRecordSetsRequest>',
+  ].join('');
+  await route53Request(
+    'changeRecordSet',
+    'POST',
+    `/${API_VERSION}/hostedzone/${encodeRfc3986(normalizeZoneId(zoneId))}/rrset`,
+    new URLSearchParams(),
+    body,
+    config,
+  );
+}
 
 export default defineDns<Config>({
   id: 'dns-route53',
@@ -29,45 +311,96 @@ export default defineDns<Config>({
     return { accountId: 'route53' };
   },
 
-  async listZones() {
-    // TODO: use @aws-sdk/client-route-53 Route53Client + ListHostedZonesCommand
-    // const client = new Route53Client({ region: 'us-east-1', credentials: {
-    //   accessKeyId: _secret('AWS_ACCESS_KEY_ID') ?? '',
-    //   secretAccessKey: _secret('AWS_SECRET_ACCESS_KEY') ?? '',
-    // }});
-    // const { HostedZones } = await client.send(new ListHostedZonesCommand({}));
-    // return HostedZones.map(z => ({ id: z.Id.replace('/hostedzone/', ''), name: z.Name }));
-    return [];
+  async listZones(config) {
+    const zones: HostedZone[] = [];
+    let marker: string | undefined;
+    let truncated = false;
+
+    do {
+      const params = new URLSearchParams({ maxitems: '100' });
+      if (marker) params.set('marker', marker);
+      const xml = await route53Request('listZones', 'GET', `/${API_VERSION}/hostedzone`, params, '', config);
+      const page = parseHostedZones(xml);
+      zones.push(...page.zones);
+      truncated = page.isTruncated;
+      marker = page.nextMarker;
+    } while (truncated && marker);
+
+    return zones;
   },
 
-  async listRecords(_zoneId) {
-    // TODO: ListResourceRecordSetsCommand({ HostedZoneId: zoneId })
-    // Map RRSets to DnsRecord[]. ALIAS records map to type 'CNAME' with value = AliasTarget.DNSName.
-    return [];
+  async listRecords(zoneId, config) {
+    const records: DnsRecord[] = [];
+    let nextName: string | undefined;
+    let nextType: string | undefined;
+    let nextIdentifier: string | undefined;
+    let truncated = false;
+
+    do {
+      const params = new URLSearchParams({ maxitems: '100' });
+      if (nextName) params.set('name', nextName);
+      if (nextType) params.set('type', nextType);
+      if (nextIdentifier) params.set('identifier', nextIdentifier);
+      const xml = await route53Request(
+        'listRecords',
+        'GET',
+        `/${API_VERSION}/hostedzone/${encodeRfc3986(normalizeZoneId(zoneId))}/rrset`,
+        params,
+        '',
+        config,
+      );
+      const page = parseRecordSets(zoneId, xml);
+      records.push(...page.records);
+      truncated = page.isTruncated;
+      nextName = page.nextRecordName;
+      nextType = page.nextRecordType;
+      nextIdentifier = page.nextRecordIdentifier;
+    } while (truncated && nextName && nextType);
+
+    return records;
   },
 
   async upsertRecord(zoneId, record, config) {
-    // TODO: ChangeResourceRecordSetsCommand with ChangeBatch Action=UPSERT
     const ttl = record.ttl ?? config.defaultTtl ?? 300;
-    return { id: 'r53-stub', ...record, zone: zoneId, ttl };
+    const existing = (await this.listRecords(zoneId, config)).filter(
+      r => r.type === record.type && recordNameMatches(r.name, record.name),
+    );
+    const values = record.type === 'CNAME'
+      ? [record.value]
+      : [...new Set([...existing.map(r => r.value), record.value])];
+    await changeRecordSet(zoneId, 'UPSERT', record.name, record.type, ttl, values, config);
+    return { id: encodeRecordId({ name: record.name, type: record.type, value: record.value }), ...record, zone: zoneId, ttl };
   },
 
-  async deleteRecord(_zoneId, _recordId) {
-    // TODO: ChangeResourceRecordSetsCommand with ChangeBatch Action=DELETE
-    // Need to fetch the full RRSet first (name+type are required for DELETE).
+  async deleteRecord(zoneId, recordId, config) {
+    const record = decodeRecordId(recordId);
+    if (!record) return;
+    const existing = (await this.listRecords(zoneId, config)).filter(
+      r => r.type === record.type && recordNameMatches(r.name, record.name),
+    );
+    if (existing.length === 0) return;
+
+    const remaining = existing.filter(r => r.value !== record.value);
+    const ttl = existing[0]?.ttl ?? config.defaultTtl ?? 300;
+    if (remaining.length === 0) {
+      await changeRecordSet(zoneId, 'DELETE', record.name, record.type, ttl, existing.map(r => r.value), config);
+      return;
+    }
+    await changeRecordSet(zoneId, 'UPSERT', record.name, record.type, ttl, remaining.map(r => r.value), config);
   },
 
   async syncRoundRobin({ zoneId, name, ips, ttl }, config) {
-    // TODO: list existing A records at `name`, diff vs `ips`, upsert/delete.
-    // Route 53 round-robins natively — just set multiple A values in one RRSet.
     const ttlFinal = ttl ?? config.defaultTtl ?? 300;
-    return ips.map((ip, i) => ({
-      id: `r53-stub-${i}`,
-      zone: zoneId,
-      name,
-      type: 'A' as const,
-      value: ip,
-      ttl: ttlFinal,
-    })) satisfies DnsRecord[];
+    const uniqueIps = [...new Set(ips)];
+    if (uniqueIps.length === 0) {
+      const existing = (await this.listRecords(zoneId, config)).filter(
+        r => r.type === 'A' && recordNameMatches(r.name, name),
+      );
+      if (existing.length > 0) await changeRecordSet(zoneId, 'DELETE', name, 'A', existing[0]?.ttl ?? ttlFinal, existing.map(r => r.value), config);
+      return [];
+    }
+
+    await changeRecordSet(zoneId, 'UPSERT', name, 'A', ttlFinal, uniqueIps, config);
+    return uniqueIps.map(ip => toDnsRecord(zoneId, name, 'A', ip, ttlFinal));
   },
 });


### PR DESCRIPTION
## Summary
- replace the Route 53 DNS stub with real AWS Route 53 REST API calls for hosted zones, resource record sets, record changes, and round-robin A records
- add dependency-free SigV4 signing plus minimal Route 53 XML parsing/building for zones, records, UPSERT, and DELETE changes
- cover auth, pagination, record mapping, upsert preservation, delete reconciliation, round-robin UPSERT, and API errors with mocked tests

Related to #6.

## Validation
- corepack pnpm@9.12.0 --filter @profullstack/sh1pt-dns-route53 typecheck
- corepack pnpm@9.12.0 exec vitest run packages/dns/route53/src/index.test.ts
- corepack pnpm@9.12.0 --filter @profullstack/sh1pt-dns-route53 build
- corepack pnpm@9.12.0 --filter @profullstack/sh1pt typecheck
- git diff --check