### PR TITLE
Implement Slack bridge Socket Mode adapter

### DIFF
--- a/packages/bridges/slack/src/index.test.ts
+++ b/packages/bridges/slack/src/index.test.ts
@@ -1,4 +1,240 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import type { BridgeMessage } from '@profullstack/sh1pt-core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'bridge' });
+
+const defaultSecrets = {
+  SLACK_APP_TOKEN: 'xapp-test',
+  SLACK_BOT_TOKEN: 'xoxb-test',
+};
+
+const sendCtx = (secrets: Record<string, string | undefined> = defaultSecrets, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: vi.fn(),
+  dryRun,
+});
+
+const subscribeCtx = (secrets: Record<string, string | undefined> = defaultSecrets, signal?: AbortSignal) => ({
+  secret: (key: string) => secrets[key],
+  log: vi.fn(),
+  signal,
+});
+
+const sampleMessage = (): BridgeMessage => ({
+  id: 'discord-1',
+  channel: 'general',
+  identity: {
+    network: 'discord',
+    username: 'Ada',
+    avatarUrl: 'https://avatar.example/ada.png',
+  },
+  text: 'hi from discord',
+  attachments: [{
+    url: 'https://cdn.example/file.png',
+    filename: 'file.png',
+    kind: 'image',
+    mimeType: 'image/png',
+  }],
+  timestamp: '2026-05-21T00:00:00.000Z',
+  originalNetwork: 'discord',
+});
+
+class FakeSocket {
+  static instances: FakeSocket[] = [];
+
+  closed = false;
+  onmessage?: (event: { data: string }) => void | Promise<void>;
+  sent: string[] = [];
+
+  constructor(public readonly url: string) {
+    FakeSocket.instances.push(this);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+}
+
+afterEach(() => {
+  FakeSocket.instances = [];
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('bridge-slack adapter', () => {
+  it('requires Slack tokens for live send and subscribe', async () => {
+    await expect(adapter.send(sendCtx({}), 'C123', sampleMessage(), {})).rejects.toThrow('SLACK_BOT_TOKEN');
+    await expect(adapter.subscribe(subscribeCtx({ SLACK_APP_TOKEN: 'xapp-test' }), ['C123'], vi.fn(), {}))
+      .rejects.toThrow('SLACK_APP_TOKEN + SLACK_BOT_TOKEN');
+  });
+
+  it('keeps dry-run send side-effect free', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(adapter.send(sendCtx(defaultSecrets, true), 'C123', sampleMessage(), {})).resolves.toEqual({
+      id: 'dry-run',
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts relayed messages through chat.postMessage', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      ok: true,
+      ts: '1716210001.000200',
+    }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(adapter.send(sendCtx(), 'C123', sampleMessage(), {})).resolves.toEqual({
+      id: '1716210001.000200',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, request] = fetchCall(fetchMock);
+    expect(url).toBe('https://slack.com/api/chat.postMessage');
+    expect(request).toMatchObject({
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer xoxb-test',
+        'content-type': 'application/json; charset=utf-8',
+      },
+    });
+    expect(JSON.parse(String(request.body))).toEqual({
+      channel: 'C123',
+      text: 'Ada [discord]: hi from discord\nhttps://cdn.example/file.png',
+      username: 'Ada [discord]',
+      icon_url: 'https://avatar.example/ada.png',
+      unfurl_links: false,
+      unfurl_media: false,
+    });
+  });
+
+  it('opens Slack Socket Mode and maps subscribed message events', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      ok: true,
+      url: 'wss://slack.example/socket',
+    }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('WebSocket', FakeSocket);
+
+    const onMessage = vi.fn();
+    const subscription = await adapter.subscribe(subscribeCtx(), ['C-allowed'], onMessage, {});
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, request] = fetchCall(fetchMock);
+    expect(url).toBe('https://slack.com/api/apps.connections.open');
+    expect(request).toMatchObject({
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer xapp-test',
+        'content-type': 'application/json; charset=utf-8',
+      },
+    });
+
+    const socket = FakeSocket.instances[0]!;
+    expect(socket.url).toBe('wss://slack.example/socket');
+
+    await socket.onmessage?.({
+      data: JSON.stringify({
+        envelope_id: 'env-1',
+        type: 'events_api',
+        payload: {
+          event: {
+            type: 'message',
+            channel: 'C-other',
+            user: 'U999',
+            text: 'ignored',
+            ts: '1716210000.000100',
+          },
+        },
+      }),
+    });
+
+    expect(socket.sent).toEqual([JSON.stringify({ envelope_id: 'env-1' })]);
+    expect(onMessage).not.toHaveBeenCalled();
+
+    await socket.onmessage?.({
+      data: JSON.stringify({
+        envelope_id: 'env-2',
+        type: 'events_api',
+        payload: {
+          event: {
+            type: 'message',
+            channel: 'C-allowed',
+            bot_id: 'B123',
+            bot_profile: {
+              name: 'Deploy Bot',
+              icons: { image_72: 'https://avatar.example/bot.png' },
+            },
+            text: 'release shipped',
+            files: [{
+              url_private: 'https://files.example/report.pdf',
+              name: 'report.pdf',
+              mimetype: 'application/pdf',
+            }],
+            event_ts: '1716210001.000200',
+            ts: '1716210001.000200',
+          },
+        },
+      }),
+    });
+
+    expect(socket.sent).toEqual([
+      JSON.stringify({ envelope_id: 'env-1' }),
+      JSON.stringify({ envelope_id: 'env-2' }),
+    ]);
+    expect(onMessage).toHaveBeenCalledWith({
+      id: '1716210001.000200',
+      channel: 'C-allowed',
+      identity: {
+        network: 'slack',
+        username: 'Deploy Bot',
+        avatarUrl: 'https://avatar.example/bot.png',
+        isBot: true,
+      },
+      text: 'release shipped',
+      attachments: [{
+        url: 'https://files.example/report.pdf',
+        filename: 'report.pdf',
+        mimeType: 'application/pdf',
+        kind: 'file',
+      }],
+      timestamp: new Date(1716210001 * 1000).toISOString(),
+      originalNetwork: 'slack',
+    });
+
+    await subscription.close();
+    expect(socket.closed).toBe(true);
+  });
+
+  it('redacts Slack tokens from API errors', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      ok: false,
+      error: 'token xoxb-secret rejected',
+    }), { status: 200 })));
+
+    let error: Error | undefined;
+    try {
+      await adapter.send(sendCtx({ SLACK_BOT_TOKEN: 'xoxb-secret' }), 'C123', sampleMessage(), {});
+    } catch (err) {
+      error = err as Error;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error?.message).toContain('token [redacted] rejected');
+    expect(error?.message).not.toContain('xoxb-secret');
+  });
+});
+
+function fetchCall(fetchMock: ReturnType<typeof vi.fn>): [string, RequestInit] {
+  const call = fetchMock.mock.calls[0];
+  if (!call) throw new Error('fetch was not called');
+  return call as unknown as [string, RequestInit];
+}

