### PR TITLE
Add autoblog webhook adapters

### DIFF
--- a/packages/autoblog/crawlproof/package.json
+++ b/packages/autoblog/crawlproof/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@profullstack/sh1pt-autoblog-crawlproof",
+  "version": "0.1.15",
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "pnpm build"
+  },
+  "dependencies": {
+    "@profullstack/sh1pt-core": "workspace:*"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/profullstack/sh1pt.git",
+    "directory": "packages/autoblog/crawlproof"
+  },
+  "homepage": "https://sh1pt.com",
+  "bugs": "https://github.com/profullstack/sh1pt/issues",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/autoblog/crawlproof/src/index.test.ts
+++ b/packages/autoblog/crawlproof/src/index.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { contractTestAutoblog, fakeConnectContext } from '@profullstack/sh1pt-core/testing';
+import adapter from './index.js';
+
+contractTestAutoblog(adapter, {
+  sampleConfig: {},
+  requiredSecrets: ['CRAWLPROOF_WEBHOOK_URL'],
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('autoblog-crawlproof publishing', () => {
+  it('posts a CrawlProof-shaped article payload', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => JSON.stringify({ requestId: 'req_456', status: 'published', url: 'https://crawlproof.com/articles/req_456' }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({
+        CRAWLPROOF_WEBHOOK_URL: 'https://hooks.crawlproof.com/sh1pt',
+        CRAWLPROOF_WEBHOOK_SECRET: 'secret',
+      }),
+      dryRun: false,
+    };
+
+    const result = await adapter.publish(ctx as any, {
+      title: 'Launch notes',
+      bodyMarkdown: 'Markdown body',
+      sourceUrl: 'https://example.com/source',
+      tags: ['seo'],
+    }, {
+      projectId: 'project_1',
+      collection: 'blog',
+      publishMode: 'publish',
+    });
+
+    expect(result).toMatchObject({
+      id: 'req_456',
+      provider: 'crawlproof',
+      status: 'published',
+      url: 'https://crawlproof.com/articles/req_456',
+      responseStatus: 200,
+    });
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://hooks.crawlproof.com/sh1pt');
+    expect((init as RequestInit).headers).toMatchObject({
+      'content-type': 'application/json',
+      'X-Sh1pt-Provider': 'crawlproof',
+    });
+    expect(JSON.parse(String((init as RequestInit).body))).toMatchObject({
+      source: 'sh1pt',
+      provider: 'crawlproof',
+      projectId: 'project_1',
+      collection: 'blog',
+      publishMode: 'publish',
+      article: {
+        title: 'Launch notes',
+        markdown: 'Markdown body',
+        sourceUrl: 'https://example.com/source',
+        tags: ['seo'],
+      },
+    });
+  });
+});

--- a/packages/autoblog/crawlproof/src/index.ts
+++ b/packages/autoblog/crawlproof/src/index.ts
@@ -1,0 +1,141 @@
+import { createHmac } from 'node:crypto';
+import {
+  defineAutoblog,
+  webhookUrlSetup,
+  type AutoblogArticle,
+  type AutoblogPublishMode,
+  type AutoblogResult,
+  type AutoblogStatus,
+} from '@profullstack/sh1pt-core';
+
+interface Config {
+  webhookUrlKey?: string;
+  secretKey?: string;
+  projectId?: string;
+  collection?: string;
+  publishMode?: AutoblogPublishMode;
+}
+
+const PROVIDER = 'crawlproof';
+const DEFAULT_URL_KEY = 'CRAWLPROOF_WEBHOOK_URL';
+const DEFAULT_SECRET_KEY = 'CRAWLPROOF_WEBHOOK_SECRET';
+
+export default defineAutoblog<Config>({
+  id: 'autoblog-crawlproof',
+  label: 'CrawlProof autoblog',
+  capabilities: {
+    webhook: true,
+    secretSigning: true,
+    draft: true,
+    canonicalUrl: true,
+    tags: true,
+  },
+
+  async publish(ctx, article, config): Promise<AutoblogResult> {
+    const urlKey = config.webhookUrlKey ?? DEFAULT_URL_KEY;
+    const url = ctx.secret(urlKey);
+    if (!url) throw new Error(`${urlKey} not in vault — run: sh1pt secret set ${urlKey} <webhook-url>`);
+
+    const submittedAt = new Date().toISOString();
+    const payload = formatCrawlProofPayload(article, config, submittedAt);
+    ctx.log(`crawlproof autoblog webhook · ${article.title}`);
+
+    if (ctx.dryRun) {
+      return { id: 'dry-run', provider: PROVIDER, status: 'dry-run', url, submittedAt };
+    }
+
+    const body = JSON.stringify(payload);
+    const secret = ctx.secret(config.secretKey ?? DEFAULT_SECRET_KEY);
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'X-Sh1pt-Provider': PROVIDER,
+        ...(secret ? { 'X-Sh1pt-Signature': sign(body, secret) } : {}),
+      },
+      body,
+    });
+
+    return readWebhookResult(res, url, submittedAt);
+  },
+
+  setup: webhookUrlSetup<Config>({
+    secretKey: DEFAULT_URL_KEY,
+    label: 'CrawlProof autoblog webhook',
+    urlPrefix: 'https://',
+    vendorDocUrl: 'https://crawlproof.com',
+    steps: [
+      'Create or open the CrawlProof autoblog webhook destination',
+      'Copy its HTTPS webhook URL',
+      'Optionally set CRAWLPROOF_WEBHOOK_SECRET so receivers can verify the X-Sh1pt-Signature header',
+    ],
+  }),
+});
+
+function formatCrawlProofPayload(article: AutoblogArticle, config: Config, submittedAt: string): Record<string, unknown> {
+  return {
+    source: 'sh1pt',
+    provider: PROVIDER,
+    projectId: config.projectId,
+    collection: config.collection,
+    publishMode: config.publishMode ?? 'draft',
+    submittedAt,
+    article: {
+      title: article.title,
+      markdown: article.bodyMarkdown,
+      canonicalUrl: article.canonicalUrl,
+      sourceUrl: article.sourceUrl,
+      excerpt: article.excerpt,
+      tags: article.tags ?? [],
+      author: article.author,
+      publishedAt: article.publishedAt,
+      metadata: article.metadata,
+    },
+  };
+}
+
+async function readWebhookResult(res: Response, url: string, submittedAt: string): Promise<AutoblogResult> {
+  const text = await res.text().catch(() => '');
+  if (!res.ok) {
+    return {
+      id: 'failed',
+      provider: PROVIDER,
+      status: 'failed',
+      url,
+      submittedAt,
+      responseStatus: res.status,
+      error: text || res.statusText,
+    };
+  }
+
+  const data = parseJson(text);
+  return {
+    id: String(data.id ?? data.jobId ?? data.requestId ?? 'queued'),
+    provider: PROVIDER,
+    status: normalizeStatus(data.status),
+    url: typeof data.url === 'string' ? data.url : url,
+    submittedAt,
+    responseStatus: res.status,
+  };
+}
+
+function parseJson(text: string): Record<string, unknown> {
+  if (!text) return {};
+  try {
+    const parsed = JSON.parse(text);
+    return parsed && typeof parsed === 'object' ? parsed as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}
+
+function normalizeStatus(status: unknown): AutoblogStatus {
+  const value = String(status ?? '').toLowerCase();
+  if (value === 'published') return 'published';
+  if (value === 'failed') return 'failed';
+  return 'queued';
+}
+
+function sign(body: string, secret: string): string {
+  return `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`;
+}

--- a/packages/autoblog/crawlproof/tsconfig.json
+++ b/packages/autoblog/crawlproof/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/autoblog/outrank/package.json
+++ b/packages/autoblog/outrank/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@profullstack/sh1pt-autoblog-outrank",
+  "version": "0.1.15",
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "pnpm build"
+  },
+  "dependencies": {
+    "@profullstack/sh1pt-core": "workspace:*"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/profullstack/sh1pt.git",
+    "directory": "packages/autoblog/outrank"
+  },
+  "homepage": "https://sh1pt.com",
+  "bugs": "https://github.com/profullstack/sh1pt/issues",
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/autoblog/outrank/src/index.test.ts
+++ b/packages/autoblog/outrank/src/index.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { contractTestAutoblog, fakeConnectContext } from '@profullstack/sh1pt-core/testing';
+import adapter from './index.js';
+
+contractTestAutoblog(adapter, {
+  sampleConfig: {},
+  requiredSecrets: ['OUTRANK_WEBHOOK_URL'],
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('autoblog-outrank publishing', () => {
+  it('posts an article payload with optional HMAC signature', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 202,
+      statusText: 'Accepted',
+      text: async () => JSON.stringify({ id: 'job_123', status: 'queued', url: 'https://outrank.so/jobs/job_123' }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({
+        OUTRANK_WEBHOOK_URL: 'https://hooks.outrank.so/sh1pt',
+        OUTRANK_WEBHOOK_SECRET: 'secret',
+      }),
+      dryRun: false,
+    };
+
+    const result = await adapter.publish(ctx as any, {
+      title: 'Release shipped',
+      bodyMarkdown: '# Release shipped',
+      canonicalUrl: 'https://example.com/release',
+      tags: ['launch', 'automation'],
+    }, {
+      siteId: 'site_1',
+      workflowId: 'workflow_1',
+      publishMode: 'draft',
+    });
+
+    expect(result).toMatchObject({
+      id: 'job_123',
+      provider: 'outrank',
+      status: 'queued',
+      url: 'https://outrank.so/jobs/job_123',
+      responseStatus: 202,
+    });
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://hooks.outrank.so/sh1pt');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as RequestInit).headers).toMatchObject({
+      'content-type': 'application/json',
+      'X-Sh1pt-Provider': 'outrank',
+    });
+    expect(String(((init as RequestInit).headers as Record<string, string>)['X-Sh1pt-Signature'])).toMatch(/^sha256=/);
+    expect(JSON.parse(String((init as RequestInit).body))).toMatchObject({
+      source: 'sh1pt',
+      provider: 'outrank',
+      siteId: 'site_1',
+      workflowId: 'workflow_1',
+      publishMode: 'draft',
+      article: {
+        title: 'Release shipped',
+        body_markdown: '# Release shipped',
+        canonical_url: 'https://example.com/release',
+        tags: ['launch', 'automation'],
+      },
+    });
+  });
+});

