### PR TITLE
Implement pkg-docker buildx planning

### DIFF
--- a/packages/targets/pkg-docker/src/index.test.ts
+++ b/packages/targets/pkg-docker/src/index.test.ts
@@ -1,4 +1,115 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'pkg', requireKind: true });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Docker buildx planning', () => {
+  it('writes deterministic build and push commands for every registry tag', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-docker-'));
+    tempDirs.push(outDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      version: 'v1.2.3',
+    }) as any, {
+      image: 'acme/widget',
+      registries: [
+        { kind: 'ghcr' },
+        { kind: 'custom', host: 'registry.example.com/' },
+      ],
+      dockerfile: 'docker/prod.Dockerfile',
+      context: 'apps/widget',
+      platforms: ['linux/amd64'],
+      tags: ['edge', 'release-{{version}}'],
+      target: 'runner',
+      buildArgs: { NODE_ENV: 'production' },
+      labels: { 'org.opencontainers.image.source': 'https://github.com/acme/widget' },
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'docker-build-plan.json'));
+
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan.refs).toEqual([
+      'ghcr.io/acme/widget:1.2.3',
+      'ghcr.io/acme/widget:latest',
+      'ghcr.io/acme/widget:edge',
+      'ghcr.io/acme/widget:release-1.2.3',
+      'registry.example.com/acme/widget:1.2.3',
+      'registry.example.com/acme/widget:latest',
+      'registry.example.com/acme/widget:edge',
+      'registry.example.com/acme/widget:release-1.2.3',
+    ]);
+    expect(plan.commands.buildLocal).toEqual([
+      'docker',
+      'buildx',
+      'build',
+      '--platform=linux/amd64',
+      '--file=docker/prod.Dockerfile',
+      '--tag=ghcr.io/acme/widget:1.2.3',
+      '--tag=ghcr.io/acme/widget:latest',
+      '--tag=ghcr.io/acme/widget:edge',
+      '--tag=ghcr.io/acme/widget:release-1.2.3',
+      '--tag=registry.example.com/acme/widget:1.2.3',
+      '--tag=registry.example.com/acme/widget:latest',
+      '--tag=registry.example.com/acme/widget:edge',
+      '--tag=registry.example.com/acme/widget:release-1.2.3',
+      '--build-arg=NODE_ENV=production',
+      '--label=org.opencontainers.image.source=https://github.com/acme/widget',
+      '--target=runner',
+      `--metadata-file=${join(outDir, 'docker-build-metadata.json')}`,
+      `--output=type=oci,dest=${join(outDir, 'acme-widget-1.2.3.oci.tar')}`,
+      'apps/widget',
+    ]);
+    expect(plan.commands.push).toContain('--push');
+    expect(plan.commands.push.at(-1)).toBe('apps/widget');
+  });
+
+  it('keeps dry-run shipping side-effect free and exposes the buildx push command', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      version: '2.0.0',
+      dryRun: true,
+    }) as any, {
+      image: 'acme/api',
+      registries: [{ kind: 'dockerhub' }],
+      tags: ['beta-$version'],
+    })).resolves.toEqual({
+      id: 'dry-run',
+      meta: {
+        pushes: [
+          'docker.io/acme/api:2.0.0',
+          'docker.io/acme/api:latest',
+          'docker.io/acme/api:beta-2.0.0',
+        ],
+        command: [
+          'docker',
+          'buildx',
+          'build',
+          '--platform=linux/amd64,linux/arm64',
+          '--file=Dockerfile',
+          '--tag=docker.io/acme/api:2.0.0',
+          '--tag=docker.io/acme/api:latest',
+          '--tag=docker.io/acme/api:beta-2.0.0',
+          '--push',
+          '.',
+        ],
+      },
+    });
+  });
+
+  it('requires an explicit host for custom registries', async () => {
+    await expect(adapter.build(fakeBuildContext() as any, {
+      image: 'acme/api',
+      registries: [{ kind: 'custom' }],
+    })).rejects.toThrow('pkg-docker requires a host for custom registry');
+  });
+});

