### PR TITLE
Implement Cloudflare DNS adapter

### DIFF
--- a/packages/dns/cloudflare/src/index.test.ts
+++ b/packages/dns/cloudflare/src/index.test.ts
@@ -1,4 +1,192 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'dns' });
+
+function ok<T>(result: T, result_info?: unknown) {
+  return new Response(JSON.stringify({ success: true, result, result_info }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function connect() {
+  await adapter.connect({ secret: () => 'cf-token', log: () => {} }, {});
+}
+
+describe('Cloudflare DNS API adapter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('connect() asks for a vault token when credentials are missing', async () => {
+    await expect(adapter.connect({ secret: () => undefined, log: () => {} }, {})).rejects.toThrow(
+      'CLOUDFLARE_API_TOKEN',
+    );
+  });
+
+  it('lists zones through the Cloudflare zones endpoint', async () => {
+    await connect();
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(ok([
+      { id: 'zone-1', name: 'example.com' },
+      { id: 'zone-2', name: 'example.net' },
+    ], { page: 1, per_page: 100, total_pages: 1, total_count: 2 }));
+
+    await expect(adapter.listZones({})).resolves.toEqual([
+      { id: 'zone-1', name: 'example.com' },
+      { id: 'zone-2', name: 'example.net' },
+    ]);
+    expect(String(fetchMock.mock.calls[0]![0])).toContain('/zones?page=1&per_page=100');
+    expect(fetchMock.mock.calls[0]![1]?.headers).toMatchObject({
+      Authorization: 'Bearer cf-token',
+    });
+  });
+
+  it('creates a DNS record when no matching name/type exists', async () => {
+    await connect();
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(ok([], { page: 1, per_page: 100, total_pages: 1, total_count: 0 }))
+      .mockResolvedValueOnce(ok({
+        id: 'record-1',
+        zone_id: 'zone-1',
+        name: 'api.example.com',
+        type: 'A',
+        content: '203.0.113.10',
+        ttl: 120,
+        proxied: true,
+      }));
+
+    await expect(adapter.upsertRecord('zone-1', {
+      zone: 'zone-1',
+      name: 'api.example.com',
+      type: 'A',
+      value: '203.0.113.10',
+      ttl: 120,
+      proxied: true,
+    }, {})).resolves.toMatchObject({
+      id: 'record-1',
+      name: 'api.example.com',
+      value: '203.0.113.10',
+      ttl: 120,
+      proxied: true,
+    });
+
+    expect(fetchMock.mock.calls[1]![1]?.method).toBe('POST');
+    expect(JSON.parse(String(fetchMock.mock.calls[1]![1]?.body))).toEqual({
+      type: 'A',
+      name: 'api.example.com',
+      content: '203.0.113.10',
+      ttl: 120,
+      proxied: true,
+    });
+  });
+
+  it('updates a DNS record when name/type already exists', async () => {
+    await connect();
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(ok([
+        {
+          id: 'record-1',
+          zone_id: 'zone-1',
+          name: 'api.example.com',
+          type: 'A',
+          content: '203.0.113.9',
+          ttl: 120,
+          proxied: false,
+        },
+      ], { page: 1, per_page: 100, total_pages: 1, total_count: 1 }))
+      .mockResolvedValueOnce(ok({
+        id: 'record-1',
+        zone_id: 'zone-1',
+        name: 'api.example.com',
+        type: 'A',
+        content: '203.0.113.10',
+        ttl: 60,
+        proxied: false,
+      }));
+
+    const updated = await adapter.upsertRecord('zone-1', {
+      zone: 'zone-1',
+      name: 'api.example.com',
+      type: 'A',
+      value: '203.0.113.10',
+      ttl: 60,
+    }, {});
+
+    expect(updated.value).toBe('203.0.113.10');
+    expect(fetchMock.mock.calls[1]![0]).toBe(`${'https://api.cloudflare.com/client/v4'}/zones/zone-1/dns_records/record-1`);
+    expect(fetchMock.mock.calls[1]![1]?.method).toBe('PUT');
+  });
+
+  it('syncs round-robin A records by updating kept records, creating missing IPs, and deleting extras', async () => {
+    await connect();
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(ok([
+        {
+          id: 'keep',
+          zone_id: 'zone-1',
+          name: 'api.example.com',
+          type: 'A',
+          content: '203.0.113.10',
+          ttl: 120,
+          proxied: false,
+        },
+        {
+          id: 'duplicate',
+          zone_id: 'zone-1',
+          name: 'api.example.com',
+          type: 'A',
+          content: '203.0.113.10',
+          ttl: 120,
+          proxied: false,
+        },
+        {
+          id: 'extra',
+          zone_id: 'zone-1',
+          name: 'api.example.com',
+          type: 'A',
+          content: '203.0.113.99',
+          ttl: 120,
+          proxied: false,
+        },
+      ], { page: 1, per_page: 100, total_pages: 1, total_count: 3 }))
+      .mockResolvedValueOnce(ok({ id: 'duplicate' }))
+      .mockResolvedValueOnce(ok({ id: 'extra' }))
+      .mockResolvedValueOnce(ok({
+        id: 'keep',
+        zone_id: 'zone-1',
+        name: 'api.example.com',
+        type: 'A',
+        content: '203.0.113.10',
+        ttl: 60,
+        proxied: true,
+      }))
+      .mockResolvedValueOnce(ok({
+        id: 'created',
+        zone_id: 'zone-1',
+        name: 'api.example.com',
+        type: 'A',
+        content: '203.0.113.11',
+        ttl: 60,
+        proxied: true,
+      }));
+
+    const records = await adapter.syncRoundRobin({
+      zoneId: 'zone-1',
+      name: 'api.example.com',
+      ips: ['203.0.113.10', '203.0.113.11'],
+      ttl: 60,
+      proxied: true,
+    }, {});
+
+    expect(records.map((record) => record.value)).toEqual(['203.0.113.10', '203.0.113.11']);
+    expect(fetchMock.mock.calls.map(([url, init]) => [String(url), init?.method ?? 'GET'])).toEqual([
+      ['https://api.cloudflare.com/client/v4/zones/zone-1/dns_records?page=1&per_page=100', 'GET'],
+      ['https://api.cloudflare.com/client/v4/zones/zone-1/dns_records/duplicate', 'DELETE'],
+      ['https://api.cloudflare.com/client/v4/zones/zone-1/dns_records/extra', 'DELETE'],
+      ['https://api.cloudflare.com/client/v4/zones/zone-1/dns_records/keep', 'PUT'],
+      ['https://api.cloudflare.com/client/v4/zones/zone-1/dns_records', 'POST'],
+    ]);
+  });
+});

