### PR TITLE
fix(cli): expose init command at root

### DIFF
--- a/packages/cli/src/commands/ship.ts
+++ b/packages/cli/src/commands/ship.ts
@@ -22,6 +22,31 @@ async function loadManifest(): Promise<Manifest> {
   return { name: 'stub', version: '0.0.0', channels: ['stable', 'beta', 'canary'], targets: {} };
 }
 
+export function createInitCmd(): Command {
+  return new Command('init')
+    .description('Scaffold sh1pt.config.ts in the current project')
+    .action(async () => {
+      const cfgPath = join(process.cwd(), 'sh1pt.config.ts');
+      try {
+        await access(cfgPath);
+        console.log(kleur.yellow('sh1pt.config.ts already exists — aborting.'));
+        return;
+      } catch {
+        // expected
+      }
+      const { name } = await prompts({
+        type: 'text',
+        name: 'name',
+        message: 'Project name',
+        initial: process.cwd().split('/').pop() ?? 'my-app',
+      });
+      if (!name) return;
+      await writeFile(cfgPath, CONFIG_TEMPLATE(name), 'utf8');
+      console.log(kleur.green(`✓ wrote sh1pt.config.ts`));
+      console.log(`  next: ${kleur.cyan('sh1pt ship target add <id>')}`);
+    });
+}
+
 export const shipCmd = new Command('ship')
   .description('Publish built artifacts to their target stores and registries')
   .option('-t, --target <id...>', 'target ids to ship (default: all enabled)')
@@ -39,29 +64,7 @@ export const shipCmd = new Command('ship')
     // TODO: load manifest, resolve latest build, invoke Target.ship(), record release
   });
 
-shipCmd
-  .command('init')
-  .description('Scaffold sh1pt.config.ts in the current project')
-  .action(async () => {
-    const cfgPath = join(process.cwd(), 'sh1pt.config.ts');
-    try {
-      await access(cfgPath);
-      console.log(kleur.yellow('sh1pt.config.ts already exists — aborting.'));
-      return;
-    } catch {
-      // expected
-    }
-    const { name } = await prompts({
-      type: 'text',
-      name: 'name',
-      message: 'Project name',
-      initial: process.cwd().split('/').pop() ?? 'my-app',
-    });
-    if (!name) return;
-    await writeFile(cfgPath, CONFIG_TEMPLATE(name), 'utf8');
-    console.log(kleur.green(`✓ wrote sh1pt.config.ts`));
-    console.log(`  next: ${kleur.cyan('sh1pt ship target add <id>')}`);
-  });
+shipCmd.addCommand(createInitCmd());
 
 shipCmd
   .command('setup')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,7 @@ import { updateCmd, removeCmd } from './commands/self.js';
 import { makeCategoryCmd } from './commands/adapter-cmd.js';
 import { CATEGORIES } from './adapter-registry.js';
 import { skillsCmd } from './commands/skills.js';
+import { createInitCmd } from './commands/ship.js';
 
 const program = new Command();
 
@@ -40,6 +41,7 @@ program.addCommand(logoutCmd);
 program.addCommand(secretsCmd);
 program.addCommand(configCmd);
 program.addCommand(skillsCmd);      // skills   · package/promote SKILL.md agent skills across marketplaces
+program.addCommand(createInitCmd()); // init     · documented shortcut for scaffolding sh1pt.config.ts
 
 // Self-management — sh1pt update / upgrade / remove / uninstall.
 program.addCommand(updateCmd);


### PR DESCRIPTION
## Summary
- extract the existing `ship init` command into a factory so it can be mounted in more than one place
- keep `sh1pt ship init` behavior unchanged
- expose documented root-level `sh1pt init` for scaffolding `sh1pt.config.ts`

## Verification
- `npm run typecheck` (packages/cli)
- `npm run build` (packages/cli)

Runtime help check note: `node dist/index.js --help` and `node dist/index.js init --help` still fail before command parsing with the existing workspace resolution error: `Cannot find module '/workspace/sh1pt/packages/core/src/target.js' imported from /workspace/sh1pt/packages/core/src/index.ts`.

Closes #241

Related to the accepted Ugig sh1pt CLI command gig.