### PR TITLE
Implement Cloudflare Workers deploy target

### DIFF
--- a/packages/targets/deploy-workers/src/index.test.ts
+++ b/packages/targets/deploy-workers/src/index.test.ts
@@ -1,4 +1,171 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { exec } from '@profullstack/sh1pt-core';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
+vi.mock('@profullstack/sh1pt-core', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@profullstack/sh1pt-core')>()),
+  exec: vi.fn(),
+}));
+
 smokeTest(adapter, { idPrefix: 'deploy', requireKind: true });
+
+const tempDirs: string[] = [];
+const execMock = vi.mocked(exec);
+
+afterEach(async () => {
+  execMock.mockReset();
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Cloudflare Workers deployment target', () => {
+  it('writes a dry-run deploy plan with the resolved Wrangler command', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-workers-'));
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-project-'));
+    tempDirs.push(outDir, projectDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      projectDir,
+      version: '1.2.3',
+      channel: 'stable',
+    }) as any, {
+      name: 'api-worker',
+      accountId: 'account-123',
+      routes: ['api.example.com/*'],
+      compatibilityDate: '2026-05-21',
+      entrypoint: 'src/worker.ts',
+      configPath: 'wrangler.toml',
+    });
+
+    expect(result.artifact).toBe(join(outDir, 'workers-deploy.json'));
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan).toEqual({
+      provider: 'cloudflare-workers',
+      name: 'api-worker',
+      accountId: 'account-123',
+      env: 'production',
+      routes: ['api.example.com/*'],
+      compatibilityDate: '2026-05-21',
+      entrypoint: join(projectDir, 'src/worker.ts'),
+      configPath: join(projectDir, 'wrangler.toml'),
+      version: '1.2.3',
+      command: [
+        'npx',
+        '--yes',
+        'wrangler',
+        'deploy',
+        join(projectDir, 'src/worker.ts'),
+        '--name',
+        'api-worker',
+        '--env',
+        'production',
+        '--account-id',
+        'account-123',
+        '--compatibility-date',
+        '2026-05-21',
+        '--config',
+        join(projectDir, 'wrangler.toml'),
+        '--route',
+        'api.example.com/*',
+        '--dry-run',
+      ],
+    });
+  });
+
+  it('keeps dry-run shipping side-effect free', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      channel: 'beta',
+      dryRun: true,
+    }) as any, {
+      name: 'api-worker',
+      accountId: 'account-123',
+    })).resolves.toEqual({
+      id: 'dry-run',
+      meta: {
+        command: [
+          'npx',
+          '--yes',
+          'wrangler',
+          'deploy',
+          '--name',
+          'api-worker',
+          '--env',
+          'preview',
+          '--account-id',
+          'account-123',
+          '--dry-run',
+        ],
+      },
+    });
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  it('requires a Cloudflare API token for real deployments', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      dryRun: false,
+    }) as any, {
+      name: 'api-worker',
+      accountId: 'account-123',
+    })).rejects.toThrow('CLOUDFLARE_API_TOKEN not in vault');
+  });
+
+  it('runs Wrangler deploy with token env and parses the worker URL', async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-workers-project-'));
+    tempDirs.push(projectDir);
+    execMock.mockResolvedValue({
+      stdout: 'Uploaded api-worker\nhttps://api-worker.account-123.workers.dev\n',
+      stderr: '',
+      exitCode: 0,
+    });
+    const log = vi.fn();
+
+    const result = await adapter.ship(fakeShipContext({
+      projectDir,
+      version: '1.2.3',
+      channel: 'stable',
+      dryRun: false,
+      env: { EXISTING: '1' },
+      secret: (key: string) => key === 'CLOUDFLARE_API_TOKEN' ? 'cf-token' : undefined,
+      log,
+    }) as any, {
+      name: 'api-worker',
+      accountId: 'account-123',
+      env: 'prod',
+      routes: ['api.example.com/*', 'example.com/api/*'],
+      vars: { SERVICE_ENV: 'production' },
+    });
+
+    expect(execMock).toHaveBeenCalledWith('npx', [
+      '--yes',
+      'wrangler',
+      'deploy',
+      '--name',
+      'api-worker',
+      '--env',
+      'prod',
+      '--account-id',
+      'account-123',
+      '--route',
+      'api.example.com/*',
+      '--route',
+      'example.com/api/*',
+    ], {
+      cwd: projectDir,
+      env: {
+        EXISTING: '1',
+        CLOUDFLARE_API_TOKEN: 'cf-token',
+        SERVICE_ENV: 'production',
+      },
+      log,
+      throwOnNonZero: true,
+    });
+    expect(result).toEqual({
+      id: 'api-worker@1.2.3',
+      url: 'https://api-worker.account-123.workers.dev',
+    });
+  });
+});

