### PR TITLE
Implement Porkbun DNS adapter

### DIFF
--- a/packages/dns/porkbun/src/index.test.ts
+++ b/packages/dns/porkbun/src/index.test.ts
@@ -1,7 +1,164 @@
-import { contractTestDns } from '@profullstack/sh1pt-core/testing';
+import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import dns from './index.js';
 
-contractTestDns(dns, {
-  sampleConfig: {},
-  requiredSecrets: ['PORKBUN_API_KEY', 'PORKBUN_API_SECRET'],
+smokeTest(dns, { idPrefix: 'dns' });
+
+function ok(body: Record<string, unknown>) {
+  return new Response(JSON.stringify({ status: 'SUCCESS', ...body }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const ctx = (secrets: Record<string, string> = {
+  PORKBUN_API_KEY: 'pk-test',
+  PORKBUN_API_SECRET: 'sk-test',
+}) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+});
+
+function request(index: number, fetchMock: any) {
+  const [url, init] = fetchMock.mock.calls[index] as [string, RequestInit];
+  return { url, init, body: JSON.parse(String(init.body ?? '{}')) as Record<string, unknown> };
+}
+
+describe('Porkbun DNS API adapter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('requires Porkbun credentials on connect', async () => {
+    await expect(dns.connect(ctx({}) as any, {})).rejects.toThrow(/PORKBUN_API_KEY/);
+  });
+
+  it('lists records through the Porkbun retrieve endpoint', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(ok({
+      records: [
+        { id: '1', name: 'api.example.com', type: 'A', content: '203.0.113.10', ttl: '600' },
+        { id: '2', name: 'example.com', type: 'NS', content: 'ns1.example.com', ttl: '600' },
+      ],
+    }));
+
+    await dns.connect(ctx() as any, {});
+    await expect(dns.listRecords('example.com', {})).resolves.toEqual([
+      { id: '1', zone: 'example.com', name: 'api.example.com', type: 'A', value: '203.0.113.10', ttl: 600 },
+    ]);
+    expect(request(0, fetchMock).url).toBe('https://api.porkbun.com/api/json/v3/dns/retrieve/example.com');
+    expect(request(0, fetchMock).body).toMatchObject({
+      apikey: 'pk-test',
+      secretapikey: 'sk-test',
+    });
+  });
+
+  it('creates a DNS record when no matching name/type exists', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(ok({ records: [] }))
+      .mockResolvedValueOnce(ok({ id: 42 }));
+
+    await dns.connect(ctx() as any, {});
+    await expect(dns.upsertRecord('example.com', {
+      zone: 'example.com',
+      name: 'api.example.com',
+      type: 'A',
+      value: '203.0.113.10',
+      ttl: 120,
+    }, {})).resolves.toMatchObject({
+      id: '42',
+      name: 'api.example.com',
+      type: 'A',
+      value: '203.0.113.10',
+      ttl: 120,
+    });
+
+    expect(request(1, fetchMock).url).toBe('https://api.porkbun.com/api/json/v3/dns/create/example.com');
+    expect(request(1, fetchMock).body).toMatchObject({
+      name: 'api',
+      type: 'A',
+      content: '203.0.113.10',
+      ttl: 120,
+    });
+  });
+
+  it('edits a DNS record when a matching name/type exists', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(ok({
+        records: [
+          { id: 'record-1', name: 'api.example.com', type: 'A', content: '203.0.113.9', ttl: '600' },
+        ],
+      }))
+      .mockResolvedValueOnce(ok({}));
+
+    await dns.connect(ctx() as any, {});
+    const updated = await dns.upsertRecord('example.com', {
+      zone: 'example.com',
+      name: 'api.example.com',
+      type: 'A',
+      value: '203.0.113.10',
+      ttl: 300,
+    }, {});
+
+    expect(updated.id).toBe('record-1');
+    expect(request(1, fetchMock).url).toBe('https://api.porkbun.com/api/json/v3/dns/edit/example.com/record-1');
+    expect(request(1, fetchMock).body).toMatchObject({
+      name: 'api',
+      type: 'A',
+      content: '203.0.113.10',
+      ttl: 300,
+    });
+  });
+
+  it('deletes records by provider id', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(ok({}));
+
+    await dns.connect(ctx() as any, {});
+    await dns.deleteRecord('example.com', 'record-1', {});
+
+    expect(request(0, fetchMock).url).toBe('https://api.porkbun.com/api/json/v3/dns/delete/example.com/record-1');
+  });
+
+  it('syncs round-robin A records by deleting extras, editing TTLs, and creating missing IPs', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(ok({
+        records: [
+          { id: 'keep', name: 'api.example.com', type: 'A', content: '203.0.113.10', ttl: '600' },
+          { id: 'duplicate', name: 'api.example.com', type: 'A', content: '203.0.113.10', ttl: '600' },
+          { id: 'extra', name: 'api.example.com', type: 'A', content: '203.0.113.99', ttl: '600' },
+        ],
+      }))
+      .mockResolvedValueOnce(ok({}))
+      .mockResolvedValueOnce(ok({}))
+      .mockResolvedValueOnce(ok({}))
+      .mockResolvedValueOnce(ok({ id: 77 }));
+
+    await dns.connect(ctx() as any, {});
+    const records = await dns.syncRoundRobin({
+      zoneId: 'example.com',
+      name: 'api.example.com',
+      ips: ['203.0.113.10', '203.0.113.10', '203.0.113.11'],
+      ttl: 120,
+    }, {});
+
+    expect(records.map(record => record.value)).toEqual(['203.0.113.10', '203.0.113.11']);
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://api.porkbun.com/api/json/v3/dns/retrieve/example.com',
+      'https://api.porkbun.com/api/json/v3/dns/delete/example.com/duplicate',
+      'https://api.porkbun.com/api/json/v3/dns/delete/example.com/extra',
+      'https://api.porkbun.com/api/json/v3/dns/edit/example.com/keep',
+      'https://api.porkbun.com/api/json/v3/dns/create/example.com',
+    ]);
+    expect(request(3, fetchMock).body).toMatchObject({ name: 'api', content: '203.0.113.10', ttl: 120 });
+    expect(request(4, fetchMock).body).toMatchObject({ name: 'api', content: '203.0.113.11', ttl: 120 });
+  });
+
+  it('surfaces Porkbun API errors', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(
+      JSON.stringify({ status: 'ERROR', message: 'bad key' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ));
+
+    await dns.connect(ctx() as any, {});
+    await expect(dns.listRecords('example.com', {})).rejects.toThrow(/bad key/);
+  });
 });

