### PR TITLE
Implement Amazon Associates PA-API adapter

### DIFF
--- a/packages/affiliates/amazon-associates/src/index.test.ts
+++ b/packages/affiliates/amazon-associates/src/index.test.ts
@@ -1,4 +1,125 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'affiliate' });
+
+const ctx = (secrets: Record<string, string> = { AMAZON_PAAPI_SECRET: 'amazon-secret' }) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+});
+
+describe('Amazon Associates adapter', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('requires PA-API credentials before probing the API', async () => {
+    await expect(adapter.connect(ctx({}), {
+      accessKey: 'AKIA_TEST',
+      partnerTag: 'example-20',
+    })).rejects.toThrow('AMAZON_PAAPI_SECRET not in vault');
+    await expect(adapter.connect(ctx(), {
+      partnerTag: 'example-20',
+    })).rejects.toThrow('Amazon PA-API accessKey is required');
+    await expect(adapter.connect(ctx(), {
+      accessKey: 'AKIA_TEST',
+    })).rejects.toThrow('Amazon Associates partnerTag is required');
+  });
+
+  it('signs a PA-API SearchItems probe during connect', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-21T03:00:00.000Z'));
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ SearchResult: { Items: [] } }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(adapter.connect(ctx(), {
+      accessKey: 'AKIA_TEST',
+      partnerTag: 'example-20',
+    })).resolves.toEqual({ accountId: 'example-20' });
+
+    const [url, request] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe('https://webservices.amazon.com/paapi5/searchitems');
+    expect(request.method).toBe('POST');
+    expect(request.headers['content-encoding']).toBe('amz-1.0');
+    expect(request.headers['content-type']).toBe('application/json; charset=utf-8');
+    expect(request.headers['x-amz-date']).toBe('20260521T030000Z');
+    expect(request.headers['x-amz-target']).toBe(
+      'com.amazon.paapi5.v1.ProductAdvertisingAPIv1.SearchItems',
+    );
+    expect(request.headers.authorization).toContain(
+      'Credential=AKIA_TEST/20260521/us-east-1/ProductAdvertisingAPI/aws4_request',
+    );
+    expect(request.headers.authorization).toContain(
+      'SignedHeaders=content-encoding;content-type;host;x-amz-date;x-amz-target',
+    );
+    expect(request.headers.authorization).not.toContain('amazon-secret');
+    expect(JSON.parse(request.body)).toMatchObject({
+      Keywords: 'sh1pt',
+      PartnerTag: 'example-20',
+      PartnerType: 'Associates',
+      Marketplace: 'www.amazon.com',
+    });
+  });
+
+  it('builds Amazon tagged links from an ASIN or supplied destination URL', async () => {
+    await expect(adapter.getTrackingLink?.(ctx(), 'B08TEST123', '', {
+      partnerTag: 'example-20',
+      subtag: 'spring campaign!',
+    })).resolves.toEqual({
+      url: 'https://www.amazon.com/dp/B08TEST123?tag=example-20&ascsubtag=spring_campaign_',
+    });
+
+    await expect(adapter.getTrackingLink?.(
+      ctx(),
+      'B08TEST123',
+      'https://www.amazon.co.uk/dp/B08TEST123?tag=existing-21',
+      { partnerTag: 'example-20' },
+    )).resolves.toEqual({
+      url: 'https://www.amazon.co.uk/dp/B08TEST123?tag=existing-21',
+    });
+  });
+
+  it('supports custom PA-API hosts, regions, and marketplaces', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-21T03:00:00.000Z'));
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ SearchResult: { Items: [] } }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.connect(ctx(), {
+      accessKey: 'AKIA_TEST',
+      apiHost: 'webservices.amazon.co.uk',
+      marketplaceHost: 'www.amazon.co.uk',
+      partnerTag: 'example-21',
+      region: 'eu-west-1',
+    });
+
+    const [url, request] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe('https://webservices.amazon.co.uk/paapi5/searchitems');
+    expect(request.headers.authorization).toContain(
+      'Credential=AKIA_TEST/20260521/eu-west-1/ProductAdvertisingAPI/aws4_request',
+    );
+    expect(JSON.parse(request.body).Marketplace).toBe('www.amazon.co.uk');
+  });
+
+  it('redacts PA-API credentials from provider error excerpts', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: async () => 'invalid AKIA_TEST / amazon-secret credentials',
+    }));
+
+    await expect(adapter.connect(ctx(), {
+      accessKey: 'AKIA_TEST',
+      partnerTag: 'example-20',
+    })).rejects.toThrow('invalid [redacted] / [redacted] credentials');
+  });
+});
+
+function jsonResponse(body: unknown) {
+  return {
+    ok: true,
+    json: async () => body,
+  };
+}