--- a/packages/autoblog/outrank/src/index.ts
+++ b/packages/autoblog/outrank/src/index.ts
@@ -1,0 +1,141 @@
+import { createHmac } from 'node:crypto';
+import {
+  defineAutoblog,
+  webhookUrlSetup,
+  type AutoblogArticle,
+  type AutoblogPublishMode,
+  type AutoblogResult,
+  type AutoblogStatus,
+} from '@profullstack/sh1pt-core';
+
+interface Config {
+  webhookUrlKey?: string;
+  secretKey?: string;
+  siteId?: string;
+  workflowId?: string;
+  publishMode?: AutoblogPublishMode;
+}
+
+const PROVIDER = 'outrank';
+const DEFAULT_URL_KEY = 'OUTRANK_WEBHOOK_URL';
+const DEFAULT_SECRET_KEY = 'OUTRANK_WEBHOOK_SECRET';
+
+export default defineAutoblog<Config>({
+  id: 'autoblog-outrank',
+  label: 'Outrank autoblog',
+  capabilities: {
+    webhook: true,
+    secretSigning: true,
+    draft: true,
+    canonicalUrl: true,
+    tags: true,
+  },
+
+  async publish(ctx, article, config): Promise<AutoblogResult> {
+    const urlKey = config.webhookUrlKey ?? DEFAULT_URL_KEY;
+    const url = ctx.secret(urlKey);
+    if (!url) throw new Error(`${urlKey} not in vault — run: sh1pt secret set ${urlKey} <webhook-url>`);
+
+    const submittedAt = new Date().toISOString();
+    const payload = formatOutrankPayload(article, config, submittedAt);
+    ctx.log(`outrank autoblog webhook · ${article.title}`);
+
+    if (ctx.dryRun) {
+      return { id: 'dry-run', provider: PROVIDER, status: 'dry-run', url, submittedAt };
+    }
+
+    const body = JSON.stringify(payload);
+    const secret = ctx.secret(config.secretKey ?? DEFAULT_SECRET_KEY);
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'X-Sh1pt-Provider': PROVIDER,
+        ...(secret ? { 'X-Sh1pt-Signature': sign(body, secret) } : {}),
+      },
+      body,
+    });
+
+    return readWebhookResult(res, url, submittedAt);
+  },
+
+  setup: webhookUrlSetup<Config>({
+    secretKey: DEFAULT_URL_KEY,
+    label: 'Outrank autoblog webhook',
+    urlPrefix: 'https://',
+    vendorDocUrl: 'https://outrank.so',
+    steps: [
+      'Create or open the Outrank autoblog workflow that should receive sh1pt article payloads',
+      'Copy its HTTPS webhook URL',
+      'Optionally set OUTRANK_WEBHOOK_SECRET so receivers can verify the X-Sh1pt-Signature header',
+    ],
+  }),
+});
+
+function formatOutrankPayload(article: AutoblogArticle, config: Config, submittedAt: string): Record<string, unknown> {
+  return {
+    source: 'sh1pt',
+    provider: PROVIDER,
+    siteId: config.siteId,
+    workflowId: config.workflowId,
+    publishMode: config.publishMode ?? 'draft',
+    submittedAt,
+    article: {
+      title: article.title,
+      body_markdown: article.bodyMarkdown,
+      canonical_url: article.canonicalUrl,
+      source_url: article.sourceUrl,
+      excerpt: article.excerpt,
+      tags: article.tags ?? [],
+      author: article.author,
+      published_at: article.publishedAt,
+      metadata: article.metadata,
+    },
+  };
+}
+
+async function readWebhookResult(res: Response, url: string, submittedAt: string): Promise<AutoblogResult> {
+  const text = await res.text().catch(() => '');
+  if (!res.ok) {
+    return {
+      id: 'failed',
+      provider: PROVIDER,
+      status: 'failed',
+      url,
+      submittedAt,
+      responseStatus: res.status,
+      error: text || res.statusText,
+    };
+  }
+
+  const data = parseJson(text);
+  return {
+    id: String(data.id ?? data.jobId ?? data.requestId ?? 'queued'),
+    provider: PROVIDER,
+    status: normalizeStatus(data.status),
+    url: typeof data.url === 'string' ? data.url : url,
+    submittedAt,
+    responseStatus: res.status,
+  };
+}
+
+function parseJson(text: string): Record<string, unknown> {
+  if (!text) return {};
+  try {
+    const parsed = JSON.parse(text);
+    return parsed && typeof parsed === 'object' ? parsed as Record<string, unknown> : {};
+  } catch {
+    return {};
+  }
+}
+
+function normalizeStatus(status: unknown): AutoblogStatus {
+  const value = String(status ?? '').toLowerCase();
+  if (value === 'published') return 'published';
+  if (value === 'failed') return 'failed';
+  return 'queued';
+}
+
+function sign(body: string, secret: string): string {
+  return `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`;
+}

