### PR TITLE
Implement pkg-aube pack and publish commands

### DIFF
--- a/packages/targets/pkg-aube/src/index.test.ts
+++ b/packages/targets/pkg-aube/src/index.test.ts
@@ -1,6 +1,77 @@
-import { contractTestTarget } from '@profullstack/sh1pt-core/testing';
+import { contractTestTarget, fakeBuildContext, fakeShipContext } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import target from './index.js';
 
 contractTestTarget(target, {
   sampleConfig: { packageDir: './fake', packageName: '@acme/fake', access: 'public' },
+});
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Aube package target', () => {
+  it('writes a dry-run pack plan using the documented Aube pack flags', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-aube-'));
+    tempDirs.push(outDir);
+
+    const result = await target.build(fakeBuildContext({
+      projectDir: '/repo',
+      outDir,
+      dryRun: true,
+    }) as any, {
+      packageDir: 'packages/app',
+      registry: 'https://registry.example.com',
+      ignoreScripts: true,
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'aube-pack-plan.json'));
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan.cwd).toBe(join('/repo', 'packages/app'));
+    expect(plan.command).toEqual([
+      'aube',
+      'pack',
+      '--json',
+      '--pack-destination',
+      outDir,
+      '--registry=https://registry.example.com',
+      '--ignore-scripts',
+      '--dry-run',
+    ]);
+  });
+
+  it('keeps dry-run publishing side-effect free and exposes the Aube publish command', async () => {
+    await expect(target.ship(fakeShipContext({
+      projectDir: '/repo',
+      channel: 'beta',
+      dryRun: true,
+    }) as any, {
+      packageDir: 'packages/app',
+      packageName: '@acme/app',
+      access: 'public',
+      tag: 'next',
+      provenance: true,
+      registry: 'https://registry.example.com',
+    })).resolves.toEqual({
+      id: 'dry-run',
+      meta: {
+        cwd: join('/repo', 'packages/app'),
+        command: [
+          'aube',
+          'publish',
+          '--json',
+          '--tag=next',
+          '--access=public',
+          '--registry=https://registry.example.com',
+          '--provenance',
+          '--dry-run',
+        ],
+      },
+    });
+  });
 });

