### PR TITLE
Harden DeepInfra AI adapter

### DIFF
--- a/packages/ai/deepinfra/src/index.test.ts
+++ b/packages/ai/deepinfra/src/index.test.ts
@@ -4,7 +4,7 @@ import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
 
-const ctx = (secrets: Record<string, string> = { DEEPINFRA_API_KEY: 'test-key' }, dryRun = false) => ({
+const ctx = (secrets: Record<string, string> = { DEEPINFRA_API_KEY: 'test-deepinfra-key' }, dryRun = false) => ({
   secret: (key: string) => secrets[key],
   log: () => {},
   dryRun,
@@ -19,7 +19,7 @@ describe('DeepInfra OpenAI-compatible generation', () => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
 
-    const result = await adapter.generate(ctx({ DEEPINFRA_API_KEY: 'test-key' }, true), 'hello', {}, {});
+    const result = await adapter.generate(ctx({ DEEPINFRA_API_KEY: 'test-deepinfra-key' }, true), 'hello', {}, {});
 
     expect(result).toEqual({ text: '[dry-run]', model: 'deepseek-ai/DeepSeek-V3' });
     expect(fetchMock).not.toHaveBeenCalled();
@@ -42,14 +42,15 @@ describe('DeepInfra OpenAI-compatible generation', () => {
       maxTokens: 20,
       temperature: 0.2,
       extra: { reasoning_effort: 'low' },
-    }, {});
+    }, { baseUrl: 'https://deepinfra.test/v1/openai/' });
 
     expect(fetchMock).toHaveBeenCalledOnce();
     const call = fetchMock.mock.calls[0];
     expect(call).toBeDefined();
     const [url, request] = call!;
-    expect(url).toBe('https://api.deepinfra.com/v1/openai/chat/completions');
-    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(url).toBe('https://deepinfra.test/v1/openai/chat/completions');
+    expect(request.headers.authorization).toBe(['Bearer', 'test-deepinfra-key'].join(' '));
+    expect(request.headers['content-type']).toBe('application/json');
     expect(JSON.parse(request.body)).toEqual({
       model: 'deepseek-ai/DeepSeek-R1',
       messages: [
@@ -68,13 +69,15 @@ describe('DeepInfra OpenAI-compatible generation', () => {
     });
   });
 
-  it('includes status and response body excerpt on errors', async () => {
+  it('redacts DeepInfra keys from provider error excerpts', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: false,
       status: 429,
-      text: async () => 'rate limited'.repeat(30),
+      text: async () => 'rate limited for test-deepinfra-key',
     }));
 
-    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/DeepInfra 429: rate limited/);
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(
+      'DeepInfra 429: rate limited for [redacted]',
+    );
   });
 });

--- a/packages/ai/deepinfra/src/index.ts
+++ b/packages/ai/deepinfra/src/index.ts
@@ -5,6 +5,7 @@ interface Config {
 }
 
 const DEFAULT_BASE = 'https://api.deepinfra.com/v1/openai';
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '');
 
 export default defineAi<Config>({
   id: 'ai-deepinfra',
@@ -28,7 +29,8 @@ export default defineAi<Config>({
     if (opts.system) messages.push({ role: 'system', content: opts.system });
     messages.push({ role: 'user', content: prompt });
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+    const baseUrl = trimTrailingSlash(config.baseUrl ?? DEFAULT_BASE);
+    const res = await fetch(`${baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         authorization: `Bearer ${apiKey}`,
@@ -42,7 +44,7 @@ export default defineAi<Config>({
         ...opts.extra,
       }),
     });
-    if (!res.ok) throw new Error(`DeepInfra ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    if (!res.ok) throw new Error(`DeepInfra ${res.status}: ${redact((await res.text()).slice(0, 200), apiKey)}`);
     const data = (await res.json()) as {
       choices: Array<{ message?: { content?: string } }>;
       model: string;
@@ -67,3 +69,7 @@ export default defineAi<Config>({
     ],
   }),
 });
+
+function redact(value: string, apiKey: string): string {
+  return value.replaceAll(apiKey, '[redacted]');
+}


### PR DESCRIPTION
## Summary
- normalizes custom DeepInfra base URLs so a trailing slash does not produce a double-slash chat-completions URL
- redacts DeepInfra API keys from provider error excerpts
- expands the focused adapter tests to cover custom base URL handling, content-type headers, and redacted errors

## Validation
- `corepack pnpm@9.12.0 exec vitest run packages/ai/deepinfra/src/index.test.ts`
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-ai-deepinfra typecheck`
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-ai-deepinfra build`
- `git diff --check`

No live DeepInfra credentials or production secrets were used; tests mock `fetch` only.

Refs #6