### PR TITLE
fix(cli): expose deploy at root, mount agents at top level

### DIFF
--- a/packages/cli/src/commands/iterate.ts
+++ b/packages/cli/src/commands/iterate.ts
@@ -1,7 +1,8 @@
 import { Command } from 'commander';
 import kleur from 'kleur';
 import { describeInput, resolveInput } from '../input.js';
-import { agentsCmd } from './agents.js';
+
+// agentsCmd moved to root level — see https://github.com/profullstack/sh1pt/issues/235
 
 export const iterateCmd = new Command('iterate')
   .description('Observe metrics, have an agent propose changes, ship, measure. Powered by Claude / Codex / Qwen.')
@@ -18,10 +19,7 @@ export const iterateCmd = new Command('iterate')
     iterateCmd.help();
   });
 
-// AI-CLI orchestration lives under iterate (was top-level `sh1pt agents`).
-// sh1pt iterate agents [list|setup|talk|run|generate]
-iterateCmd.addCommand(agentsCmd);
-
+// AI-CLI agents moved to root level — see #235.
 iterateCmd
   .command('run')
   .description('Single-shot cycle: pull metrics → have agent propose changes → apply (with confirmation) → ship')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,6 +14,7 @@ import { makeCategoryCmd } from './commands/adapter-cmd.js';
 import { CATEGORIES } from './adapter-registry.js';
 import { skillsCmd } from './commands/skills.js';
 import { agentsCmd } from './commands/agents.js';
+import { deployCmd } from './commands/deploy.js';
 
 const program = new Command();
 
@@ -44,6 +45,7 @@ program.addCommand(secretsCmd);
 program.addCommand(configCmd);
 program.addCommand(skillsCmd);      // skills   · package/promote SKILL.md agent skills across marketplaces
 program.addCommand(agentsCmd);      // agents   · generate/run/talk with AI coding CLIs
+program.addCommand(deployCmd);      // deploy   · provision cloud infrastructure
 
 // Self-management — sh1pt update / upgrade / remove / uninstall.
 program.addCommand(updateCmd);


### PR DESCRIPTION
Closes #239, closes #235

Changes:
- Import and register deployCmd in CLI index (#239) — deploy.ts existed but was never wired
- Remove agentsCmd nesting under iterate — agents already at CLI root, double-registration caused Commander.js conflict (#235)
- Remove unused agentsCmd import from iterate.ts

Verification:
- All 26 existing CLI tests pass
- `pnpm vitest run packages/cli` ✓