### PR TITLE
Implement Google Slides docs adapter

### DIFF
--- a/packages/docs/gslides/src/index.test.ts
+++ b/packages/docs/gslides/src/index.test.ts
@@ -1,4 +1,235 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { contractTestDocs } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
-smokeTest(adapter, { idPrefix: 'docs', requireSupports: true });
+contractTestDocs(adapter, {
+  sampleConfig: { templatePresentationId: 'template-123' },
+  sampleSpec: {
+    kind: 'pitch-deck',
+    title: 'Seed Deck',
+    format: 'pptx',
+    variables: { company: 'Acme' },
+  },
+});
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+const ctx = (
+  secrets: Record<string, string> = { GSLIDES_ACCESS_TOKEN: 'access-token' },
+  dryRun = false,
+) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('docs-gslides generation', () => {
+  it('copies a template, replaces text, exports the deck, and writes the file', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-gslides-'));
+    tempDirs.push(outDir);
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({
+        id: 'copy-123',
+        webViewLink: 'https://docs.google.com/presentation/d/copy-123/edit',
+      }))
+      .mockResolvedValueOnce(jsonResponse({ replies: [] }))
+      .mockResolvedValueOnce(binaryResponse('pptx bytes'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), {
+      kind: 'pitch-deck',
+      title: 'Seed Deck',
+      subtitle: 'Q2 fundraise',
+      author: 'sh1pt',
+      format: 'pptx',
+      markdown: '# Slide 1',
+      variables: { company: 'Acme', tagline: 'Ship faster' },
+      templateId: 'template-123',
+    }, {
+      folderId: 'folder-456',
+      outDir,
+    });
+
+    expect(result).toEqual({
+      id: 'copy-123',
+      format: 'pptx',
+      url: 'https://docs.google.com/presentation/d/copy-123/edit',
+      localPath: join(outDir, 'pitch-deck.pptx'),
+    });
+    await expect(readFile(join(outDir, 'pitch-deck.pptx'), 'utf-8')).resolves.toBe('pptx bytes');
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const [copyUrl, copyRequest] = fetchMock.mock.calls[0]!;
+    expect(copyUrl).toBe('https://www.googleapis.com/drive/v3/files/template-123/copy?supportsAllDrives=true&fields=id%2CwebViewLink');
+    expect(copyRequest).toMatchObject({
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer access-token',
+        'content-type': 'application/json',
+      },
+    });
+    expect(JSON.parse(String(copyRequest.body))).toEqual({
+      name: 'Seed Deck',
+      parents: ['folder-456'],
+    });
+
+    const [batchUrl, batchRequest] = fetchMock.mock.calls[1]!;
+    expect(batchUrl).toBe('https://slides.googleapis.com/v1/presentations/copy-123:batchUpdate');
+    expect(batchRequest).toMatchObject({
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer access-token',
+        'content-type': 'application/json',
+      },
+    });
+    expect(JSON.parse(String(batchRequest.body))).toEqual({
+      requests: [
+        replaceRequest('title', 'Seed Deck'),
+        replaceRequest('subtitle', 'Q2 fundraise'),
+        replaceRequest('author', 'sh1pt'),
+        replaceRequest('markdown', '# Slide 1'),
+        replaceRequest('body', '# Slide 1'),
+        replaceRequest('company', 'Acme'),
+        replaceRequest('tagline', 'Ship faster'),
+      ],
+    });
+
+    const [exportUrl, exportRequest] = fetchMock.mock.calls[2]!;
+    expect(exportUrl).toBe(
+      'https://www.googleapis.com/drive/v3/files/copy-123/export?mimeType=application%2Fvnd.openxmlformats-officedocument.presentationml.presentation',
+    );
+    expect(exportRequest.headers).toEqual({ authorization: 'Bearer access-token' });
+  });
+
+  it('exchanges a refresh token before calling Google APIs', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-gslides-refresh-'));
+    tempDirs.push(outDir);
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ access_token: 'fresh-access-token' }))
+      .mockResolvedValueOnce(jsonResponse({ id: 'copy-456' }))
+      .mockResolvedValueOnce(jsonResponse({ replies: [] }))
+      .mockResolvedValueOnce(binaryResponse('pdf bytes'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({
+      GSLIDES_REFRESH_TOKEN: 'refresh-token',
+      GSLIDES_CLIENT_ID: 'client-id',
+      GSLIDES_CLIENT_SECRET: 'client-secret',
+    }), {
+      kind: 'sales-deck',
+      title: 'Sales Deck',
+      format: 'pdf',
+    }, {
+      templatePresentationId: 'template-456',
+      outDir,
+      tokenUrl: 'https://oauth.example.test/token',
+    });
+
+    expect(result).toMatchObject({
+      id: 'copy-456',
+      format: 'pdf',
+      localPath: join(outDir, 'sales-deck.pdf'),
+    });
+    await expect(readFile(join(outDir, 'sales-deck.pdf'), 'utf-8')).resolves.toBe('pdf bytes');
+
+    const [tokenUrl, tokenRequest] = fetchMock.mock.calls[0]!;
+    expect(tokenUrl).toBe('https://oauth.example.test/token');
+    expect(tokenRequest).toMatchObject({
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+    });
+    expect(String(tokenRequest.body)).toBe(
+      'grant_type=refresh_token&refresh_token=refresh-token&client_id=client-id&client_secret=client-secret',
+    );
+    expect(fetchMock.mock.calls[1]?.[1].headers.authorization).toBe('Bearer fresh-access-token');
+  });
+
+  it('supports exporting an existing presentation with convert()', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-gslides-convert-'));
+    tempDirs.push(outDir);
+    const fetchMock = vi.fn().mockResolvedValue(binaryResponse('html zip'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.convert?.(ctx(), 'presentation-789', 'html', { outDir });
+
+    expect(result).toEqual({
+      id: 'presentation-789',
+      format: 'html',
+      url: 'https://docs.google.com/presentation/d/presentation-789/edit',
+      localPath: join(outDir, 'presentation-789.zip'),
+    });
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      'https://www.googleapis.com/drive/v3/files/presentation-789/export?mimeType=application%2Fzip',
+    );
+    await expect(readFile(join(outDir, 'presentation-789.zip'), 'utf-8')).resolves.toBe('html zip');
+  });
+
+  it('reports missing Google credentials before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(adapter.generate(ctx({}, false), {
+      kind: 'pitch-deck',
+      title: 'Seed Deck',
+      format: 'pdf',
+      templateId: 'template-123',
+    }, {})).rejects.toThrow('GSLIDES_ACCESS_TOKEN or GSLIDES_REFRESH_TOKEN');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('redacts access tokens from Google API errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: async () => 'access-token cannot copy this file',
+    }));
+
+    await expect(adapter.generate(ctx(), {
+      kind: 'pitch-deck',
+      title: 'Seed Deck',
+      format: 'pdf',
+      templateId: 'template-123',
+    }, {})).rejects.toThrow('Google Drive copy 403: [redacted] cannot copy this file');
+  });
+});
+
+function replaceRequest(key: string, value: string): object {
+  return {
+    replaceAllText: {
+      containsText: { text: `{{${key}}}`, matchCase: true },
+      replaceText: value,
+    },
+  };
+}
+
+function jsonResponse(data: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => data,
+    text: async () => JSON.stringify(data),
+  } as Response;
+}
+
+function binaryResponse(data: string): Response {
+  const bytes = new TextEncoder().encode(data);
+  return {
+    ok: true,
+    status: 200,
+    arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+    text: async () => data,
+  } as Response;
+}