--- a/packages/affiliates/amazon-associates/src/index.ts
+++ b/packages/affiliates/amazon-associates/src/index.ts
@@ -1,46 +1,212 @@
-import { defineAffiliate, tokenSetup } from '@profullstack/sh1pt-core';
+import { createHash, createHmac } from 'node:crypto';
+import { defineAffiliate, tokenSetup, type AffiliateConnectContext } from '@profullstack/sh1pt-core';
 
 interface Config {
+  accessKey?: string;
   accountId?: string;
+  apiHost?: string;
+  marketplace?: string;
+  marketplaceHost?: string;
+  partnerTag?: string;
+  region?: string;
+  subtag?: string;
 }
 
+const DEFAULT_API_HOST = 'webservices.amazon.com';
+const DEFAULT_MARKETPLACE_HOST = 'www.amazon.com';
+const DEFAULT_REGION = 'us-east-1';
+const SERVICE = 'ProductAdvertisingAPI';
+
 export default defineAffiliate<Config>({
-  id: "affiliate-amazon-associates",
-  label: "Amazon Associates / PAAPI",
-  side: "publisher",
+  id: 'affiliate-amazon-associates',
+  label: 'Amazon Associates / PA-API',
+  side: 'publisher',
 
   async connect(ctx, config) {
-    const token = ctx.secret("AMAZON_PAAPI_SECRET");
-    if (!token) throw new Error("AMAZON_PAAPI_SECRET not in vault — run `sh1pt promote affiliates setup`");
-    return { accountId: config.accountId ?? "affiliate-amazon-associates" };
+    const partnerTag = requirePartnerTag(config);
+    await paapiRequest(ctx, config, 'SearchItems', {
+      Keywords: 'sh1pt',
+      SearchIndex: 'All',
+      ItemCount: 1,
+      PartnerTag: partnerTag,
+      PartnerType: 'Associates',
+      Marketplace: marketplace(config),
+      Resources: ['ItemInfo.Title'],
+    });
+    return { accountId: config.accountId ?? partnerTag };
   },
 
-  async createProgram(ctx, program) {
-    ctx.log(`[stub] ${"affiliate-amazon-associates"} createProgram name=${program.name} commission=${program.commissionRate}${program.commissionType === 'percentage' ? '%' : ''}`);
-    return {
-      programId: `stub-${Date.now()}`,
-      marketplaceUrl: "https://affiliate-program.amazon.com",
-    };
-  },
-
-  async getTrackingLink(ctx, programId, destinationUrl) {
-    ctx.log(`[stub] ${"affiliate-amazon-associates"} getTrackingLink program=${programId}`);
-    return { url: destinationUrl };
-  },
-
-  async stats(ctx, programId) {
-    ctx.log(`[stub] ${"affiliate-amazon-associates"} stats program=${programId}`);
-    return { publishers: 0, clicks: 0, conversions: 0, revenue: 0, commissionsPaid: 0, currency: 'USD' };
+  async getTrackingLink(ctx, programId, destinationUrl, config) {
+    const partnerTag = requirePartnerTag(config);
+    ctx.log(`amazon associates link · asin=${programId}`);
+    const url = new URL(destinationUrl || `https://${marketplaceHost(config)}/dp/${encodeURIComponent(programId)}`);
+    if (!url.searchParams.has('tag')) url.searchParams.set('tag', partnerTag);
+    const subtag = cleanSubtag(config.subtag);
+    if (subtag && !url.searchParams.has('ascsubtag')) url.searchParams.set('ascsubtag', subtag);
+    return { url: url.toString() };
   },
 
   setup: tokenSetup<Config>({
-    secretKey: "AMAZON_PAAPI_SECRET",
-    label: "Amazon Associates / PAAPI",
-    vendorDocUrl: "https://affiliate-program.amazon.com",
+    secretKey: 'AMAZON_PAAPI_SECRET',
+    label: 'Amazon Associates / PA-API',
+    vendorDocUrl: 'https://webservices.amazon.com/paapi5/documentation/',
     steps: [
-      "Join affiliate-program.amazon.com (per region)",
-      "Apply for the Product Advertising API (requires 3 sales)",
-      "Generate access key + secret in IAM; paste the secret below",
+      'Join Amazon Associates for the target marketplace',
+      'Apply for Product Advertising API access and create access credentials',
+      'Paste the PA-API secret key below; enter the access key and partner tag as fields',
+    ],
+    fields: [
+      {
+        key: 'accessKey',
+        message: 'Amazon PA-API access key:',
+      },
+      {
+        key: 'partnerTag',
+        message: 'Amazon Associates partner tag, for example example-20:',
+      },
+      {
+        key: 'marketplaceHost',
+        message: 'Marketplace host for tagged links (default: www.amazon.com):',
+      },
     ],
   }),
 });
+
+async function paapiRequest(
+  ctx: AffiliateConnectContext,
+  config: Config,
+  operation: 'SearchItems' | 'GetItems',
+  payload: Record<string, unknown>,
+): Promise<unknown> {
+  const accessKey = requireValue(config.accessKey, 'Amazon PA-API accessKey is required');
+  const secretKey = requireValue(ctx.secret('AMAZON_PAAPI_SECRET'), 'AMAZON_PAAPI_SECRET not in vault');
+  const apiHost = config.apiHost ?? DEFAULT_API_HOST;
+  const region = config.region ?? DEFAULT_REGION;
+  const path = `/paapi5/${operation.toLowerCase()}`;
+  const body = JSON.stringify(payload);
+  const now = new Date();
+  const amzDate = amzTimestamp(now);
+  const dateStamp = amzDate.slice(0, 8);
+  const target = `com.amazon.paapi5.v1.ProductAdvertisingAPIv1.${operation}`;
+  const headers = signedHeaders({
+    accessKey,
+    apiHost,
+    amzDate,
+    body,
+    dateStamp,
+    path,
+    region,
+    secretKey,
+    target,
+  });
+  const res = await fetch(`https://${apiHost}${path}`, {
+    method: 'POST',
+    headers,
+    body,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Amazon PA-API ${res.status}: ${redact(text, [accessKey, secretKey]).slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+function signedHeaders(input: {
+  accessKey: string;
+  apiHost: string;
+  amzDate: string;
+  body: string;
+  dateStamp: string;
+  path: string;
+  region: string;
+  secretKey: string;
+  target: string;
+}): Record<string, string> {
+  const canonicalHeaders = [
+    'content-encoding:amz-1.0',
+    'content-type:application/json; charset=utf-8',
+    `host:${input.apiHost}`,
+    `x-amz-date:${input.amzDate}`,
+    `x-amz-target:${input.target}`,
+    '',
+  ].join('\n');
+  const signedHeaderNames = 'content-encoding;content-type;host;x-amz-date;x-amz-target';
+  const canonicalRequest = [
+    'POST',
+    input.path,
+    '',
+    canonicalHeaders,
+    signedHeaderNames,
+    sha256(input.body),
+  ].join('\n');
+  const credentialScope = `${input.dateStamp}/${input.region}/${SERVICE}/aws4_request`;
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    input.amzDate,
+    credentialScope,
+    sha256(canonicalRequest),
+  ].join('\n');
+  const signature = hmacHex(signingKey(input.secretKey, input.dateStamp, input.region), stringToSign);
+  return {
+    accept: 'application/json',
+    'content-encoding': 'amz-1.0',
+    'content-type': 'application/json; charset=utf-8',
+    host: input.apiHost,
+    'x-amz-date': input.amzDate,
+    'x-amz-target': input.target,
+    authorization: [
+      `AWS4-HMAC-SHA256 Credential=${input.accessKey}/${credentialScope}`,
+      `SignedHeaders=${signedHeaderNames}`,
+      `Signature=${signature}`,
+    ].join(', '),
+  };
+}
+
+function signingKey(secretKey: string, dateStamp: string, region: string): Buffer {
+  const kDate = hmac(Buffer.from(`AWS4${secretKey}`, 'utf8'), dateStamp);
+  const kRegion = hmac(kDate, region);
+  const kService = hmac(kRegion, SERVICE);
+  return hmac(kService, 'aws4_request');
+}
+
+function hmac(key: Buffer | string, data: string): Buffer {
+  return createHmac('sha256', key).update(data, 'utf8').digest();
+}
+
+function hmacHex(key: Buffer | string, data: string): string {
+  return createHmac('sha256', key).update(data, 'utf8').digest('hex');
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+function amzTimestamp(date: Date): string {
+  return date.toISOString().replace(/[:-]|\.\d{3}/g, '');
+}
+
+function marketplace(config: Config): string {
+  return `www.${marketplaceHost(config).replace(/^www\./, '')}`;
+}
+
+function marketplaceHost(config: Config): string {
+  return config.marketplaceHost ?? config.marketplace ?? DEFAULT_MARKETPLACE_HOST;
+}
+
+function requirePartnerTag(config: Config): string {
+  return requireValue(config.partnerTag ?? config.accountId, 'Amazon Associates partnerTag is required');
+}
+
+function requireValue(value: string | undefined, message: string): string {
+  if (!value) throw new Error(message);
+  return value;
+}
+
+function cleanSubtag(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  return value.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 100);
+}
+
+function redact(value: string, secrets: string[]): string {
+  return secrets.reduce((text, secret) => text.split(secret).join('[redacted]'), value);
+}


### PR DESCRIPTION
Related: #6

Summary:
- replaces the Amazon Associates stub with a signed Product Advertising API SearchItems connect probe
- generates tagged Amazon destination links from either an ASIN or an existing Amazon URL, with optional ascsubtag support
- adds setup fields for access key, partner tag, marketplace host, and provider error redaction
- adds focused mocked coverage for credentials, SigV4 headers, marketplace overrides, tagged links, and credential redaction

Validation:
- pnpm exec vitest run packages/affiliates/amazon-associates/src/index.test.ts
- pnpm --filter @profullstack/sh1pt-affiliate-amazon-associates typecheck
- pnpm --filter @profullstack/sh1pt-affiliate-amazon-associates build
- git diff --check

Payment details can be provided after maintainer confirmation.