### PR TITLE
fix(cli): sync dns adapter registry

### DIFF
--- a/packages/cli/src/adapter-registry.ts
+++ b/packages/cli/src/adapter-registry.ts
@@ -60,8 +60,8 @@ export const CATEGORIES: readonly AdapterCategory[] = [
   {
     id: 'dns',
     pkgPrefix: '@profullstack/sh1pt-dns',
-    description: 'DNS providers — Porkbun, Cloudflare',
-    adapters: ['cloudflare', 'porkbun'],
+    description: 'DNS providers — Cloudflare, Porkbun, Route 53, Azure, Google, DigitalOcean, DNSimple, Namecheap',
+    adapters: ['azure', 'cloudflare', 'digitalocean', 'dnsimple', 'googledns', 'namecheap', 'porkbun', 'route53'],
   },
   {
     id: 'secrets',


### PR DESCRIPTION
## Summary
- sync the CLI `dns` adapter registry with all existing `packages/dns/*` provider directories
- expose generic adapter commands such as `sh1pt dns route53 info` and `sh1pt dns dnsimple setup`
- update the category description to include the broader provider set

## Verification
- filesystem check: `packages/dns` has 8 provider directories and the registry now has 8 entries, with no missing or extra adapters
- `npm run typecheck` (packages/cli)
- `npm run build` (packages/cli)

Closes #247

Related to the accepted Ugig sh1pt CLI/package PR gig.