### PR TITLE
fix(cli): mount agents command at root

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,7 @@ import { updateCmd, removeCmd } from './commands/self.js';
 import { makeCategoryCmd } from './commands/adapter-cmd.js';
 import { CATEGORIES } from './adapter-registry.js';
 import { skillsCmd } from './commands/skills.js';
+import { agentsCmd } from './commands/agents.js';
 
 const program = new Command();
 
@@ -40,6 +41,7 @@ program.addCommand(logoutCmd);
 program.addCommand(secretsCmd);
 program.addCommand(configCmd);
 program.addCommand(skillsCmd);      // skills   · package/promote SKILL.md agent skills across marketplaces
+program.addCommand(agentsCmd);      // agents   · generate/run/talk with AI coding CLIs
 
 // Self-management — sh1pt update / upgrade / remove / uninstall.
 program.addCommand(updateCmd);
@@ -48,6 +50,7 @@ program.addCommand(removeCmd);
 // Filesystem-mirrored adapter commands. One top-level command per
 // packages/<category>/ directory → `sh1pt <category> <name> setup`.
 for (const cat of CATEGORIES) {
+  if (cat.id === 'agents') continue;
   program.addCommand(makeCategoryCmd(cat));
 }
 


### PR DESCRIPTION
## Summary\n- mount the implemented `agentsCmd` on the root CLI so documented commands like `sh1pt agents generate` work\n- skip the generic adapter-category `agents` command at root to avoid shadowing the implemented command\n- keep `iterate agents` behavior available\n\nCloses #235\nAddresses #133\n\n## Verification\n- `corepack pnpm --filter @profullstack/sh1pt typecheck`\n- `corepack pnpm --filter @profullstack/sh1pt exec tsx src/index.ts agents --help` shows list/setup/run/talk/generate\n- `corepack pnpm --filter @profullstack/sh1pt exec tsx src/index.ts iterate agents --help` still shows the agent subcommands