### PR TITLE
fix: expose `sh1pt init` as top-level command

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,49 @@
+import { Command } from 'commander';
+import { writeFile, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import kleur from 'kleur';
+import prompts from 'prompts';
+
+const CONFIG_TEMPLATE = (name: string) => `import { defineConfig } from '@profullstack/sh1pt-core';
+
+export default defineConfig({
+  name: '${name}',
+  version: '0.0.0',
+  targets: {
+    // add targets with \`sh1pt ship target add <id>\`
+  },
+});
+`;
+
+/**
+ * Shared init action — scaffolds sh1pt.config.ts in the current project.
+ * Used by both `sh1pt init` (top-level) and `sh1pt ship init` (sub-command).
+ */
+export async function initAction(): Promise<void> {
+  const cfgPath = join(process.cwd(), 'sh1pt.config.ts');
+  try {
+    await access(cfgPath);
+    console.log(kleur.yellow('sh1pt.config.ts already exists — aborting.'));
+    return;
+  } catch {
+    // expected — file does not exist
+  }
+  const { name } = await prompts({
+    type: 'text',
+    name: 'name',
+    message: 'Project name',
+    initial: process.cwd().split('/').pop() ?? 'my-app',
+  });
+  if (!name) return;
+  await writeFile(cfgPath, CONFIG_TEMPLATE(name), 'utf8');
+  console.log(kleur.green('✓ wrote sh1pt.config.ts'));
+  console.log(`  next: ${kleur.cyan('sh1pt ship target add <id>')}`);
+}
+
+/**
+ * Top-level `sh1pt init` command — an alias for `sh1pt ship init`.
+ * The README documents `sh1pt init` as the primary way to scaffold a project config.
+ */
+export const initCmd = new Command('init')
+  .description('Scaffold sh1pt.config.ts in the current project')
+  .action(initAction);

--- a/packages/cli/src/commands/ship.ts
+++ b/packages/cli/src/commands/ship.ts
@@ -1,21 +1,9 @@
 import { Command } from 'commander';
-import { writeFile, access } from 'node:fs/promises';
 import { join } from 'node:path';
 import kleur from 'kleur';
-import prompts from 'prompts';
 import { lint } from '@profullstack/sh1pt-policy';
 import type { Manifest } from '@profullstack/sh1pt-core';
-
-const CONFIG_TEMPLATE = (name: string) => `import { defineConfig } from '@profullstack/sh1pt-core';
-
-export default defineConfig({
-  name: '${name}',
-  version: '0.0.0',
-  targets: {
-    // add targets with \`sh1pt ship target add <id>\`
-  },
-});
-`;
+import { initAction } from './init.js';
 
 async function loadManifest(): Promise<Manifest> {
   // Stub — real impl dynamic-imports ./sh1pt.config.ts
@@ -42,26 +30,7 @@ export const shipCmd = new Command('ship')
 shipCmd
   .command('init')
   .description('Scaffold sh1pt.config.ts in the current project')
-  .action(async () => {
-    const cfgPath = join(process.cwd(), 'sh1pt.config.ts');
-    try {
-      await access(cfgPath);
-      console.log(kleur.yellow('sh1pt.config.ts already exists — aborting.'));
-      return;
-    } catch {
-      // expected
-    }
-    const { name } = await prompts({
-      type: 'text',
-      name: 'name',
-      message: 'Project name',
-      initial: process.cwd().split('/').pop() ?? 'my-app',
-    });
-    if (!name) return;
-    await writeFile(cfgPath, CONFIG_TEMPLATE(name), 'utf8');
-    console.log(kleur.green(`✓ wrote sh1pt.config.ts`));
-    console.log(`  next: ${kleur.cyan('sh1pt ship target add <id>')}`);
-  });
+  .action(initAction);
 
 shipCmd
   .command('setup')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@ import { promoteCmd } from './commands/promote.js';
 import { scaleCmd } from './commands/scale.js';
 import { iterateCmd } from './commands/iterate.js';
 import { shipCmd } from './commands/ship.js';
+import { initCmd } from './commands/init.js';
 import { loginCmd, logoutCmd } from './commands/login.js';
 import { secretsCmd } from './commands/secrets.js';
 import { configCmd } from './commands/config.js';
@@ -38,6 +39,9 @@ program.addCommand(promoteCmd);    // promote  · publish (ship), ads, merch —
 program.addCommand(shipCmd);       // ship     · publish built artifacts to stores and registries
 program.addCommand(scaleCmd);      // scale    · provision (deploy), DNS, rollouts, cost
 program.addCommand(iterateCmd);    // iterate  · observe + agent-propose + ship + measure (agents nested)
+
+// Top-level init — `sh1pt init` scaffolds sh1pt.config.ts (alias for `sh1pt ship init`).
+program.addCommand(initCmd);
 
 // Auth + config utilities — cross-cutting, kept top-level for convention.
 program.addCommand(loginCmd);


### PR DESCRIPTION
## Summary

Fixes #241

The README documents `sh1pt init` as the way to scaffold a new project, but the CLI only registered it as a subcommand under `sh1pt ship init`.

## Changes

- **New file**: `packages/cli/src/commands/init.ts` — exports `initCmd` (top-level) and `initAction` (shared logic)
- **Modified**: `packages/cli/src/index.ts` — imports and registers `initCmd` as a top-level command
- **Modified**: `packages/cli/src/commands/ship.ts` — imports `initAction` from `init.ts` instead of defining the action inline, so `sh1pt ship init` still works

## Behavior

Both commands now work identically:
```
sh1pt init          # ✅ top-level (documented in README)
sh1pt ship init     # ✅ still works as subcommand
```

## Testing

All 1887 tests pass (`pnpm test`).

SOL wallet: `0xadf380b5048e9730af0957fd39d5ef1de374475d`
