### PR TITLE
Implement Tapfiliate affiliate adapter

### DIFF
--- a/packages/affiliates/tapfiliate/src/index.test.ts
+++ b/packages/affiliates/tapfiliate/src/index.test.ts
@@ -1,4 +1,142 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'affiliate' });
+
+const ctx = (secrets: Record<string, string> = { TAPFILIATE_API_KEY: 'tap-key' }) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+});
+
+function response(body: unknown, status = 200) {
+  return new Response(typeof body === 'string' ? body : JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('Tapfiliate affiliate adapter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('requires an API key on connect', async () => {
+    await expect(adapter.connect(ctx({}), {})).rejects.toThrow(/TAPFILIATE_API_KEY/);
+  });
+
+  it('resolves a configured Tapfiliate program', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(response({
+      id: 'johns-affiliate-program',
+      title: "John's affiliate program",
+      currency: 'USD',
+      default_landing_page_url: 'https://example.com/product',
+    }));
+
+    const result = await adapter.createProgram!(ctx(), {
+      name: "John's affiliate program",
+      destinationUrl: 'https://example.com/product',
+      commissionType: 'percentage',
+      commissionRate: 20,
+    }, { programId: 'johns-affiliate-program' });
+
+    expect(result).toEqual({
+      programId: 'johns-affiliate-program',
+      marketplaceUrl: 'https://example.com/product',
+    });
+    expect(fetchMock).toHaveBeenCalledWith('https://api.tapfiliate.com/1.6/programs/johns-affiliate-program/', {
+      headers: {
+        'content-type': 'application/json',
+        'X-Api-Key': 'tap-key',
+      },
+    });
+  });
+
+  it('finds an existing program by landing page when no program id is configured', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(response([
+      {
+        id: 'existing-program',
+        title: 'Existing Program',
+        currency: 'USD',
+        default_landing_page_url: 'https://example.com/product',
+      },
+    ]));
+
+    const result = await adapter.createProgram!(ctx(), {
+      name: 'Different UI Name',
+      destinationUrl: 'https://example.com/product',
+      commissionType: 'flat',
+      commissionRate: 5,
+      currency: 'USD',
+    }, {});
+
+    expect(result.programId).toBe('existing-program');
+  });
+
+  it('returns a referral link for a configured affiliate', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(response({
+      id: 'janejameson',
+      referral_link: {
+        link: 'https://example.com/product?ref=nwjinmy',
+        asset_id: '1-aaaaaa',
+      },
+    }));
+
+    const link = await adapter.getTrackingLink!(
+      ctx(),
+      'johns-affiliate-program',
+      'https://example.com/product',
+      { affiliateId: 'janejameson' },
+    );
+
+    expect(link.url).toBe('https://example.com/product?ref=nwjinmy');
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      'https://api.tapfiliate.com/1.6/programs/johns-affiliate-program/affiliates/janejameson/',
+    );
+  });
+
+  it('aggregates publishers, clicks, conversions, revenue, and paid commissions', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(response({ id: 'program-1', currency: 'USD' }))
+      .mockResolvedValueOnce(response([
+        { id: 'approved', approved: true },
+        { id: 'pending', approved: null },
+        { id: 'rejected', approved: false },
+      ]))
+      .mockResolvedValueOnce(response([
+        {
+          amount: 100,
+          program: { id: 'program-1', currency: 'USD' },
+          commissions: [
+            { amount: 10, payout: { id: 'pay-1' } },
+            { amount: 5, payout: null },
+          ],
+        },
+        { amount: 50, commissions: [{ amount: 8, payout: { id: 'pay-2' } }] },
+      ]))
+      .mockResolvedValueOnce(response([{ id: 'click-1' }, { id: 'click-2' }]));
+
+    await expect(adapter.stats!(ctx(), 'program-1', {})).resolves.toEqual({
+      publishers: 2,
+      clicks: 2,
+      conversions: 2,
+      revenue: 150,
+      commissionsPaid: 18,
+      currency: 'USD',
+    });
+  });
+
+  it('treats unavailable enterprise click stats as zero while keeping other stats', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(response({ id: 'program-1', currency: 'EUR' }))
+      .mockResolvedValueOnce(response([{ id: 'approved', approved: true }]))
+      .mockResolvedValueOnce(response([{ amount: 25, commissions: [] }]))
+      .mockResolvedValueOnce(response('enterprise only', 403));
+
+    await expect(adapter.stats!(ctx(), 'program-1', {})).resolves.toMatchObject({
+      clicks: 0,
+      revenue: 25,
+      currency: 'EUR',
+    });
+  });
+});

