### PR TITLE
Implement JetBrains plugin Gradle commands

### DIFF
--- a/packages/targets/plugin-jetbrains/src/index.test.ts
+++ b/packages/targets/plugin-jetbrains/src/index.test.ts
@@ -1,4 +1,59 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'plugin', requireKind: true });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('JetBrains plugin target', () => {
+  it('writes a dry-run Gradle build plan with the expected plugin artifact', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-jetbrains-'));
+    tempDirs.push(outDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      projectDir: '/repo',
+      outDir,
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      pluginId: '12345',
+      projectDir: 'plugins/idea',
+      gradleCommand: './gradlew',
+      buildTask: 'buildPlugin',
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'jetbrains-build-plan.json'));
+    await expect(readFile(result.artifact, 'utf-8').then(JSON.parse)).resolves.toEqual({
+      cwd: join('/repo', 'plugins/idea'),
+      command: ['./gradlew', 'buildPlugin', '--no-daemon'],
+      artifact: join('/repo', 'plugins/idea', 'build', 'distributions', '12345-1.2.3.zip'),
+    });
+  });
+
+  it('keeps dry-run publishing side-effect free and exposes the Gradle command', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      projectDir: '/repo',
+      dryRun: true,
+    }) as any, {
+      pluginId: '12345',
+      channel: 'eap',
+      projectDir: 'plugins/idea',
+      gradleCommand: './gradlew',
+      publishTask: 'publishPlugin',
+    })).resolves.toEqual({
+      id: 'dry-run',
+      meta: {
+        cwd: join('/repo', 'plugins/idea'),
+        command: ['./gradlew', 'publishPlugin', '-PpluginVersionChannel=eap', '--no-daemon'],
+      },
+    });
+  });
+});

--- a/packages/targets/plugin-jetbrains/src/index.ts
+++ b/packages/targets/plugin-jetbrains/src/index.ts
@@ -1,8 +1,40 @@
-import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { defineTarget, exec, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { isAbsolute, join } from 'node:path';
 
 interface Config {
   pluginId: string;         // Numeric JetBrains Plugin ID
   channel?: 'stable' | 'eap';
+  projectDir?: string;
+  gradleCommand?: string;
+  buildTask?: string;
+  publishTask?: string;
+  artifactPath?: string;
+}
+
+function pluginDir(ctx: { projectDir: string }, config: Config): string {
+  if (!config.projectDir) return ctx.projectDir;
+  return isAbsolute(config.projectDir) ? config.projectDir : join(ctx.projectDir, config.projectDir);
+}
+
+function gradleCommand(config: Config): string {
+  if (config.gradleCommand) return config.gradleCommand;
+  return process.platform === 'win32' ? 'gradlew.bat' : './gradlew';
+}
+
+function buildArgs(config: Config): string[] {
+  return [config.buildTask ?? 'buildPlugin', '--no-daemon'];
+}
+
+function publishArgs(config: Config, channel: string): string[] {
+  return [config.publishTask ?? 'publishPlugin', `-PpluginVersionChannel=${channel}`, '--no-daemon'];
+}
+
+function artifactPath(ctx: { projectDir: string; version: string }, config: Config): string {
+  if (config.artifactPath) {
+    return isAbsolute(config.artifactPath) ? config.artifactPath : join(pluginDir(ctx, config), config.artifactPath);
+  }
+  return join(pluginDir(ctx, config), 'build', 'distributions', `${config.pluginId}-${ctx.version}.zip`);
 }
 
 export default defineTarget<Config>({
@@ -10,16 +42,52 @@ export default defineTarget<Config>({
   kind: 'plugin',
   label: 'JetBrains Marketplace',
   async build(ctx, config) {
-    ctx.log(`build JetBrains plugin ${config.pluginId} v${ctx.version}`);
-    // TODO: run Gradle bundlePlugin / buildPlugin task to produce plugin zip
-    return { artifact: `${ctx.outDir}/plugin-${ctx.version}.zip` };
+    const cwd = pluginDir(ctx, config);
+    const command = gradleCommand(config);
+    const args = buildArgs(config);
+    const artifact = artifactPath(ctx, config);
+    ctx.log(`${command} ${args.join(' ')} (cwd=${cwd})`);
+
+    if (ctx.dryRun) {
+      const planPath = join(ctx.outDir, 'jetbrains-build-plan.json');
+      await mkdir(ctx.outDir, { recursive: true });
+      await writeFile(planPath, `${JSON.stringify({ cwd, command: [command, ...args], artifact }, null, 2)}\n`, 'utf-8');
+      return { artifact: planPath, meta: { command: [command, ...args], cwd, pluginArtifact: artifact } };
+    }
+
+    await exec(command, args, {
+      cwd,
+      env: ctx.env,
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+    return { artifact, meta: { command: [command, ...args], cwd } };
   },
   async ship(ctx, config) {
     const channel = config.channel ?? 'stable';
-    ctx.log(`upload JetBrains plugin ${config.pluginId}@${ctx.version} to channel: ${channel}`);
-    if (ctx.dryRun) return { id: 'dry-run' };
-    // TODO: POST zip to https://plugins.jetbrains.com/api/plugins/{pluginId}/upload
-    // Uses JETBRAINS_TOKEN from ctx.secret('JETBRAINS_TOKEN')
+    const cwd = pluginDir(ctx, config);
+    const command = gradleCommand(config);
+    const args = publishArgs(config, channel);
+    ctx.log(`${command} ${args.join(' ')} (cwd=${cwd})`);
+    if (ctx.dryRun) return { id: 'dry-run', meta: { command: [command, ...args], cwd } };
+
+    const token = ctx.secret('JETBRAINS_TOKEN');
+    if (!token) {
+      throw new Error('JETBRAINS_TOKEN not in vault. Run: sh1pt secret set JETBRAINS_TOKEN <token>');
+    }
+
+    await exec(command, args, {
+      cwd,
+      env: {
+        ...ctx.env,
+        JETBRAINS_TOKEN: token,
+        PUBLISH_TOKEN: token,
+        ORG_GRADLE_PROJECT_intellijPublishToken: token,
+      },
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+
     return {
       id: `${config.pluginId}@${ctx.version}`,
       url: `https://plugins.jetbrains.com/plugin/${config.pluginId}`,


### PR DESCRIPTION
## Summary- replace the `plugin-jetbrains` build/upload stub with Gradle build and publish command execution- add dry-run build plans that expose the Gradle command and expected plugin zip artifact- pass `JETBRAINS_TOKEN` through common Gradle/Marketplace environment keys during publish without committing secrets- add targeted coverage for dry-run build and publish behavior## Paid task- uGig task: https://ugig.net/gigs/134f0007-139c-4cb8-98eb-652b5846f9ab- GitHub task thread: #6## Validation- `corepack pnpm@9.12.0 exec vitest run packages/targets/plugin-jetbrains/src/index.test.ts`- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-target-plugin-jetbrains typecheck`- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-target-plugin-jetbrains build`- `git diff --check`