### PR TITLE
fix(cli): register affiliate adapter category

### DIFF
--- a/packages/cli/src/adapter-registry.ts
+++ b/packages/cli/src/adapter-registry.ts
@@ -16,6 +16,17 @@ export interface AdapterCategory {
 
 export const CATEGORIES: readonly AdapterCategory[] = [
   {
+    id: 'affiliates',
+    pkgPrefix: '@profullstack/sh1pt-affiliate',
+    description: 'Affiliate networks — CJ, Rakuten, ShareASale, Awin, Impact, Amazon Associates, ClickBank…',
+    adapters: [
+      'admitad', 'amazon-associates', 'avangate', 'awin', 'cj', 'clickbank',
+      'digistore24', 'ebay-partner', 'everflow', 'flexoffers', 'impact',
+      'jvzoo', 'partnerstack', 'rakuten', 'refersion', 'shareasale',
+      'skimlinks', 'sovrn', 'tapfiliate', 'tradedoubler',
+    ],
+  },
+  {
     id: 'agents',
     pkgPrefix: '@profullstack/sh1pt-agent',
     description: 'AI coding CLIs — Claude Code, Codex, Qwen',


### PR DESCRIPTION
## Summary
- register the existing `packages/affiliates/*` adapter family in the CLI adapter registry
- expose generic adapter commands such as `sh1pt affiliates list` and `sh1pt affiliates cj info`
- keep the higher-level `sh1pt promote affiliates` workflow unchanged

## Verification
- filesystem check: `packages/affiliates` has 20 adapter directories with `src/`, matching the registry list
- `npm run typecheck` (packages/cli)
- `npm run build` (packages/cli)

Closes #243

Related to the accepted Ugig sh1pt CLI/package PR gig.