--- a/packages/targets/pkg-docker/src/index.ts
+++ b/packages/targets/pkg-docker/src/index.ts
@@ -1,4 +1,6 @@
-import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { defineTarget, exec, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 // OCI image distribution to any compliant registry: Docker Hub, GHCR,
 // GitLab Registry, Quay, AWS ECR, GCP Artifact Registry, Azure ACR,
@@ -12,6 +14,9 @@ interface Config {
   platforms?: string[];                                    // e.g. ['linux/amd64','linux/arm64']
   context?: string;
   tags?: string[];                                         // extra tags beyond ctx.version + 'latest'
+  target?: string;
+  buildArgs?: Record<string, string>;
+  labels?: Record<string, string>;
 }
 
 const HOST: Record<Registry, string> = {
@@ -25,22 +30,124 @@ const HOST: Record<Registry, string> = {
   custom: '<configure host>',
 };
 
+function versionTag(version: string): string {
+  return version.replace(/^v/, '');
+}
+
+function safeFilename(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_.-]+/g, '-').replace(/^-|-$/g, '') || 'image';
+}
+
+function normalizeHost(registry: { kind: Registry; host?: string }): string {
+  const host = registry.host ?? HOST[registry.kind];
+  if (host.includes('<')) {
+    throw new Error(`pkg-docker requires a host for ${registry.kind} registry`);
+  }
+  return host.replace(/\/+$/, '');
+}
+
+function tagValue(tag: string, version: string): string {
+  const normalized = versionTag(version);
+  return tag
+    .replaceAll('{{version}}', normalized)
+    .replaceAll('{version}', normalized)
+    .replaceAll('$version', normalized);
+}
+
+function imageRefs(ctx: { version: string }, config: Config): string[] {
+  const tags = [versionTag(ctx.version), 'latest', ...(config.tags ?? []).map((tag) => tagValue(tag, ctx.version))];
+  const uniqueTags = [...new Set(tags.filter(Boolean))];
+  return config.registries.flatMap((registry) => {
+    const host = normalizeHost(registry);
+    return uniqueTags.map((tag) => `${host}/${config.image}:${tag}`);
+  });
+}
+
+function buildxArgs(
+  ctx: { outDir: string; projectDir: string; version: string },
+  config: Config,
+  opts: { push: boolean },
+): string[] {
+  const platforms = config.platforms ?? ['linux/amd64', 'linux/arm64'];
+  const context = config.context ?? '.';
+  const dockerfile = config.dockerfile ?? 'Dockerfile';
+  const args = [
+    'buildx',
+    'build',
+    `--platform=${platforms.join(',')}`,
+    `--file=${dockerfile}`,
+  ];
+
+  for (const ref of imageRefs(ctx, config)) {
+    args.push(`--tag=${ref}`);
+  }
+  for (const [key, value] of Object.entries(config.buildArgs ?? {})) {
+    args.push(`--build-arg=${key}=${value}`);
+  }
+  for (const [key, value] of Object.entries(config.labels ?? {})) {
+    args.push(`--label=${key}=${value}`);
+  }
+  if (config.target) {
+    args.push(`--target=${config.target}`);
+  }
+
+  if (opts.push) {
+    args.push('--push');
+  } else {
+    args.push(`--metadata-file=${join(ctx.outDir, 'docker-build-metadata.json')}`);
+    args.push(`--output=type=oci,dest=${join(ctx.outDir, `${safeFilename(config.image)}-${versionTag(ctx.version)}.oci.tar`)}`);
+  }
+
+  args.push(context);
+  return args;
+}
+
 export default defineTarget<Config>({
   id: 'pkg-docker',
   kind: 'package-manager',
   label: 'Container registries (Docker Hub / GHCR / Quay / ECR / GCR / ACR)',
   async build(ctx, config) {
-    const platforms = (config.platforms ?? ['linux/amd64', 'linux/arm64']).join(',');
-    ctx.log(`docker buildx build --platform=${platforms} --tag=${config.image}:${ctx.version}`);
-    // TODO: docker buildx with --push=false, cache mount to ctx.outDir
-    return { artifact: `${config.image}:${ctx.version}` };
+    const platforms = config.platforms ?? ['linux/amd64', 'linux/arm64'];
+    const refs = imageRefs(ctx, config);
+    const planPath = join(ctx.outDir, 'docker-build-plan.json');
+    const localArgs = buildxArgs(ctx, config, { push: false });
+    const pushArgs = buildxArgs(ctx, config, { push: true });
+    const plan = {
+      image: config.image,
+      version: versionTag(ctx.version),
+      context: config.context ?? '.',
+      dockerfile: config.dockerfile ?? 'Dockerfile',
+      platforms,
+      refs,
+      commands: {
+        buildLocal: ['docker', ...localArgs],
+        push: ['docker', ...pushArgs],
+      },
+    };
+
+    ctx.log(`prepare docker buildx plan for ${config.image}:${versionTag(ctx.version)}`);
+    await mkdir(ctx.outDir, { recursive: true });
+    await writeFile(planPath, `${JSON.stringify(plan, null, 2)}\n`, 'utf-8');
+    return { artifact: planPath, meta: { image: config.image, refs, platforms } };
   },
   async ship(ctx, config) {
-    const pushes = config.registries.map((r) => `${r.host ?? HOST[r.kind]}/${config.image}:${ctx.version}`);
-    ctx.log(`push:\n  ${pushes.join('\n  ')}`);
-    if (ctx.dryRun) return { id: 'dry-run', meta: { pushes } };
-    // TODO: docker login per registry, then buildx --push for all tags (version + latest + extras)
-    return { id: `${config.image}:${ctx.version}`, meta: { pushes } };
+    const pushes = imageRefs(ctx, config);
+    const args = buildxArgs(ctx, config, { push: true });
+    ctx.log(`docker buildx push:\n  ${pushes.join('\n  ')}`);
+    if (ctx.dryRun) return { id: 'dry-run', meta: { pushes, command: ['docker', ...args] } };
+
+    await exec('docker', args, {
+      cwd: ctx.projectDir,
+      env: ctx.env,
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+
+    return { id: `${config.image}@${versionTag(ctx.version)}`, meta: { pushes } };
+  },
+  async status(id) {
+    const [image, version] = id.split('@');
+    return { state: 'live', version, message: `${image} image pushed` };
   },
 
   setup: manualSetup({


### PR DESCRIPTION
## Summary- replace the `pkg-docker` tag-only stub with deterministic Docker buildx planning- write `docker-build-plan.json` containing local OCI-build and push commands- support registry host normalization, version/tag templating, build args, labels, and targets- execute `docker buildx build --push` only when shipping outside dry-run mode## Paid task- uGig task: https://ugig.net/gigs/134f0007-139c-4cb8-98eb-652b5846f9ab- GitHub task thread: #6## Validation- `corepack pnpm@9.12.0 exec vitest run packages/targets/pkg-docker/src/index.test.ts`- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-target-pkg-docker typecheck`- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-target-pkg-docker build`- `git diff --check`