### PR TITLE
feat(deploy-vercel): implement real CLI-backed vercel integration

### DIFF
--- a/packages/targets/deploy-vercel/src/index.ts
+++ b/packages/targets/deploy-vercel/src/index.ts
@@ -1,4 +1,4 @@
-import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { defineTarget, manualSetup, exec } from '@profullstack/sh1pt-core';
 
 interface Config {
   project?: string;
@@ -10,15 +10,60 @@ export default defineTarget<Config>({
   id: 'deploy-vercel',
   kind: 'web',
   label: 'Vercel',
-  async build(ctx) {
-    ctx.log('vercel build');
+  async build(ctx, config) {
+    const prod = config.prod ?? ctx.channel === 'stable';
+    ctx.log(`vercel build${prod ? ' --prod' : ''}`);
+
+    const token = ctx.secret('VERCEL_TOKEN');
+    if (!token) throw new Error('VERCEL_TOKEN secret not set. Run: sh1pt secret set VERCEL_TOKEN <token>');
+
+    const args: string[] = ['build'];
+    if (prod) args.push('--prod');
+
+    await exec('vercel', args, {
+      cwd: ctx.projectDir,
+      log: ctx.log,
+      throwOnNonZero: true,
+      env: { VERCEL_TOKEN: token },
+    });
+
     return { artifact: `${ctx.outDir}/vercel-output` };
   },
   async ship(ctx, config) {
     const prod = config.prod ?? ctx.channel === 'stable';
-    ctx.log(`vercel deploy ${prod ? '--prod' : ''} · project=${config.project ?? 'linked'}`);
+    ctx.log(`vercel deploy${prod ? ' --prod' : ''} · project=${config.project ?? 'linked'}`);
     if (ctx.dryRun) return { id: 'dry-run' };
-    return { id: `${config.project ?? 'vercel'}@${ctx.version}`, url: undefined };
+
+    const token = ctx.secret('VERCEL_TOKEN');
+    if (!token) {
+      throw new Error(
+        'VERCEL_TOKEN is required for deployment. ' +
+          'Create a token at vercel.com/account/tokens, ' +
+          'then set it: sh1pt secret set VERCEL_TOKEN <token>'
+      );
+    }
+
+    const args: string[] = ['deploy', '--token', token];
+    if (prod) args.push('--prod');
+
+    const { stdout } = await exec('vercel', args, {
+      cwd: ctx.projectDir,
+      log: ctx.log,
+      throwOnNonZero: true,
+      env: { VERCEL_TOKEN: token },
+    });
+
+    // Vercel prints the deployment URL as the last line of stdout
+    // e.g. "https://my-project-abc123.vercel.app"
+    const lines = stdout.trim().split('\n').filter(Boolean);
+    const urlMatch = stdout.match(/https:\/\/[a-zA-Z0-9.-]+\.vercel\.app/);
+    const url = urlMatch?.[0] ?? lines[lines.length - 1]?.trim();
+
+    const projectLabel = config.project ?? 'vercel';
+    const id = `${projectLabel}@${ctx.version}`;
+
+    ctx.log(`vercel deploy complete · id=${id} · url=${url}`);
+    return { id, url };
   },
   setup: manualSetup({
     label: 'Vercel CLI',


### PR DESCRIPTION
## Summary

- Replace stub `build()` and `ship()` with real `exec()` calls to the Vercel CLI
- `build()`: runs `vercel build` (with `--prod` when `config.prod` is set or channel is `stable`)
- `ship()`: runs `vercel deploy --token <token>` (with `--prod` on stable); passes token via both CLI flag and env var
- Reads token via `ctx.secret('VERCEL_TOKEN')`, throws descriptive error if missing
- Short-circuits on `ctx.dryRun` in `ship()`
- Parses deployment URL from vercel stdout (`https://*.vercel.app`)
- Passes `cwd: ctx.projectDir` and `env: { VERCEL_TOKEN }` to `exec` for proper isolation

## Test plan

- [ ] Set `VERCEL_TOKEN` secret: `sh1pt secret set VERCEL_TOKEN <token>`
- [ ] Dry-run: `sh1pt ship deploy-vercel --dry-run` should return `{ id: 'dry-run' }` without calling vercel
- [ ] Build: `sh1pt build deploy-vercel` should invoke `vercel build`
- [ ] Full deploy: `sh1pt ship deploy-vercel` should invoke `vercel deploy --token <token>` and return `{ id, url }`
- [ ] Prod deploy: with `prod: true` or `channel: stable`, should add `--prod` flag
- [ ] Missing token: should throw with helpful message pointing to `sh1pt secret set VERCEL_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)