### PR TITLE
fix(cli): sync ai adapter registry

### DIFF
--- a/packages/cli/src/adapter-registry.ts
+++ b/packages/cli/src/adapter-registry.ts
@@ -24,8 +24,20 @@ export const CATEGORIES: readonly AdapterCategory[] = [
   {
     id: 'ai',
     pkgPrefix: '@profullstack/sh1pt-ai',
-    description: 'AI API providers for content generation — Claude (Anthropic), OpenAI, Qwen, Gemini',
-    adapters: ['claude', 'gemini', 'openai', 'qwen'],
+    description: 'AI API providers for content generation — Claude (Anthropic), OpenAI, Qwen, Gemini, and BYOK providers',
+    adapters: [
+      'ai21', 'aionlabs', 'akashml', 'alibaba-cloud', 'amazon-bedrock',
+      'arcee', 'atlascloud', 'azure', 'baidu', 'baseten', 'cerebras',
+      'chutes', 'clarifai', 'claude', 'cloudflare', 'cohere', 'deepinfra',
+      'deepseek', 'featherless', 'fireworks', 'friendli', 'gemini',
+      'gmicloud', 'google-vertex', 'groq', 'inception', 'inceptron',
+      'infermatic', 'inflection', 'ionet', 'kimi', 'liquid', 'mancer',
+      'minimax', 'mistral', 'moonshot', 'morph', 'nebius', 'nextbit',
+      'novita', 'openai', 'openinference', 'parasail', 'perceptron',
+      'perplexity', 'phala', 'qwen', 'reka', 'relace', 'sambanova',
+      'siliconflow', 'stepfun', 'switchpoint', 'together', 'venice',
+      'wandb', 'xai', 'xiaomi', 'zai',
+    ],
   },
   {
     id: 'bots',


### PR DESCRIPTION
## Summary
- sync the CLI `ai` adapter registry with all existing `packages/ai/*` provider directories
- expose BYOK provider commands through the generic adapter surface, e.g. `sh1pt ai groq info` and `sh1pt ai mistral setup`
- update the category description to reflect the broader provider set

## Verification
- filesystem check: `packages/ai` has 59 provider directories and the registry now has 59 entries, with no missing or extra adapters
- `npm run typecheck` (packages/cli)
- `npm run build` (packages/cli)

Closes #245

Related to the accepted Ugig sh1pt CLI/package PR gig.