--- a/packages/docs/gslides/src/index.ts
+++ b/packages/docs/gslides/src/index.ts
@@ -1,13 +1,30 @@
-import { defineDocs, oauthSetup } from '@profullstack/sh1pt-core';
+import { defineDocs, oauthSetup, type DocFormat } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
-// Google Slides — the practical way to generate a real editable .pptx.
-// Flow: copy a template presentation → batchUpdate with
-// replaceAllText (for variables) + insertImage (for screenshots) →
-// export as .pptx or .pdf via Drive API.
+// Google Slides: copy a template deck, merge {{variables}} through the
+// Slides API, then export the generated presentation through Drive.
 interface Config {
-  templatePresentationId?: string;  // copy this deck; users can maintain templates in their own Drive
-  folderId?: string;                // where to store the generated copies
+  templatePresentationId?: string;
+  folderId?: string;
+  outDir?: string;
+  driveBaseUrl?: string;
+  slidesBaseUrl?: string;
+  tokenUrl?: string;
 }
+
+const DEFAULT_DRIVE_BASE = 'https://www.googleapis.com/drive/v3';
+const DEFAULT_SLIDES_BASE = 'https://slides.googleapis.com/v1';
+const DEFAULT_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+
+const EXPORTS: Partial<Record<DocFormat, { mimeType: string; extension: string }>> = {
+  pdf: { mimeType: 'application/pdf', extension: 'pdf' },
+  pptx: {
+    mimeType: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    extension: 'pptx',
+  },
+  html: { mimeType: 'application/zip', extension: 'zip' },
+};
 
 export default defineDocs<Config>({
   id: 'docs-gslides',
@@ -15,34 +32,246 @@ export default defineDocs<Config>({
   supports: ['pptx', 'pdf', 'html'],
 
   async generate(ctx, spec, config) {
-    if (!ctx.secret('GOOGLE_OAUTH_REFRESH_TOKEN')) {
-      throw new Error('GOOGLE_OAUTH_REFRESH_TOKEN not in vault (sh1pt login google)');
-    }
     const templateId = spec.templateId ?? config.templatePresentationId;
     if (!templateId) {
-      throw new Error('docs-gslides needs a templateId — copy a Google Slides deck, share with sh1pt, pass its ID');
+      throw new Error('docs-gslides needs a templateId: copy a Google Slides deck, share it with sh1pt, and pass its ID');
     }
-    ctx.log(`gslides · copy template ${templateId} · replace ${Object.keys(spec.variables ?? {}).length} vars`);
-    if (ctx.dryRun) return { id: 'dry-run', format: spec.format, url: 'https://docs.google.com/presentation/d/stub' };
-    // TODO:
-    //   1. drive.files.copy(templateId) → new presentationId
-    //   2. slides.presentations.batchUpdate({
-    //        requests: [ { replaceAllText: { containsText: '{{var}}', replaceText: value } },
-    //                    { insertImage: { url: assets.screenshots[i], ... } } ]
-    //      })
-    //   3. drive.files.export(presentationId, mimeType=spec.format) → buffer
-    return { id: `gslides_${Date.now()}`, format: spec.format, url: 'https://docs.google.com/presentation/d/stub' };
+    ensureSupported(spec.format);
+    ensureGoogleCredential(ctx);
+
+    const outputPath = outputFile(spec.kind, spec.format, config);
+    const variables = mergeVariables(spec);
+    ctx.log(`gslides - copy template ${templateId} - replace ${Object.keys(variables).length} vars`);
+    if (ctx.dryRun) {
+      return {
+        id: 'dry-run',
+        format: spec.format,
+        url: 'https://docs.google.com/presentation/d/stub',
+        localPath: outputPath,
+      };
+    }
+
+    const token = await accessToken(ctx, config);
+    const copied = await copyTemplate(token, templateId, spec.title, config);
+    await replaceText(token, copied.id, variables, config);
+    await exportPresentation(token, copied.id, spec.format, outputPath, config);
+
+    return {
+      id: copied.id,
+      format: spec.format,
+      url: copied.webViewLink ?? `https://docs.google.com/presentation/d/${copied.id}/edit`,
+      localPath: outputPath,
+    };
+  },
+
+  async convert(ctx, sourceId, to, config) {
+    ensureSupported(to);
+    ensureGoogleCredential(ctx);
+
+    const outputPath = outputFile(sourceId, to, config);
+    if (ctx.dryRun) return { id: sourceId, format: to, localPath: outputPath };
+
+    const token = await accessToken(ctx, config);
+    await exportPresentation(token, sourceId, to, outputPath, config);
+    return {
+      id: sourceId,
+      format: to,
+      url: `https://docs.google.com/presentation/d/${sourceId}/edit`,
+      localPath: outputPath,
+    };
   },
 
   setup: oauthSetup({
-    secretKey: "GSLIDES_REFRESH_TOKEN",
-    label: "Google Slides",
-    vendorDocUrl: "https://console.cloud.google.com/apis/credentials",
+    secretKey: 'GSLIDES_ACCESS_TOKEN',
+    label: 'Google Slides',
+    vendorDocUrl: 'https://console.cloud.google.com/apis/credentials',
     steps: [
-      "console.cloud.google.com \u2192 APIs \u2192 enable Google Slides API + Google Drive API",
-      "Create OAuth 2.0 Client credentials (Desktop type)",
-      "Complete OAuth with scopes: presentations drive.file",
-      "Paste the refresh token when prompted",
+      'Enable Google Slides API and Google Drive API in Google Cloud',
+      'Create OAuth 2.0 Client credentials (Desktop type)',
+      'Store client ID with `sh1pt secret set GSLIDES_CLIENT_ID <client-id>`',
+      'If Google issued a client secret, store it with `sh1pt secret set GSLIDES_CLIENT_SECRET <client-secret>`',
+      'Store a refresh token with `sh1pt secret set GSLIDES_REFRESH_TOKEN <refresh-token>`, or paste a short-lived access token when prompted',
     ],
+    loopback: process.env.SH1PT_GSLIDES_CLIENT_ID
+      ? {
+          clientId: process.env.SH1PT_GSLIDES_CLIENT_ID,
+          authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+          tokenUrl: DEFAULT_TOKEN_URL,
+          scopes: [
+            'https://www.googleapis.com/auth/presentations',
+            'https://www.googleapis.com/auth/drive.file',
+          ],
+          refreshSecretKey: 'GSLIDES_REFRESH_TOKEN',
+          extraAuthParams: { access_type: 'offline', prompt: 'consent' },
+        }
+      : undefined,
   }),
 });
+
+interface DriveCopyResponse {
+  id?: string;
+  webViewLink?: string;
+}
+
+interface TokenResponse {
+  access_token?: string;
+}
+
+type TextVariables = Record<string, string>;
+
+function ensureGoogleCredential(ctx: { secret(k: string): string | undefined }): void {
+  if (ctx.secret('GSLIDES_ACCESS_TOKEN') || ctx.secret('GOOGLE_OAUTH_ACCESS_TOKEN')) return;
+  if (ctx.secret('GSLIDES_REFRESH_TOKEN') || ctx.secret('GOOGLE_OAUTH_REFRESH_TOKEN')) return;
+  throw new Error('GSLIDES_ACCESS_TOKEN or GSLIDES_REFRESH_TOKEN not in vault');
+}
+
+async function accessToken(ctx: { secret(k: string): string | undefined }, config: Config): Promise<string> {
+  const existing = ctx.secret('GSLIDES_ACCESS_TOKEN') ?? ctx.secret('GOOGLE_OAUTH_ACCESS_TOKEN');
+  if (existing) return existing;
+
+  const refreshToken = ctx.secret('GSLIDES_REFRESH_TOKEN') ?? ctx.secret('GOOGLE_OAUTH_REFRESH_TOKEN');
+  if (!refreshToken) throw new Error('GSLIDES_REFRESH_TOKEN not in vault');
+
+  const clientId = ctx.secret('GSLIDES_CLIENT_ID') ?? ctx.secret('GOOGLE_OAUTH_CLIENT_ID');
+  if (!clientId) throw new Error('GSLIDES_CLIENT_ID not in vault');
+
+  const clientSecret = ctx.secret('GSLIDES_CLIENT_SECRET') ?? ctx.secret('GOOGLE_OAUTH_CLIENT_SECRET');
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    client_id: clientId,
+  });
+  if (clientSecret) body.set('client_secret', clientSecret);
+
+  const res = await fetch(config.tokenUrl ?? DEFAULT_TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/x-www-form-urlencoded',
+    },
+    body,
+  });
+  if (!res.ok) {
+    throw new Error(`Google OAuth ${res.status}: ${redact(await res.text(), [refreshToken, clientId, clientSecret])}`);
+  }
+
+  const data = await res.json() as TokenResponse;
+  if (!data.access_token) throw new Error('Google OAuth response missing access_token');
+  return data.access_token;
+}
+
+async function copyTemplate(
+  token: string,
+  templateId: string,
+  title: string,
+  config: Config,
+): Promise<{ id: string; webViewLink?: string }> {
+  const url = new URL(`${baseUrl(config.driveBaseUrl ?? DEFAULT_DRIVE_BASE)}/files/${encodeURIComponent(templateId)}/copy`);
+  url.searchParams.set('supportsAllDrives', 'true');
+  url.searchParams.set('fields', 'id,webViewLink');
+
+  const body = {
+    name: title,
+    ...(config.folderId ? { parents: [config.folderId] } : {}),
+  };
+
+  const res = await fetch(url.toString(), {
+    method: 'POST',
+    headers: googleJsonHeaders(token),
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`Google Drive copy ${res.status}: ${redact(await res.text(), [token])}`);
+
+  const data = await res.json() as DriveCopyResponse;
+  if (!data.id) throw new Error('Google Drive copy response missing id');
+  return { id: data.id, webViewLink: data.webViewLink };
+}
+
+async function replaceText(
+  token: string,
+  presentationId: string,
+  variables: TextVariables,
+  config: Config,
+): Promise<void> {
+  const requests = Object.entries(variables).map(([key, value]) => ({
+    replaceAllText: {
+      containsText: { text: `{{${key}}}`, matchCase: true },
+      replaceText: value,
+    },
+  }));
+  if (requests.length === 0) return;
+
+  const url = `${baseUrl(config.slidesBaseUrl ?? DEFAULT_SLIDES_BASE)}/presentations/${encodeURIComponent(presentationId)}:batchUpdate`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: googleJsonHeaders(token),
+    body: JSON.stringify({ requests }),
+  });
+  if (!res.ok) throw new Error(`Google Slides batchUpdate ${res.status}: ${redact(await res.text(), [token])}`);
+}
+
+async function exportPresentation(
+  token: string,
+  presentationId: string,
+  format: DocFormat,
+  outputPath: string,
+  config: Config,
+): Promise<void> {
+  const exportSpec = ensureSupported(format);
+  const url = new URL(`${baseUrl(config.driveBaseUrl ?? DEFAULT_DRIVE_BASE)}/files/${encodeURIComponent(presentationId)}/export`);
+  url.searchParams.set('mimeType', exportSpec.mimeType);
+
+  const res = await fetch(url.toString(), {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`Google Drive export ${res.status}: ${redact(await res.text(), [token])}`);
+
+  await mkdir(config.outDir ?? join('.', '.sh1pt', 'docs'), { recursive: true });
+  await writeFile(outputPath, Buffer.from(await res.arrayBuffer()));
+}
+
+function mergeVariables(spec: { title: string; subtitle?: string; author?: string; markdown?: string; variables?: TextVariables }): TextVariables {
+  return {
+    title: spec.title,
+    ...(spec.subtitle ? { subtitle: spec.subtitle } : {}),
+    ...(spec.author ? { author: spec.author } : {}),
+    ...(spec.markdown ? { markdown: spec.markdown, body: spec.markdown } : {}),
+    ...(spec.variables ?? {}),
+  };
+}
+
+function ensureSupported(format: DocFormat): { mimeType: string; extension: string } {
+  const exportSpec = EXPORTS[format];
+  if (!exportSpec) throw new Error(`docs-gslides cannot export ${format}`);
+  return exportSpec;
+}
+
+function outputFile(kindOrId: string, format: DocFormat, config: Config): string {
+  const exportSpec = ensureSupported(format);
+  const outDir = config.outDir ?? join('.', '.sh1pt', 'docs');
+  return join(outDir, `${safeName(kindOrId)}.${exportSpec.extension}`);
+}
+
+function googleJsonHeaders(token: string): Record<string, string> {
+  return {
+    authorization: `Bearer ${token}`,
+    'content-type': 'application/json',
+  };
+}
+
+function baseUrl(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+function safeName(value: string): string {
+  const name = value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  return name || 'presentation';
+}
+
+function redact(value: string, secrets: Array<string | undefined>): string {
+  let out = value;
+  for (const secret of secrets) {
+    if (secret) out = out.split(secret).join('[redacted]');
+  }
+  return out.slice(0, 200);
+}


### PR DESCRIPTION
## Summary
- replaces the Google Slides docs stub with a real Drive/Slides API flow
- supports template copy, {{variable}} replacement, PDF/PPTX/HTML export, and convert() for existing presentations
- adds access-token and refresh-token auth paths with token redaction on provider errors
- adds focused tests for request shape, token exchange, file export, convert(), missing credentials, and redacted errors

## Validation
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-docs-gslides typecheck`
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-docs-gslides build`
- `corepack pnpm@9.12.0 exec vitest run packages/docs/gslides/src/index.test.ts`
- `git diff --check`

I also ran `corepack pnpm@9.12.0 test`; this change's tests passed, but the full suite has unrelated existing Windows/local-tool failures in `packages/docs/pandoc/src/index.test.ts` (pandoc not on PATH) and `packages/targets/pkg-jsr/src/index.test.ts` (expects POSIX cwd while Windows returns backslashes).

No live Google credentials or production secrets were used; tests use mocked fetch responses only.

Refs #6