--- a/packages/autoblog/outrank/tsconfig.json
+++ b/packages/autoblog/outrank/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/packages/cli/src/adapter-registry.ts
+++ b/packages/cli/src/adapter-registry.ts
@@ -22,6 +22,12 @@ export const CATEGORIES: readonly AdapterCategory[] = [
     adapters: ['claude', 'codex', 'qwen'],
   },
   {
+    id: 'autoblog',
+    pkgPrefix: '@profullstack/sh1pt-autoblog',
+    description: 'Autoblog providers — Outrank and CrawlProof webhook publishing',
+    adapters: ['crawlproof', 'outrank'],
+  },
+  {
     id: 'ai',
     pkgPrefix: '@profullstack/sh1pt-ai',
     description: 'AI API providers for content generation — Claude (Anthropic), OpenAI, Qwen, Gemini',

--- a/packages/core/src/autoblog.ts
+++ b/packages/core/src/autoblog.ts
@@ -1,0 +1,66 @@
+import { autoSetup } from './setup-helpers.js';
+
+export type AutoblogPublishMode = 'draft' | 'publish';
+export type AutoblogStatus = 'dry-run' | 'queued' | 'published' | 'failed';
+
+export interface AutoblogArticle {
+  title: string;
+  bodyMarkdown: string;
+  canonicalUrl?: string;
+  sourceUrl?: string;
+  excerpt?: string;
+  tags?: string[];
+  author?: string;
+  publishedAt?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AutoblogResult {
+  id: string;
+  provider: string;
+  status: AutoblogStatus;
+  url?: string;
+  submittedAt: string;
+  responseStatus?: number;
+  error?: string;
+}
+
+export interface AutoblogCapabilities {
+  webhook: boolean;
+  secretSigning?: boolean;
+  draft?: boolean;
+  scheduled?: boolean;
+  canonicalUrl?: boolean;
+  tags?: boolean;
+}
+
+export interface AutoblogProvider<Config = unknown> {
+  id: string;
+  label: string;
+  capabilities: AutoblogCapabilities;
+  publish(
+    ctx: { secret(k: string): string | undefined; log(m: string): void; dryRun: boolean },
+    article: AutoblogArticle,
+    config: Config,
+  ): Promise<AutoblogResult>;
+  setup?(ctx: import('./setup.js').SetupContext): Promise<import('./setup.js').SetupResult<Config>>;
+}
+
+export function defineAutoblog<Config>(provider: AutoblogProvider<Config>): AutoblogProvider<Config> {
+  return autoSetup(provider);
+}
+
+const autoblogRegistry = new Map<string, AutoblogProvider<any>>();
+
+export function registerAutoblogProvider(provider: AutoblogProvider<any>): void {
+  if (autoblogRegistry.has(provider.id)) throw new Error(`Autoblog provider already registered: ${provider.id}`);
+  autoblogRegistry.set(provider.id, provider);
+}
+
+export function getAutoblogProvider(id: string): AutoblogProvider<any> | undefined {
+  return autoblogRegistry.get(id);
+}
+
+export function listAutoblogProviders(): AutoblogProvider<any>[] {
+  return [...autoblogRegistry.values()];
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export * from './manifest.js';
 export * from './registry.js';
 export * from './promo.js';
 export * from './affiliate.js';
+export * from './autoblog.js';
 export * from './cloud.js';
 export * from './dns.js';
 export * from './agent.js';

--- a/packages/core/src/testing/contract-autoblog.ts
+++ b/packages/core/src/testing/contract-autoblog.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import type { AutoblogArticle, AutoblogProvider } from '../autoblog.js';
+import { fakeConnectContext, looksLikeVaultHint } from './harness.js';
+
+export interface AutoblogContractOptions {
+  sampleConfig: unknown;
+  sampleArticle?: AutoblogArticle;
+  requiredSecrets: string[];
+}
+
+export function contractTestAutoblog(provider: AutoblogProvider<any>, opts: AutoblogContractOptions): void {
+  const article = opts.sampleArticle ?? {
+    title: 'Launch notes',
+    bodyMarkdown: 'A short article body.',
+    tags: ['launch'],
+  };
+
+  describe(`AutoblogProvider contract · ${provider.id}`, () => {
+    it('declares required fields', () => {
+      expect(provider.id).toMatch(/^autoblog-[a-z][a-z0-9-]*$/);
+      expect(provider.label).toBeTruthy();
+      expect(provider.capabilities.webhook).toBe(true);
+    });
+
+    it('publish() throws vault-hint when the webhook URL secret is missing', async () => {
+      const ctx = { ...fakeConnectContext({}), dryRun: false };
+      await expect(provider.publish(ctx as any, article, opts.sampleConfig)).rejects.toSatisfy((e: unknown) =>
+        e instanceof Error && looksLikeVaultHint(e),
+      );
+    });
+
+    it('publish() dry-run returns ok without calling the network', async () => {
+      const ctx = {
+        secret: (key: string) => opts.requiredSecrets.includes(key) ? 'https://example.com/autoblog' : undefined,
+        log: () => {},
+        dryRun: true,
+      };
+
+      const result = await provider.publish(ctx as any, article, opts.sampleConfig);
+      expect(result.provider).toBe(provider.id.replace(/^autoblog-/, ''));
+      expect(result.status).toBe('dry-run');
+      expect(result.url).toBe('https://example.com/autoblog');
+    });
+  });
+}

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -24,5 +24,6 @@ export * from './contract-bridge.js';
 export * from './contract-docs.js';
 export * from './contract-jurisdiction.js';
 export * from './contract-bot.js';
+export * from './contract-autoblog.js';
 export * from './smoke.js';
 export * from './harness.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -542,6 +542,18 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
 
+  packages/autoblog/crawlproof:
+    dependencies:
+      '@profullstack/sh1pt-core':
+        specifier: workspace:*
+        version: link:../../core
+
+  packages/autoblog/outrank:
+    dependencies:
+      '@profullstack/sh1pt-core':
+        specifier: workspace:*
+        version: link:../../core
+
   packages/bots/core:
     dependencies:
       zod:


### PR DESCRIPTION
## Summary
- add a core autoblog provider contract and contract-test runner
- add Outrank and CrawlProof autoblog adapters backed by vault-stored webhook URLs and optional HMAC signing secrets
- register the new autoblog category in the CLI adapter registry

Closes #210

## Verification
- corepack pnpm --filter @profullstack/sh1pt-core typecheck
- corepack pnpm --filter @profullstack/sh1pt typecheck
- corepack pnpm --filter @profullstack/sh1pt-autoblog-outrank --filter @profullstack/sh1pt-autoblog-crawlproof typecheck
- corepack pnpm exec vitest run packages/autoblog/outrank/src/index.test.ts packages/autoblog/crawlproof/src/index.test.ts
- git diff --check