--- a/packages/dns/cloudflare/src/index.ts
+++ b/packages/dns/cloudflare/src/index.ts
@@ -12,51 +12,226 @@ interface Config {
 }
 
 const API = 'https://api.cloudflare.com/client/v4';
+let _secret: (k: string) => string | undefined = () => undefined;
+
+interface CloudflareEnvelope<T> {
+  success: boolean;
+  errors?: { message?: string; code?: number }[];
+  result: T;
+  result_info?: {
+    page: number;
+    per_page: number;
+    total_pages: number;
+    total_count: number;
+  };
+}
+
+interface CloudflareZone {
+  id: string;
+  name: string;
+}
+
+interface CloudflareDnsRecord {
+  id: string;
+  zone_id?: string;
+  zone_name?: string;
+  name: string;
+  type: string;
+  content: string;
+  ttl: number;
+  proxied?: boolean;
+}
+
+function authHeaders() {
+  return {
+    Authorization: `Bearer ${_secret('CLOUDFLARE_API_TOKEN')}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+function errorMessage(prefix: string, status: number, body: string) {
+  try {
+    const parsed = JSON.parse(body) as { errors?: { message?: string; code?: number }[] };
+    const details = parsed.errors?.map((e) => e.message ?? e.code).filter(Boolean).join('; ');
+    return details ? `${prefix}: ${status} ${details}` : `${prefix}: ${status}`;
+  } catch {
+    return `${prefix}: ${status}${body ? ` ${body.slice(0, 160)}` : ''}`;
+  }
+}
+
+async function cfRequest<T>(path: string, init: RequestInit = {}, prefix = 'Cloudflare DNS') {
+  const res = await fetch(`${API}${path}`, {
+    ...init,
+    headers: {
+      ...authHeaders(),
+      ...(init.headers ?? {}),
+    },
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(errorMessage(prefix, res.status, text));
+  const json = JSON.parse(text) as CloudflareEnvelope<T>;
+  if (!json.success) {
+    const details = json.errors?.map((e) => e.message ?? e.code).filter(Boolean).join('; ');
+    throw new Error(details ? `${prefix}: ${details}` : `${prefix}: request failed`);
+  }
+  return json;
+}
+
+async function cfListAll<T>(path: string, prefix: string) {
+  const items: T[] = [];
+  let page = 1;
+  let totalPages = 1;
+
+  do {
+    const separator = path.includes('?') ? '&' : '?';
+    const json = await cfRequest<T[]>(`${path}${separator}page=${page}&per_page=100`, {}, prefix);
+    items.push(...json.result);
+    totalPages = json.result_info?.total_pages ?? 1;
+    page += 1;
+  } while (page <= totalPages);
+
+  return items;
+}
+
+function supportsProxied(type: string) {
+  return type === 'A' || type === 'AAAA' || type === 'CNAME';
+}
+
+function toDnsRecord(zoneId: string, record: CloudflareDnsRecord): DnsRecord {
+  return {
+    id: record.id,
+    zone: record.zone_id ?? zoneId,
+    name: record.name,
+    type: record.type as DnsRecord['type'],
+    value: record.content,
+    ttl: record.ttl,
+    ...(record.proxied === undefined ? {} : { proxied: record.proxied }),
+  };
+}
+
+function recordPayload(record: Omit<DnsRecord, 'id'>, config: Config) {
+  const ttl = record.ttl ?? config.defaultTtl ?? 1;
+  const proxied = record.proxied ?? config.defaultProxied;
+  return {
+    type: record.type,
+    name: record.name,
+    content: record.value,
+    ttl,
+    ...(proxied === undefined || !supportsProxied(record.type) ? {} : { proxied }),
+  };
+}
 
 export default defineDns<Config>({
   id: 'dns-cloudflare',
   label: 'Cloudflare DNS',
 
   async connect(ctx) {
+    _secret = (k) => ctx.secret(k);
     if (!ctx.secret('CLOUDFLARE_API_TOKEN')) throw new Error('CLOUDFLARE_API_TOKEN not set');
     return { accountId: 'cloudflare' };
   },
 
   async listZones() {
-    // TODO: GET ${API}/zones → { result: [{ id, name }] }
-    return [];
+    const zones = await cfListAll<CloudflareZone>('/zones', 'Cloudflare listZones');
+    return zones.map((zone) => ({ id: zone.id, name: zone.name }));
   },
 
   async listRecords(zoneId) {
-    // TODO: GET ${API}/zones/${zoneId}/dns_records
-    return [];
+    const records = await cfListAll<CloudflareDnsRecord>(
+      `/zones/${zoneId}/dns_records`,
+      'Cloudflare listRecords',
+    );
+    return records.map((record) => toDnsRecord(zoneId, record));
   },
 
   async upsertRecord(zoneId, record, config) {
-    // TODO: POST ${API}/zones/${zoneId}/dns_records (or PUT /:recordId for update)
-    const proxied = record.proxied ?? config.defaultProxied ?? false;
-    return { id: 'stub', ...record, zone: zoneId, proxied };
+    const existing = (await this.listRecords(zoneId, config)).find(
+      (candidate) => candidate.name === record.name && candidate.type === record.type,
+    );
+    const payload = recordPayload(record, config);
+
+    if (existing) {
+      const { result } = await cfRequest<CloudflareDnsRecord>(
+        `/zones/${zoneId}/dns_records/${existing.id}`,
+        { method: 'PUT', body: JSON.stringify(payload) },
+        'Cloudflare upsertRecord (update)',
+      );
+      return toDnsRecord(zoneId, result);
+    }
+
+    const { result } = await cfRequest<CloudflareDnsRecord>(
+      `/zones/${zoneId}/dns_records`,
+      { method: 'POST', body: JSON.stringify(payload) },
+      'Cloudflare upsertRecord (create)',
+    );
+    return toDnsRecord(zoneId, result);
   },
 
   async deleteRecord(zoneId, recordId) {
-    // TODO: DELETE ${API}/zones/${zoneId}/dns_records/${recordId}
+    const res = await fetch(`${API}/zones/${zoneId}/dns_records/${recordId}`, {
+      method: 'DELETE',
+      headers: authHeaders(),
+    });
+    if (!res.ok && res.status !== 404) {
+      const text = await res.text();
+      throw new Error(errorMessage('Cloudflare deleteRecord', res.status, text));
+    }
   },
 
   async syncRoundRobin({ zoneId, name, ips, ttl, proxied }, config) {
     const ttlFinal = ttl ?? config.defaultTtl ?? 60;
     const proxiedFinal = proxied ?? config.defaultProxied ?? false;
-    // TODO: listRecords() → diff → create missing, delete extras, leave matching.
-    // Orange-cloud mode (proxied=true) makes CF the A record publicly; use only
-    // when backends are sh1pt-deployed VPSes with CF-issued origin certs.
-    return ips.map((ip, i) => ({
-      id: `cf-stub-${i}`,
-      zone: zoneId,
-      name,
-      type: 'A' as const,
-      value: ip,
-      ttl: ttlFinal,
-      proxied: proxiedFinal,
-    })) satisfies DnsRecord[];
+    const desired = [...new Set(ips)];
+    const existing = (await this.listRecords(zoneId, config)).filter(
+      (record) => record.name === name && record.type === 'A',
+    );
+    const kept = new Map<string, DnsRecord>();
+    const extraIds: string[] = [];
+
+    for (const record of existing) {
+      if (desired.includes(record.value) && !kept.has(record.value)) {
+        kept.set(record.value, record);
+      } else {
+        extraIds.push(record.id);
+      }
+    }
+
+    await Promise.all(extraIds.map((recordId) => this.deleteRecord(zoneId, recordId, config)));
+
+    const synced: DnsRecord[] = [];
+    for (const ip of desired) {
+      const current = kept.get(ip);
+      if (current && current.ttl === ttlFinal && current.proxied === proxiedFinal) {
+        synced.push(current);
+        continue;
+      }
+
+      const payload = {
+        type: 'A',
+        name,
+        content: ip,
+        ttl: ttlFinal,
+        proxied: proxiedFinal,
+      };
+
+      if (current) {
+        const { result } = await cfRequest<CloudflareDnsRecord>(
+          `/zones/${zoneId}/dns_records/${current.id}`,
+          { method: 'PUT', body: JSON.stringify(payload) },
+          'Cloudflare syncRoundRobin (update)',
+        );
+        synced.push(toDnsRecord(zoneId, result));
+      } else {
+        const { result } = await cfRequest<CloudflareDnsRecord>(
+          `/zones/${zoneId}/dns_records`,
+          { method: 'POST', body: JSON.stringify(payload) },
+          'Cloudflare syncRoundRobin (create)',
+        );
+        synced.push(toDnsRecord(zoneId, result));
+      }
+    }
+
+    return synced;
   },
 
   setup: tokenSetup<Config>({


### PR DESCRIPTION
## Summary
- Replace the Cloudflare DNS TODO stub with live Cloudflare API v4 calls for zone listing, record listing, record create/update/delete, and response/error mapping.
- Implement `syncRoundRobin` by diffing current A records, deleting duplicates/extras, updating kept records when TTL/proxy settings change, and creating missing IP records.
- Add focused mocked tests for auth hints, zone listing, create/update upsert behavior, and round-robin syncing.

## Verification
- `npx --yes pnpm@9.12.0 vitest run packages/dns/cloudflare/src/index.test.ts`
- `npx --yes pnpm@9.12.0 --filter @profullstack/sh1pt-dns-cloudflare typecheck`
- `npx --yes pnpm@9.12.0 --filter @profullstack/sh1pt-dns-cloudflare build`
- `git diff --check`

Related to #6; Cloudflare DNS was called out as one of the needed DNS providers.