--- a/packages/targets/pkg-aube/src/index.ts
+++ b/packages/targets/pkg-aube/src/index.ts
@@ -1,4 +1,6 @@
-import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { defineTarget, exec, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { isAbsolute, join } from 'node:path';
 
 interface Config {
   packageDir?: string;
@@ -7,6 +9,57 @@ interface Config {
   access?: 'public' | 'restricted';
   registry?: string;
   provenance?: boolean;
+  ignoreScripts?: boolean;
+}
+
+interface AubePackResult {
+  filename?: string;
+  name?: string;
+  version?: string;
+}
+
+function packageDir(ctx: { projectDir: string }, config: Config): string {
+  if (!config.packageDir) return ctx.projectDir;
+  return isAbsolute(config.packageDir) ? config.packageDir : join(ctx.projectDir, config.packageDir);
+}
+
+function packArgs(ctx: { outDir: string }, config: Config, opts: { dryRun?: boolean } = {}): string[] {
+  const args = ['pack', '--json', '--pack-destination', ctx.outDir];
+  if (config.registry) args.push(`--registry=${config.registry}`);
+  if (config.ignoreScripts) args.push('--ignore-scripts');
+  if (opts.dryRun) args.push('--dry-run');
+  return args;
+}
+
+function publishArgs(
+  ctx: { channel: string },
+  config: Config,
+  opts: { dryRun?: boolean } = {},
+): string[] {
+  const tag = config.tag ?? (ctx.channel === 'stable' ? 'latest' : ctx.channel);
+  const args = ['publish', '--json', `--tag=${tag}`, `--access=${config.access ?? 'public'}`];
+  if (config.registry) args.push(`--registry=${config.registry}`);
+  if (config.provenance) args.push('--provenance');
+  if (config.ignoreScripts) args.push('--ignore-scripts');
+  if (opts.dryRun) args.push('--dry-run');
+  return args;
+}
+
+function packagePath(name: string): string {
+  return name.split('/').map((segment) => encodeURIComponent(segment)).join('/');
+}
+
+function resolvePackedArtifact(outDir: string, stdout: string): string {
+  try {
+    const parsed = JSON.parse(stdout) as AubePackResult | AubePackResult[];
+    const first = Array.isArray(parsed) ? parsed[0] : parsed;
+    if (first?.filename) {
+      return isAbsolute(first.filename) ? first.filename : join(outDir, first.filename);
+    }
+  } catch {
+    // Fall through to a stable fallback name when older Aube versions print text.
+  }
+  return join(outDir, 'package.tgz');
 }
 
 export default defineTarget<Config>({
@@ -14,23 +67,47 @@ export default defineTarget<Config>({
   kind: 'package-manager',
   label: 'Aube',
   async build(ctx, config) {
-    const destination = config.packageDir ?? ctx.projectDir;
-    ctx.log(`aube pack --pack-destination ${ctx.outDir} (cwd=${destination})`);
-    // TODO: spawn `aube pack --pack-destination <outDir>` in ctx.projectDir/config.packageDir.
-    return { artifact: `${ctx.outDir}/package.tgz` };
+    const cwd = packageDir(ctx, config);
+    const args = packArgs(ctx, config, { dryRun: ctx.dryRun });
+    ctx.log(`aube ${args.join(' ')} (cwd=${cwd})`);
+
+    if (ctx.dryRun) {
+      const planPath = join(ctx.outDir, 'aube-pack-plan.json');
+      await mkdir(ctx.outDir, { recursive: true });
+      await writeFile(planPath, `${JSON.stringify({ cwd, command: ['aube', ...args] }, null, 2)}\n`, 'utf-8');
+      return { artifact: planPath, meta: { command: ['aube', ...args], cwd } };
+    }
+
+    const { stdout } = await exec('aube', args, {
+      cwd,
+      env: ctx.env,
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+    return { artifact: resolvePackedArtifact(ctx.outDir, stdout), meta: { command: ['aube', ...args], cwd } };
   },
   async ship(ctx, config) {
     const tag = config.tag ?? (ctx.channel === 'stable' ? 'latest' : ctx.channel);
-    const registry = config.registry ? ` (registry=${config.registry})` : '';
-    const provenance = config.provenance ? ' --provenance' : '';
-    ctx.log(`aube publish --tag ${tag} --access ${config.access ?? 'public'}${provenance}${registry}`);
-    if (ctx.dryRun) return { id: 'dry-run' };
-    // TODO: aube reads npm-compatible auth from .npmrc/NPM_TOKEN; run publish in packageDir.
+    const cwd = packageDir(ctx, config);
+    const args = publishArgs(ctx, config, { dryRun: ctx.dryRun });
+    ctx.log(`aube ${args.join(' ')} (cwd=${cwd})`);
+    if (ctx.dryRun) return { id: 'dry-run', meta: { command: ['aube', ...args], cwd } };
+
+    await exec('aube', args, {
+      cwd,
+      env: {
+        ...ctx.env,
+        NPM_TOKEN: ctx.secret('NPM_TOKEN'),
+        NODE_AUTH_TOKEN: ctx.secret('NPM_TOKEN'),
+      },
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+
     const name = config.packageName ?? ctx.version;
-    const packagePath = name.split('/').map((segment) => encodeURIComponent(segment)).join('/');
     return {
       id: `${name}@${ctx.version}:${tag}`,
-      url: config.registry ? undefined : `https://www.npmjs.com/package/${packagePath}`,
+      url: config.registry ? undefined : `https://www.npmjs.com/package/${packagePath(name)}`,
     };
   },
   async status(id) {


### PR DESCRIPTION
## Summary- replace the `pkg-aube` pack/publish stub with documented Aube CLI commands- run `aube pack --json --pack-destination ...` for real builds, while writing an inspectable dry-run plan- run `aube publish --json` with tag, access, provenance, registry, and script flags during shipping- pass npm-compatible auth tokens through the publish environment without committing any secrets## Paid task- uGig task: https://ugig.net/gigs/134f0007-139c-4cb8-98eb-652b5846f9ab- GitHub task thread: #6## Validation- `corepack pnpm@9.12.0 exec vitest run packages/targets/pkg-aube/src/index.test.ts`- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-target-pkg-aube typecheck`- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-target-pkg-aube build`- `git diff --check`## References- Aube pack CLI: https://aube.en.dev/cli/pack.html- Aube publish CLI: https://aube.en.dev/cli/publish.html