### PR TITLE
fix(cli): register ship command at root

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ import { buildCmd } from './commands/build.js';
 import { promoteCmd } from './commands/promote.js';
 import { scaleCmd } from './commands/scale.js';
 import { iterateCmd } from './commands/iterate.js';
+import { shipCmd } from './commands/ship.js';
 import { loginCmd, logoutCmd } from './commands/login.js';
 import { secretsCmd } from './commands/secrets.js';
 import { configCmd } from './commands/config.js';
@@ -31,6 +32,7 @@ program
 // Entity-ops lives under `build` (see docs/prd/entityctl.md).
 program.addCommand(buildCmd);      // build    · compile · entity-ops nested
 program.addCommand(promoteCmd);    // promote  · publish (ship), ads, merch — anything that gets users
+program.addCommand(shipCmd);       // ship     · publish built artifacts to stores and registries
 program.addCommand(scaleCmd);      // scale    · provision (deploy), DNS, rollouts, cost
 program.addCommand(iterateCmd);    // iterate  · observe + agent-propose + ship + measure (agents nested)
 


### PR DESCRIPTION
## Summary\n- mount the existing `shipCmd` on the root CLI program\n- make documented commands like `sh1pt ship init`, `sh1pt ship status`, and `sh1pt ship target ...` discoverable and runnable\n\nCloses #233\nAddresses #133\n\n## Verification\n- `corepack pnpm --filter @profullstack/sh1pt typecheck`\n- `corepack pnpm --filter @profullstack/sh1pt exec tsx src/index.ts --help` shows top-level `ship`\n- `corepack pnpm --filter @profullstack/sh1pt exec tsx src/index.ts ship --help` shows ship subcommands