--- a/packages/dns/porkbun/src/index.ts
+++ b/packages/dns/porkbun/src/index.ts
@@ -13,12 +13,91 @@ interface Config {
 }
 
 const API = 'https://api.porkbun.com/api/json/v3';
+let _secret: (k: string) => string | undefined = () => undefined;
+
+interface PorkbunRecord {
+  id: string | number;
+  name: string;
+  type: string;
+  content: string;
+  ttl: string | number;
+  prio?: string | number;
+}
+
+interface PorkbunResponse {
+  status: string;
+  message?: string;
+  id?: string | number;
+  records?: PorkbunRecord[];
+}
+
+function credentials() {
+  const apikey = _secret('PORKBUN_API_KEY');
+  const secretapikey = _secret('PORKBUN_API_SECRET');
+  if (!apikey || !secretapikey) {
+    throw new Error('PORKBUN_API_KEY / PORKBUN_API_SECRET not set');
+  }
+  return { apikey, secretapikey };
+}
+
+function supportedType(type: string): type is DnsRecord['type'] {
+  return type === 'A' || type === 'AAAA' || type === 'CNAME' || type === 'TXT' || type === 'MX';
+}
+
+function relativeName(zoneId: string, name: string): string {
+  if (name === zoneId || name === '@' || name === '') return '';
+  return name.endsWith(`.${zoneId}`) ? name.slice(0, -(zoneId.length + 1)) : name;
+}
+
+function nameMatches(zoneId: string, actual: string, requested: string): boolean {
+  if (actual === requested) return true;
+  if (requested === '@' || requested === '') return actual === zoneId;
+  return actual === `${requested}.${zoneId}`;
+}
+
+function toDnsRecord(zoneId: string, record: PorkbunRecord): DnsRecord | undefined {
+  if (!supportedType(record.type)) return undefined;
+  return {
+    id: String(record.id),
+    zone: zoneId,
+    name: record.name,
+    type: record.type,
+    value: record.content,
+    ttl: Number(record.ttl),
+  };
+}
+
+function recordBody(zoneId: string, record: Omit<DnsRecord, 'id'>, ttl: number) {
+  return {
+    name: relativeName(zoneId, record.name),
+    type: record.type,
+    content: record.value,
+    ttl,
+  };
+}
+
+async function porkbunRequest(path: string, body: Record<string, unknown> = {}, operation = 'Porkbun request'): Promise<PorkbunResponse> {
+  const res = await fetch(`${API}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ...credentials(), ...body }),
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`${operation}: ${res.status}${text ? ` ${text.slice(0, 200)}` : ''}`);
+
+  const json = JSON.parse(text) as PorkbunResponse;
+  if (json.status !== 'SUCCESS') {
+    throw new Error(`${operation}: ${json.message ?? json.status}`);
+  }
+  return json;
+}
 
 export default defineDns<Config>({
   id: 'dns-porkbun',
   label: 'Porkbun DNS',
 
   async connect(ctx) {
+    _secret = (k) => ctx.secret(k);
     if (!ctx.secret('PORKBUN_API_KEY') || !ctx.secret('PORKBUN_API_SECRET')) {
       throw new Error('PORKBUN_API_KEY / PORKBUN_API_SECRET not set — run `sh1pt secret set PORKBUN_API_KEY ...`');
     }
@@ -33,35 +112,102 @@ export default defineDns<Config>({
   },
 
   async listRecords(zoneId) {
-    // TODO: POST ${API}/dns/retrieve/${zoneId} with { apikey, secretapikey }
-    // Map response.records to DnsRecord[]
-    return [];
+    const { records = [] } = await porkbunRequest(
+      `/dns/retrieve/${encodeURIComponent(zoneId)}`,
+      {},
+      'Porkbun listRecords',
+    );
+    return records
+      .map(record => toDnsRecord(zoneId, record))
+      .filter((record): record is DnsRecord => Boolean(record));
   },
 
-  async upsertRecord(zoneId, record) {
-    // TODO: check existing via retrieve, then create or edit as appropriate.
-    // POST ${API}/dns/create/${zoneId} with { apikey, secretapikey, name, type, content, ttl, prio? }
-    return { id: 'stub', ...record, zone: zoneId };
+  async upsertRecord(zoneId, record, config) {
+    const ttl = record.ttl ?? config.defaultTtl ?? 600;
+    const existing = (await this.listRecords(zoneId, config)).find(
+      current => nameMatches(zoneId, current.name, record.name) && current.type === record.type,
+    );
+
+    if (existing) {
+      await porkbunRequest(
+        `/dns/edit/${encodeURIComponent(zoneId)}/${encodeURIComponent(existing.id)}`,
+        recordBody(zoneId, record, ttl),
+        'Porkbun upsertRecord (edit)',
+      );
+      return { ...record, id: existing.id, zone: zoneId, ttl };
+    }
+
+    const created = await porkbunRequest(
+      `/dns/create/${encodeURIComponent(zoneId)}`,
+      recordBody(zoneId, record, ttl),
+      'Porkbun upsertRecord (create)',
+    );
+    return { ...record, id: String(created.id), zone: zoneId, ttl };
   },
 
   async deleteRecord(zoneId, recordId) {
-    // TODO: POST ${API}/dns/delete/${zoneId}/${recordId}
+    await porkbunRequest(
+      `/dns/delete/${encodeURIComponent(zoneId)}/${encodeURIComponent(recordId)}`,
+      {},
+      'Porkbun deleteRecord',
+    );
   },
 
-  async syncRoundRobin({ zoneId, name, ips, ttl }) {
-    // Diff current A records at <name> vs desired `ips`. Create missing,
-    // delete extras, leave matching untouched. Porkbun doesn't weight A
-    // records; clients round-robin by DNS resolver behaviour.
-    // TODO: real diff against listRecords()
-    const ttlFinal = ttl ?? 600;
-    return ips.map((ip, i) => ({
-      id: `stub-${i}`,
-      zone: zoneId,
-      name,
-      type: 'A' as const,
-      value: ip,
-      ttl: ttlFinal,
-    })) satisfies DnsRecord[];
+  async syncRoundRobin({ zoneId, name, ips, ttl }, config) {
+    const ttlFinal = ttl ?? config.defaultTtl ?? 600;
+    const desiredIps = [...new Set(ips)];
+    const existing = (await this.listRecords(zoneId, config)).filter(
+      record => record.type === 'A' && nameMatches(zoneId, record.name, name),
+    );
+    const resultByIp = new Map<string, DnsRecord>();
+    const keepByIp = new Map<string, DnsRecord>();
+
+    for (const record of existing) {
+      if (desiredIps.includes(record.value) && !keepByIp.has(record.value)) {
+        keepByIp.set(record.value, record);
+        continue;
+      }
+      await this.deleteRecord(zoneId, record.id, config);
+    }
+
+    for (const ip of desiredIps) {
+      const kept = keepByIp.get(ip);
+      if (!kept) {
+        const record = {
+          zone: zoneId,
+          name,
+          type: 'A',
+          value: ip,
+          ttl: ttlFinal,
+        } satisfies Omit<DnsRecord, 'id'>;
+        const created = await porkbunRequest(
+          `/dns/create/${encodeURIComponent(zoneId)}`,
+          recordBody(zoneId, record, ttlFinal),
+          'Porkbun syncRoundRobin (create)',
+        );
+        resultByIp.set(ip, { ...record, id: String(created.id) });
+        continue;
+      }
+
+      if (kept.ttl !== ttlFinal) {
+        await porkbunRequest(
+          `/dns/edit/${encodeURIComponent(zoneId)}/${encodeURIComponent(kept.id)}`,
+          recordBody(zoneId, {
+            zone: zoneId,
+            name,
+            type: 'A',
+            value: ip,
+            ttl: ttlFinal,
+          }, ttlFinal),
+          'Porkbun syncRoundRobin (edit)',
+        );
+        resultByIp.set(ip, { ...kept, name, ttl: ttlFinal });
+      } else {
+        resultByIp.set(ip, kept);
+      }
+    }
+
+    return desiredIps.map(ip => resultByIp.get(ip)!);
   },
 
   setup: tokenSetup<Config>({


### PR DESCRIPTION
## Summary
- Replace the Porkbun DNS placeholder with real v3 API calls for record retrieve, create, edit, and delete.
- Normalize Porkbun record responses into `DnsRecord` shape and support relative or fully qualified names for upserts.
- Implement round-robin A record syncing by deduping desired IPs, deleting duplicate/extra records, editing TTL changes, and creating missing IP records.

## Verification
- `npx --yes pnpm@9.12.0 vitest run packages/dns/porkbun/src/index.test.ts`
- `npx --yes pnpm@9.12.0 --filter @profullstack/sh1pt-dns-porkbun typecheck`
- `npx --yes pnpm@9.12.0 --filter @profullstack/sh1pt-dns-porkbun build`
- `git diff --check`

Related to #6; Porkbun DNS was still stubbed and had no open PR.