--- a/packages/bridges/slack/src/index.ts
+++ b/packages/bridges/slack/src/index.ts
@@ -1,4 +1,4 @@
-import { defineBridge, tokenSetup } from '@profullstack/sh1pt-core';
+import { defineBridge, type BridgeAttachment, type BridgeMessage, tokenSetup } from '@profullstack/sh1pt-core';
 
 // Slack bridge — Socket Mode for receive (no public HTTP endpoint
 // required), chat.postMessage for send. Bot needs channels:history,
@@ -13,33 +13,205 @@ export default defineBridge<Config>({
   label: 'Slack',
 
   async subscribe(ctx, channels, onMessage) {
-    if (!ctx.secret('SLACK_APP_TOKEN') || !ctx.secret('SLACK_BOT_TOKEN')) {
+    const appToken = ctx.secret('SLACK_APP_TOKEN');
+    const botToken = ctx.secret('SLACK_BOT_TOKEN');
+    if (!appToken || !botToken) {
       throw new Error('SLACK_APP_TOKEN + SLACK_BOT_TOKEN required in vault (Socket Mode)');
     }
     ctx.log(`slack bridge · subscribing via Socket Mode to ${channels.length} channels`);
-    // TODO: WebSocket to wss://wss-primary.slack.com/...; filter
-    // message events to subscribed channel ids.
-    return { async close() {} };
+    const connection = await slackPost<{ url: string }>('apps.connections.open', appToken, {});
+    const WebSocketCtor = websocketConstructor();
+    const socket = new WebSocketCtor(connection.url);
+    const subscribed = new Set(channels);
+
+    socket.onmessage = async (event) => {
+      const envelope = parseJson<SlackEnvelope>(String(event.data));
+      if (!envelope) return;
+      if (envelope.envelope_id) socket.send(JSON.stringify({ envelope_id: envelope.envelope_id }));
+      if (envelope.type !== 'events_api' || envelope.payload?.event?.type !== 'message') return;
+      const slackMessage = envelope.payload.event;
+      if (!subscribed.has(slackMessage.channel) || slackMessage.subtype === 'message_deleted') return;
+      await onMessage(toBridgeMessage(slackMessage));
+    };
+
+    const abort = () => socket.close();
+    ctx.signal?.addEventListener('abort', abort, { once: true });
+    return {
+      async close() {
+        ctx.signal?.removeEventListener('abort', abort);
+        socket.close();
+      },
+    };
   },
 
   async send(ctx, channel, msg) {
-    if (!ctx.secret('SLACK_BOT_TOKEN')) throw new Error('SLACK_BOT_TOKEN not in vault');
+    const botToken = ctx.secret('SLACK_BOT_TOKEN');
+    if (!botToken) throw new Error('SLACK_BOT_TOKEN not in vault');
     ctx.log(`slack bridge send → ${channel}`);
     if (ctx.dryRun) return { id: 'dry-run' };
-    // TODO: POST https://slack.com/api/chat.postMessage with
-    //   { channel, text, username: msg.identity.username + ` [${msg.originalNetwork}]`,
-    //     icon_url: msg.identity.avatarUrl, blocks: [...] }
-    return { id: `s_${Date.now()}` };
+    const response = await slackPost<{ ts?: string }>('chat.postMessage', botToken, {
+      channel,
+      text: renderMessage(msg),
+      username: renderUsername(msg),
+      icon_url: msg.identity.avatarUrl,
+      unfurl_links: false,
+      unfurl_media: false,
+    });
+    return { id: response.ts ?? `slack_${Date.now()}` };
   },
 
   setup: tokenSetup({
-    secretKey: 'SLACK_BRIDGE_BOT_TOKEN',
-    label: 'Slack bridge',
+    secretKey: 'SLACK_BOT_TOKEN',
+    label: 'Slack bridge bot',
     vendorDocUrl: 'https://api.slack.com/apps',
     steps: [
       'Open https://api.slack.com/apps',
-      'Create a bot application / API key',
-      'Copy the token shown (usually once)',
+      'Create a Slack app with Socket Mode enabled',
+      'Add channels:history, channels:read, chat:write, app_mentions:read scopes',
+      'Install the app and copy the bot token',
+      'Create an app-level token with connections:write for Socket Mode',
+    ],
+    fields: [
+      {
+        key: 'SLACK_APP_TOKEN',
+        message: 'Paste the Slack app-level token for Socket Mode:',
+        secret: true,
+        required: true,
+      },
     ],
   }),
 });
+
+interface SlackEnvelope {
+  envelope_id?: string;
+  type?: string;
+  payload?: {
+    event?: SlackMessageEvent;
+  };
+}
+
+interface SlackMessageEvent {
+  bot_id?: string;
+  bot_profile?: {
+    name?: string;
+    icons?: {
+      image_72?: string;
+    };
+  };
+  channel: string;
+  event_ts?: string;
+  files?: SlackFile[];
+  subtype?: string;
+  text?: string;
+  ts: string;
+  type: 'message';
+  user?: string;
+  username?: string;
+}
+
+interface SlackFile {
+  filetype?: string;
+  mimetype?: string;
+  name?: string;
+  url_private?: string;
+}
+
+interface SlackSocket {
+  close(): void;
+  onmessage?: (event: { data: string }) => void | Promise<void>;
+  send(data: string): void;
+}
+
+interface SlackWebSocketConstructor {
+  new(url: string): SlackSocket;
+}
+
+async function slackPost<T>(method: string, token: string, body: Record<string, unknown>): Promise<T> {
+  const res = await fetch(`https://slack.com/api/${method}`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json; charset=utf-8',
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  const data = parseJson<Record<string, unknown>>(text) ?? {};
+  if (!res.ok || data.ok === false) {
+    const reason = typeof data.error === 'string' ? data.error : text;
+    throw new Error(`Slack ${method} failed: ${redact(reason, token)}`);
+  }
+  return data as T;
+}
+
+function toBridgeMessage(event: SlackMessageEvent): BridgeMessage {
+  return {
+    id: event.ts,
+    channel: event.channel,
+    identity: {
+      network: 'slack',
+      username: event.username ?? event.bot_profile?.name ?? event.user ?? event.bot_id ?? 'unknown',
+      avatarUrl: event.bot_profile?.icons?.image_72,
+      isBot: Boolean(event.bot_id),
+    },
+    text: event.text ?? '',
+    attachments: event.files?.map(toAttachment).filter(isAttachment),
+    timestamp: slackTimestamp(event.event_ts ?? event.ts),
+    originalNetwork: 'slack',
+  };
+}
+
+function toAttachment(file: SlackFile): BridgeAttachment | undefined {
+  if (!file.url_private) return undefined;
+  return {
+    url: file.url_private,
+    filename: file.name,
+    mimeType: file.mimetype,
+    kind: fileKind(file.mimetype ?? file.filetype),
+  };
+}
+
+function isAttachment(value: BridgeAttachment | undefined): value is BridgeAttachment {
+  return Boolean(value);
+}
+
+function fileKind(value: string | undefined): BridgeAttachment['kind'] {
+  if (value?.startsWith('image/')) return 'image';
+  if (value?.startsWith('video/')) return 'video';
+  if (value?.startsWith('audio/')) return 'audio';
+  return 'file';
+}
+
+function renderMessage(msg: BridgeMessage): string {
+  const prefix = `${msg.identity.username} [${msg.originalNetwork ?? msg.identity.network}]`;
+  const attachments = msg.attachments?.map((attachment) => attachment.url).join('\n');
+  return [`${prefix}: ${msg.text}`, attachments].filter(Boolean).join('\n');
+}
+
+function renderUsername(msg: BridgeMessage): string {
+  return `${msg.identity.username} [${msg.originalNetwork ?? msg.identity.network}]`;
+}
+
+function slackTimestamp(value: string): string {
+  const seconds = Number(value.split('.')[0]);
+  if (!Number.isFinite(seconds)) return new Date().toISOString();
+  return new Date(seconds * 1000).toISOString();
+}
+
+function websocketConstructor(): SlackWebSocketConstructor {
+  const WebSocketCtor = (globalThis as unknown as { WebSocket?: SlackWebSocketConstructor }).WebSocket;
+  if (!WebSocketCtor) throw new Error('WebSocket is not available in this runtime');
+  return WebSocketCtor;
+}
+
+function parseJson<T>(value: string): T | undefined {
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+function redact(value: string, token: string): string {
+  return value.split(token).join('[redacted]');
+}


### PR DESCRIPTION
Related to #6.

## Scope
- Replaces the Slack bridge placeholder with a Socket Mode subscriber using `apps.connections.open` and envelope acknowledgements.
- Filters inbound Slack message events to subscribed channels and maps identity, timestamps, bot flags, and file attachments into `BridgeMessage`.
- Sends relayed messages through `chat.postMessage` with source identity rendering, avatar forwarding, attachment URL fallback, and token-redacted Slack API errors.
- Updates setup guidance to collect `SLACK_BOT_TOKEN` and required `SLACK_APP_TOKEN`.

## Validation
- `pnpm exec vitest run packages/bridges/slack/src/index.test.ts`
- `pnpm --filter @profullstack/sh1pt-bridge-slack typecheck`
- `pnpm --filter @profullstack/sh1pt-bridge-slack build`
- `pnpm test`
- `git diff --check`

No real Slack workspace token, app token, or production secret was used; tests use synthetic placeholders only. Payment details can be provided after maintainer confirmation.