### PR TITLE
Harden Perplexity AI adapter

### DIFF
--- a/packages/ai/perplexity/src/index.test.ts
+++ b/packages/ai/perplexity/src/index.test.ts
@@ -4,7 +4,7 @@ import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
 
-const ctx = (secrets: Record<string, string> = { PERPLEXITY_API_KEY: 'test-key' }, dryRun = false) => ({
+const ctx = (secrets: Record<string, string> = { PERPLEXITY_API_KEY: 'test-perplexity-key' }, dryRun = false) => ({
   secret: (key: string) => secrets[key],
   log: () => {},
   dryRun,
@@ -19,7 +19,7 @@ describe('Perplexity Sonar generation', () => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
 
-    const result = await adapter.generate(ctx({ PERPLEXITY_API_KEY: 'test-key' }, true), 'hello', {}, {});
+    const result = await adapter.generate(ctx({ PERPLEXITY_API_KEY: 'test-perplexity-key' }, true), 'hello', {}, {});
 
     expect(result).toEqual({ text: '[dry-run]', model: 'sonar-pro' });
     expect(fetchMock).not.toHaveBeenCalled();
@@ -42,14 +42,15 @@ describe('Perplexity Sonar generation', () => {
       maxTokens: 20,
       temperature: 0.2,
       extra: { search_recency_filter: 'month' },
-    }, {});
+    }, { baseUrl: 'https://perplexity.test/' });
 
     expect(fetchMock).toHaveBeenCalledOnce();
     const call = fetchMock.mock.calls[0];
     expect(call).toBeDefined();
     const [url, request] = call!;
-    expect(url).toBe('https://api.perplexity.ai/v1/sonar');
-    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(url).toBe('https://perplexity.test/v1/sonar');
+    expect(request.headers.authorization).toBe(['Bearer', 'test-perplexity-key'].join(' '));
+    expect(request.headers['content-type']).toBe('application/json');
     expect(JSON.parse(request.body)).toEqual({
       model: 'sonar',
       messages: [
@@ -68,13 +69,15 @@ describe('Perplexity Sonar generation', () => {
     });
   });
 
-  it('includes status and response body excerpt on errors', async () => {
+  it('redacts Perplexity keys from provider error excerpts', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: false,
       status: 429,
-      text: async () => 'rate limited'.repeat(30),
+      text: async () => 'rate limited for test-perplexity-key',
     }));
 
-    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/Perplexity 429: rate limited/);
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(
+      'Perplexity 429: rate limited for [redacted]',
+    );
   });
 });

--- a/packages/ai/perplexity/src/index.ts
+++ b/packages/ai/perplexity/src/index.ts
@@ -5,6 +5,7 @@ interface Config {
 }
 
 const DEFAULT_BASE = 'https://api.perplexity.ai';
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '');
 
 export default defineAi<Config>({
   id: 'ai-perplexity',
@@ -28,7 +29,8 @@ export default defineAi<Config>({
     if (opts.system) messages.push({ role: 'system', content: opts.system });
     messages.push({ role: 'user', content: prompt });
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/sonar`, {
+    const baseUrl = trimTrailingSlash(config.baseUrl ?? DEFAULT_BASE);
+    const res = await fetch(`${baseUrl}/v1/sonar`, {
       method: 'POST',
       headers: {
         authorization: `Bearer ${apiKey}`,
@@ -42,7 +44,7 @@ export default defineAi<Config>({
         ...opts.extra,
       }),
     });
-    if (!res.ok) throw new Error(`Perplexity ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    if (!res.ok) throw new Error(`Perplexity ${res.status}: ${redact((await res.text()).slice(0, 200), apiKey)}`);
     const data = (await res.json()) as {
       choices: Array<{ message?: { content?: string } }>;
       model: string;
@@ -67,3 +69,9 @@ export default defineAi<Config>({
     ],
   }),
 });
+
+function redact(value: string, apiKey: string): string {
+  return value
+    .replaceAll(apiKey, '[redacted]')
+    .replace(/pplx-[A-Za-z0-9._~+/=-]{12,}/g, '[redacted]');
+}


### PR DESCRIPTION
## Summary
- normalizes custom Perplexity base URLs so a trailing slash does not produce `//v1/sonar`
- redacts Perplexity API keys from provider error excerpts
- expands the focused Sonar tests to cover custom base URL handling, content-type headers, and redacted errors

## Validation
- `corepack pnpm@9.12.0 exec vitest run packages/ai/perplexity/src/index.test.ts`
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-ai-perplexity typecheck`
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-ai-perplexity build`
- `git diff --check`

No live Perplexity credentials or production secrets were used; tests mock `fetch` only.

Refs #6