### PR TITLE
fix(cli): expose deploy command at root

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -1,11 +1,12 @@
 import { Command } from 'commander';
 import kleur from 'kleur';
 
-export const deployCmd = new Command('deploy')
-  .description('Provision cloud infrastructure — VPS, GPU, bare metal, managed databases, object storage')
-  .action(() => {
-    deployCmd.help();
-  });
+export function createDeployCmd() {
+  const deployCmd = new Command('deploy')
+    .description('Provision cloud infrastructure — VPS, GPU, bare metal, managed databases, object storage')
+    .action(() => {
+      deployCmd.help();
+    });
 
 deployCmd
   .command('setup')
@@ -82,3 +83,8 @@ deployCmd
   .action((id: string, opts: { provider: string }) => {
     console.log(kleur.dim(`[stub] deploy status ${id} on ${opts.provider}`));
   });
+
+  return deployCmd;
+}
+
+export const deployCmd = createDeployCmd();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,7 @@ import { updateCmd, removeCmd } from './commands/self.js';
 import { makeCategoryCmd } from './commands/adapter-cmd.js';
 import { CATEGORIES } from './adapter-registry.js';
 import { skillsCmd } from './commands/skills.js';
+import { createDeployCmd } from './commands/deploy.js';
 
 const program = new Command();
 
@@ -40,6 +41,7 @@ program.addCommand(logoutCmd);
 program.addCommand(secretsCmd);
 program.addCommand(configCmd);
 program.addCommand(skillsCmd);      // skills   · package/promote SKILL.md agent skills across marketplaces
+program.addCommand(createDeployCmd()); // deploy · documented top-level alias for scale deploy
 
 // Self-management — sh1pt update / upgrade / remove / uninstall.
 program.addCommand(updateCmd);


### PR DESCRIPTION
## Summary
- add a createDeployCmd() factory so deploy can be mounted in more than one command tree
- keep the existing sh1pt scale deploy path intact
- expose the documented top-level sh1pt deploy command as an alias for cloud provisioning workflows

## Verification
- npm run typecheck (packages/cli)
- npm run build (packages/cli)

Closes #239

Related to the accepted Ugig sh1pt CLI command gig.