### PR TITLE
Add webhook subscription list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,6 +691,7 @@ sh1pt config webhooks add telegram                      # bot token + chat_id
 sh1pt config webhooks add teams
 sh1pt config webhooks add generic                       # any HTTP URL; body is HMAC-signed
 sh1pt config webhooks test discord --event ship.published   # fire a stub event
+sh1pt config webhooks sub list --json                   # machine-readable subscriptions
 ```
 
 Sh1pt fires every configured target on the events you subscribe it to — `ship.published`, `promote.campaign.started`, `promote.merch.order.placed`, `scale.alarm.tripped`, `payments.checkout.completed`, `iterate.cycle.completed`, etc. Or use `*` to get everything.

--- a/packages/cli/src/commands/config.test.ts
+++ b/packages/cli/src/commands/config.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest';
+import { configCmd } from './config.js';
+
+describe('config webhooks subscriptions', () => {
+  it('prints machine-readable subscription listings', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    let output = '';
+
+    try {
+      await configCmd.parseAsync(['webhooks', 'sub', 'list', '--json'], { from: 'user' });
+      output = log.mock.calls.map(([line]) => String(line)).join('\n');
+    } finally {
+      log.mockRestore();
+    }
+
+    expect(JSON.parse(output)).toEqual({ subscriptions: [] });
+  });
+});

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -271,6 +271,15 @@ const subCmd = webhooksCmd
   .action(() => { subCmd.help(); });
 
 subCmd
+  .command('list')
+  .description('List configured event subscriptions')
+  .option('--json')
+  .action((opts: { json?: boolean }) => {
+    if (opts.json) { console.log(JSON.stringify({ subscriptions: [] }, null, 2)); return; }
+    console.log(kleur.dim('[stub] webhooks sub list'));
+  });
+
+subCmd
   .command('add <url>')
   .description('Subscribe an external URL to sh1pt events (sh1pt POSTs to it with HMAC-signed bodies)')
   .option('--events <list>', 'comma-separated event names, or * for all', '*')

--- a/sites/sh1pt.com/app/docs/page.tsx
+++ b/sites/sh1pt.com/app/docs/page.tsx
@@ -530,6 +530,7 @@ export default function DocsPage() {
           <CommandBlock signature="sh1pt config webhooks remove <target>" description="Disable a webhook target." examples={[{ command: 'sh1pt config webhooks remove discord' }]} />
           <CommandBlock signature="sh1pt config webhooks test <target>" description="Fire a stub event at a registered target." examples={[{ command: 'sh1pt config webhooks test slack --event ship.published' }]} />
           <CommandBlock signature="sh1pt config webhooks list" description="All configured outbound targets + subscription URLs." examples={[{ command: 'sh1pt config webhooks list --json' }]} />
+          <CommandBlock signature="sh1pt config webhooks sub list" description="List configured event subscription URLs." examples={[{ command: 'sh1pt config webhooks sub list --json' }]} />
           <CommandBlock signature="sh1pt config webhooks sub add <url>" description="Subscribe an external URL to sh1pt events (HMAC-signed POSTs)." options={[{ flag: '--events <csv>', description: 'event names or * (default: *)' }, { flag: '--description <text>', description: 'human label' }]} examples={[{ command: 'sh1pt config webhooks sub add https://example.com/hooks/sh1pt --events ship.published,ship.rolled-back' }]} />
           <CommandBlock signature="sh1pt config webhooks sub remove <subscriptionId>" description="Remove a subscription." examples={[{ command: 'sh1pt config webhooks sub remove sub_abc123' }]} />
         </div>


### PR DESCRIPTION
Closes #205.
Part of #133.

## What changed
- Adds `sh1pt config webhooks sub list` so event subscriptions have the same inspectable list path as webhook targets.
- Supports `--json` for automation with a stable `{ subscriptions: [] }` shape while the backing store is still stubbed.
- Documents the command in the README webhook examples and the docs page.

## Verification
- `pnpm exec vitest run packages/cli/src/commands/config.test.ts`
- `pnpm --filter @profullstack/sh1pt typecheck`
- `pnpm --filter sh1pt-dot-com build`
- `git diff --check`