--- a/packages/targets/deploy-workers/src/index.ts
+++ b/packages/targets/deploy-workers/src/index.ts
@@ -1,42 +1,119 @@
-import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { defineTarget, exec, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { isAbsolute, join } from 'node:path';
 
 interface Config {
-  name: string;                          // worker name
+  name: string;
   accountId: string;
-  routes?: string[];                     // custom routes
-  // 'production' | 'preview' env from wrangler.toml
+  routes?: string[];
   env?: string;
   compatibilityDate?: string;
+  entrypoint?: string;
+  configPath?: string;
+  vars?: Record<string, string>;
+}
+
+function workerEntry(ctx: { projectDir: string }, config: Config): string | undefined {
+  if (!config.entrypoint) return undefined;
+  return isAbsolute(config.entrypoint) ? config.entrypoint : join(ctx.projectDir, config.entrypoint);
+}
+
+function wranglerConfig(ctx: { projectDir: string }, config: Config): string | undefined {
+  if (!config.configPath) return undefined;
+  return isAbsolute(config.configPath) ? config.configPath : join(ctx.projectDir, config.configPath);
+}
+
+function deployEnv(ctx: { channel: string }, config: Config): string {
+  return config.env ?? (ctx.channel === 'stable' ? 'production' : 'preview');
+}
+
+function deployArgs(ctx: { channel: string; projectDir: string }, config: Config, opts: { dryRun?: boolean } = {}): string[] {
+  const args = ['--yes', 'wrangler', 'deploy'];
+  const entrypoint = workerEntry(ctx, config);
+  if (entrypoint) args.push(entrypoint);
+  args.push('--name', config.name);
+  args.push('--env', deployEnv(ctx, config));
+  if (config.accountId) args.push('--account-id', config.accountId);
+  if (config.compatibilityDate) args.push('--compatibility-date', config.compatibilityDate);
+  const configFile = wranglerConfig(ctx, config);
+  if (configFile) args.push('--config', configFile);
+  for (const route of config.routes ?? []) args.push('--route', route);
+  if (opts.dryRun) args.push('--dry-run');
+  return args;
+}
+
+function renderPlan(ctx: { channel: string; projectDir: string; version: string }, config: Config): string {
+  return `${JSON.stringify({
+    provider: 'cloudflare-workers',
+    name: config.name,
+    accountId: config.accountId,
+    env: deployEnv(ctx, config),
+    routes: config.routes ?? [],
+    compatibilityDate: config.compatibilityDate ?? null,
+    entrypoint: workerEntry(ctx, config) ?? null,
+    configPath: wranglerConfig(ctx, config) ?? null,
+    version: ctx.version,
+    command: ['npx', ...deployArgs(ctx, config, { dryRun: true })],
+  }, null, 2)}\n`;
+}
+
+function parseWorkerUrl(stdout: string): string | undefined {
+  return stdout.match(/https:\/\/[^\s]+\.workers\.dev[^\s]*/)?.[0]
+    ?? stdout.match(/https:\/\/[^\s]+/i)?.[0];
 }
 
 export default defineTarget<Config>({
   id: 'deploy-workers',
   kind: 'web',
   label: 'Cloudflare Workers',
-  async build(ctx) {
-    ctx.log(`wrangler deploy --dry-run`);
-    return { artifact: `${ctx.outDir}/worker-bundle` };
+  async build(ctx, config) {
+    const planPath = join(ctx.outDir, 'workers-deploy.json');
+    ctx.log(`wrangler deploy --dry-run - name=${config.name}`);
+    await mkdir(ctx.outDir, { recursive: true });
+    await writeFile(planPath, renderPlan(ctx, config), 'utf-8');
+    return { artifact: planPath };
   },
   async ship(ctx, config) {
-    const env = config.env ?? (ctx.channel === 'stable' ? 'production' : 'preview');
-    ctx.log(`wrangler deploy · name=${config.name} · env=${env}`);
-    if (ctx.dryRun) return { id: 'dry-run' };
-    // TODO: `wrangler deploy --env ${env}` with CF_API_TOKEN
+    const env = deployEnv(ctx, config);
+    ctx.log(`wrangler deploy - name=${config.name} - env=${env}`);
+    if (ctx.dryRun) {
+      return {
+        id: 'dry-run',
+        meta: { command: ['npx', ...deployArgs(ctx, config, { dryRun: true })] },
+      };
+    }
+
+    const token = ctx.secret('CLOUDFLARE_API_TOKEN');
+    if (!token) {
+      throw new Error('CLOUDFLARE_API_TOKEN not in vault - run: sh1pt secret set CLOUDFLARE_API_TOKEN <token>');
+    }
+
+    const result = await exec('npx', deployArgs(ctx, config), {
+      cwd: ctx.projectDir,
+      env: {
+        ...ctx.env,
+        CLOUDFLARE_API_TOKEN: token,
+        ...(config.vars ?? {}),
+      },
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+
     return {
       id: `${config.name}@${ctx.version}`,
-      url: `https://${config.name}.${config.accountId}.workers.dev`,
+      url: parseWorkerUrl(result.stdout) ?? `https://${config.name}.${config.accountId}.workers.dev`,
     };
   },
 
   setup: manualSetup({
-    label: "Cloudflare Workers",
-    vendorDocUrl: "https://dash.cloudflare.com/profile/api-tokens",
+    label: 'Cloudflare Workers',
+    vendorDocUrl: 'https://developers.cloudflare.com/workers/wrangler/',
     steps: [
-      "Install with mise: mise use npm:wrangler",
-      "Authenticate locally: wrangler login",
-      "Open dash.cloudflare.com \u2192 My Profile \u2192 API Tokens \u2192 Edit Cloudflare Workers template",
-      "Scope: Workers Scripts:Edit, Account:Read, Zone:Read",
-      "Run: sh1pt secret set CLOUDFLARE_API_TOKEN <token>",
+      'Install with mise: mise use npm:wrangler',
+      'Authenticate locally: wrangler login',
+      'Open dash.cloudflare.com -> My Profile -> API Tokens -> Edit Cloudflare Workers template',
+      'Scope: Workers Scripts:Edit, Account:Read, Zone:Read',
+      'Run: sh1pt secret set CLOUDFLARE_API_TOKEN <token>',
     ],
   }),
 });


### PR DESCRIPTION
## Summary
- replaces the Cloudflare Workers deploy stub with a real Wrangler-backed target
- writes an inspectable `workers-deploy.json` plan during build
- keeps dry-run shipping side-effect free and includes the exact Wrangler command
- runs real deploys through `npx wrangler deploy` with `CLOUDFLARE_API_TOKEN`, route/env/config/entrypoint options, and worker URL parsing
- adds focused tests for deploy plan generation, dry-run behavior, token requirements, CLI args, env wiring, and URL mapping

## Validation
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-target-deploy-workers typecheck`
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-target-deploy-workers build`
- `corepack pnpm@9.12.0 exec vitest run packages/targets/deploy-workers/src/index.test.ts`
- `git diff --check`

No live Cloudflare credentials or production secrets were used; tests mock the exec wrapper only.

Refs #6