--- a/packages/affiliates/tapfiliate/src/index.ts
+++ b/packages/affiliates/tapfiliate/src/index.ts
@@ -1,46 +1,227 @@
-import { defineAffiliate, tokenSetup } from '@profullstack/sh1pt-core';
+import {
+  defineAffiliate,
+  tokenSetup,
+  type AffiliateConnectContext,
+  type AffiliateProgram,
+} from '@profullstack/sh1pt-core';
 
 interface Config {
   accountId?: string;
+  baseUrl?: string;
+  programId?: string;
+  assetId?: string;
+  affiliateId?: string;
+  affiliateEmail?: string;
+  sourceId?: string;
+}
+
+const DEFAULT_BASE_URL = 'https://api.tapfiliate.com/1.6';
+
+interface TapfiliateProgram {
+  id: string;
+  title?: string;
+  currency?: string;
+  default_landing_page_url?: string;
+}
+
+interface TapfiliateAffiliate {
+  id: string;
+  email?: string;
+  approved?: boolean | null;
+  referral_link?: {
+    link?: string;
+    asset_id?: string;
+    source_id?: string | null;
+  };
+}
+
+interface TapfiliateCommission {
+  amount?: number;
+  currency?: string;
+  payout?: unknown;
+}
+
+interface TapfiliateConversion {
+  amount?: number;
+  program?: {
+    id?: string;
+    currency?: string;
+  };
+  commissions?: TapfiliateCommission[];
 }
 
 export default defineAffiliate<Config>({
-  id: "affiliate-tapfiliate",
-  label: "Tapfiliate",
-  side: "merchant",
+  id: 'affiliate-tapfiliate',
+  label: 'Tapfiliate',
+  side: 'merchant',
 
   async connect(ctx, config) {
-    const token = ctx.secret("TAPFILIATE_API_KEY");
-    if (!token) throw new Error("TAPFILIATE_API_KEY not in vault — run `sh1pt promote affiliates setup`");
-    return { accountId: config.accountId ?? "affiliate-tapfiliate" };
+    const token = ctx.secret('TAPFILIATE_API_KEY');
+    if (!token) throw new Error('TAPFILIATE_API_KEY not in vault - run `sh1pt promote affiliates setup`');
+    return { accountId: config.accountId ?? 'affiliate-tapfiliate' };
   },
 
-  async createProgram(ctx, program) {
-    ctx.log(`[stub] ${"affiliate-tapfiliate"} createProgram name=${program.name} commission=${program.commissionRate}${program.commissionType === 'percentage' ? '%' : ''}`);
+  async createProgram(ctx, program, config) {
+    ctx.log(`tapfiliate - resolve program ${program.name}`);
+    const tapProgram = await resolveProgram(ctx, program, config);
     return {
-      programId: `stub-${Date.now()}`,
-      marketplaceUrl: "https://tapfiliate.com",
+      programId: tapProgram.id,
+      marketplaceUrl: tapProgram.default_landing_page_url ?? 'https://tapfiliate.com',
     };
   },
 
-  async getTrackingLink(ctx, programId, destinationUrl) {
-    ctx.log(`[stub] ${"affiliate-tapfiliate"} getTrackingLink program=${programId}`);
-    return { url: destinationUrl };
+  async getTrackingLink(ctx, programId, _destinationUrl, config) {
+    ctx.log(`tapfiliate - tracking link program=${programId}`);
+    const affiliate = await resolveAffiliate(ctx, programId, config);
+    const link = affiliate.referral_link?.link;
+    if (!link) {
+      throw new Error(`Tapfiliate affiliate ${affiliate.id} has no referral_link for program ${programId}`);
+    }
+    return { url: link };
   },
 
-  async stats(ctx, programId) {
-    ctx.log(`[stub] ${"affiliate-tapfiliate"} stats program=${programId}`);
-    return { publishers: 0, clicks: 0, conversions: 0, revenue: 0, commissionsPaid: 0, currency: 'USD' };
+  async stats(ctx, programId, config) {
+    ctx.log(`tapfiliate - stats program=${programId}`);
+    const [program, affiliates, conversions, clicks] = await Promise.all([
+      tapfiliateRequest<TapfiliateProgram>(ctx, config, `/programs/${encodeURIComponent(programId)}/`),
+      tapfiliateRequest<TapfiliateAffiliate[]>(ctx, config, `/programs/${encodeURIComponent(programId)}/affiliates/`),
+      tapfiliateRequest<TapfiliateConversion[]>(ctx, config, `/conversions/?${query({ program_id: programId })}`),
+      optionalTapfiliateRequest<unknown[]>(ctx, config, `/clicks/?${query({ program_id: programId })}`),
+    ]);
+
+    const revenue = conversions.reduce((sum, conversion) => sum + numberValue(conversion.amount), 0);
+    const commissionsPaid = conversions.reduce((sum, conversion) => {
+      return sum + (conversion.commissions ?? []).reduce((inner, commission) => {
+        return inner + (commission.payout ? numberValue(commission.amount) : 0);
+      }, 0);
+    }, 0);
+
+    return {
+      publishers: affiliates.filter((affiliate) => affiliate.approved !== false).length,
+      clicks: clicks.length,
+      conversions: conversions.length,
+      revenue,
+      commissionsPaid,
+      currency: program.currency ?? conversions[0]?.program?.currency ?? 'USD',
+    };
   },
 
   setup: tokenSetup<Config>({
-    secretKey: "TAPFILIATE_API_KEY",
-    label: "Tapfiliate",
-    vendorDocUrl: "https://tapfiliate.com",
+    secretKey: 'TAPFILIATE_API_KEY',
+    label: 'Tapfiliate',
+    vendorDocUrl: 'https://tapfiliate.com/docs/rest/',
     steps: [
-      "Log into tapfiliate.com → API tab",
-      "Generate a new API key",
-      "Paste below",
+      'Log into tapfiliate.com -> API tab',
+      'Generate a new API key',
+      'Paste below',
+      'Set programId or assetId in config for accounts with multiple programs',
     ],
   }),
 });
+
+async function resolveProgram(
+  ctx: AffiliateConnectContext,
+  program: Pick<AffiliateProgram, 'name' | 'destinationUrl'>,
+  config: Config,
+): Promise<TapfiliateProgram> {
+  if (config.programId) {
+    return tapfiliateRequest<TapfiliateProgram>(ctx, config, `/programs/${encodeURIComponent(config.programId)}/`);
+  }
+
+  const programs = await tapfiliateRequest<TapfiliateProgram[]>(
+    ctx,
+    config,
+    `/programs/${config.assetId ? `?${query({ asset_id: config.assetId })}` : ''}`,
+  );
+  const match = programs.find((tapProgram) => {
+    return tapProgram.title?.toLowerCase() === program.name.toLowerCase()
+      || tapProgram.default_landing_page_url === program.destinationUrl;
+  });
+  if (match) return match;
+
+  if (programs.length === 1 && !config.assetId) return programs[0]!;
+
+  throw new Error(
+    'Tapfiliate REST API does not expose program creation. Set config.programId or config.assetId for an existing Tapfiliate program.',
+  );
+}
+
+async function resolveAffiliate(
+  ctx: AffiliateConnectContext,
+  programId: string,
+  config: Config,
+): Promise<TapfiliateAffiliate> {
+  if (config.affiliateId) {
+    return tapfiliateRequest<TapfiliateAffiliate>(
+      ctx,
+      config,
+      `/programs/${encodeURIComponent(programId)}/affiliates/${encodeURIComponent(config.affiliateId)}/`,
+    );
+  }
+
+  const filters = {
+    email: config.affiliateEmail,
+    source_id: config.sourceId,
+  };
+  if (!filters.email && !filters.source_id) {
+    throw new Error('Tapfiliate tracking links require config.affiliateId, config.affiliateEmail, or config.sourceId');
+  }
+
+  const affiliates = await tapfiliateRequest<TapfiliateAffiliate[]>(
+    ctx,
+    config,
+    `/programs/${encodeURIComponent(programId)}/affiliates/?${query(filters)}`,
+  );
+  const affiliate = affiliates.find((candidate) => candidate.referral_link?.link);
+  if (!affiliate) throw new Error(`No Tapfiliate affiliate with a referral link found for program ${programId}`);
+  return affiliate;
+}
+
+async function optionalTapfiliateRequest<T>(
+  ctx: AffiliateConnectContext,
+  config: Config,
+  path: string,
+): Promise<T> {
+  try {
+    return await tapfiliateRequest<T>(ctx, config, path);
+  } catch (error) {
+    if (error instanceof Error && /Tapfiliate 403/.test(error.message)) {
+      ctx.log('tapfiliate - clicks endpoint unavailable for this account plan', 'warn');
+      return [] as T;
+    }
+    throw error;
+  }
+}
+
+async function tapfiliateRequest<T>(
+  ctx: AffiliateConnectContext,
+  config: Config,
+  path: string,
+): Promise<T> {
+  const apiKey = ctx.secret('TAPFILIATE_API_KEY');
+  if (!apiKey) throw new Error('TAPFILIATE_API_KEY not in vault');
+  const baseUrl = (config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, '');
+  const res = await fetch(`${baseUrl}${path}`, {
+    headers: {
+      'content-type': 'application/json',
+      'X-Api-Key': apiKey,
+    },
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`Tapfiliate ${res.status}: ${text.slice(0, 200)}`);
+  }
+  return (text ? JSON.parse(text) : {}) as T;
+}
+
+function query(params: Record<string, string | number | boolean | undefined>): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== '') search.set(key, String(value));
+  }
+  return search.toString();
+}
+
+function numberValue(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}


### PR DESCRIPTION
## Summary
- Replace the Tapfiliate affiliate stub with real REST API calls using `X-Api-Key` auth.
- Resolve existing Tapfiliate programs by configured `programId`/`assetId`, title, or landing page because the public REST API exposes program retrieval/listing rather than program creation.
- Add affiliate referral-link lookup and aggregate program stats from affiliates, conversions, commissions, and enterprise click stats when available.

## Verification
- `npx --yes pnpm@9.12.0 vitest run packages/affiliates/tapfiliate/src/index.test.ts`
- `npx --yes pnpm@9.12.0 --filter @profullstack/sh1pt-affiliate-tapfiliate typecheck`
- `npx --yes pnpm@9.12.0 --filter @profullstack/sh1pt-affiliate-tapfiliate build`
- `git diff --check`

Related to #6. No real Tapfiliate API key or other secret was used; tests use mocked fetch calls and fake placeholders only.