### PR TITLE
fix(cli): register vu1nz agent adapter

### DIFF
--- a/packages/agents/vu1nz/package.json
+++ b/packages/agents/vu1nz/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sh1pt/agent-vu1nz",
+  "name": "@profullstack/sh1pt-agent-vu1nz",
   "version": "0.0.0",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/agents/vu1nz/src/index.test.ts
+++ b/packages/agents/vu1nz/src/index.test.ts
@@ -3,7 +3,7 @@ import { contractTestAgent } from "@profullstack/sh1pt-core/testing";
 
 import agent from "./index.js";
 
-describe("@sh1pt/agent-vu1nz", () => {
+describe("@profullstack/sh1pt-agent-vu1nz", () => {
   it("has required agent metadata", () => {
     expect(agent.id).toBe("agent-vu1nz");
     expect(agent.label).toBe("vu1nz Actions Security Scanner");

--- a/packages/cli/src/adapter-registry.ts
+++ b/packages/cli/src/adapter-registry.ts
@@ -19,7 +19,7 @@ export const CATEGORIES: readonly AdapterCategory[] = [
     id: 'agents',
     pkgPrefix: '@profullstack/sh1pt-agent',
     description: 'AI coding CLIs — Claude Code, Codex, Qwen',
-    adapters: ['claude', 'codex', 'qwen'],
+    adapters: ['claude', 'codex', 'qwen', 'vu1nz'],
   },
   {
     id: 'ai',


### PR DESCRIPTION
## Summary
- normalize the vu1nz agent package name to `@profullstack/sh1pt-agent-vu1nz`
- register `vu1nz` in the generic `agents` CLI adapter category
- update the focused package test label to match the package name

## Verification
- registry/filesystem check: `packages/agents` has 4 provider directories and the registry now has 4 entries, with no missing or extra adapters
- `npm run typecheck` (packages/agents/vu1nz)
- `npm run typecheck` (packages/cli)
- `npm run build` (packages/cli)
- `npx vitest run packages/agents/vu1nz/src/index.test.ts`

Closes #249

Related to the accepted Ugig sh1pt CLI/package PR gig.