### PR TITLE
Harden compatible AI adapters

### DIFF
--- a/packages/ai/friendli/src/index.test.ts
+++ b/packages/ai/friendli/src/index.test.ts
@@ -1,4 +1,80 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { FRIENDLI_TOKEN: 'test-friendli-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Friendli chat completions generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ FRIENDLI_TOKEN: 'test-friendli-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'meta-llama/Llama-3.1-8B-Instruct' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from friendli' } }],
+        model: 'meta-llama/Llama-3.1-8B-Instruct',
+        usage: { prompt_tokens: 7, completion_tokens: 4 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      system: 'be brief',
+      maxTokens: 32,
+      temperature: 0.3,
+      extra: { top_p: 0.8 },
+    }, { baseUrl: 'https://friendli.test/serverless/' });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, request] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://friendli.test/serverless/v1/chat/completions');
+    expect(request.headers.authorization).toBe(['Bearer', 'test-friendli-key'].join(' '));
+    expect(request.headers['content-type']).toBe('application/json');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'meta-llama/Llama-3.1-8B-Instruct',
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 32,
+      temperature: 0.3,
+      top_p: 0.8,
+    });
+    expect(result).toEqual({
+      text: 'hi from friendli',
+      model: 'meta-llama/Llama-3.1-8B-Instruct',
+      inputTokens: 7,
+      outputTokens: 4,
+    });
+  });
+
+  it('redacts Friendli tokens from provider error excerpts', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => 'bad token test-friendli-key',
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(
+      'Friendli 401: bad token [redacted]',
+    );
+  });
+});

--- a/packages/ai/friendli/src/index.ts
+++ b/packages/ai/friendli/src/index.ts
@@ -5,6 +5,7 @@ interface Config {
 }
 
 const DEFAULT_BASE = 'https://api.friendli.ai/serverless';
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '');
 
 export default defineAi<Config>({
   id: 'ai-friendli',
@@ -23,7 +24,8 @@ export default defineAi<Config>({
     if (opts.system) messages.push({ role: 'system', content: opts.system });
     messages.push({ role: 'user', content: prompt });
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/chat/completions`, {
+    const baseUrl = trimTrailingSlash(config.baseUrl ?? DEFAULT_BASE);
+    const res = await fetch(`${baseUrl}/v1/chat/completions`, {
       method: 'POST',
       headers: {
         authorization: `Bearer ${apiKey}`,
@@ -37,7 +39,7 @@ export default defineAi<Config>({
         ...opts.extra,
       }),
     });
-    if (!res.ok) throw new Error(`Friendli ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    if (!res.ok) throw new Error(`Friendli ${res.status}: ${redact((await res.text()).slice(0, 200), apiKey)}`);
     const data = (await res.json()) as {
       choices: Array<{ message?: { content?: string } }>;
       model: string;
@@ -62,3 +64,7 @@ export default defineAi<Config>({
     ],
   }),
 });
+
+function redact(value: string, apiKey: string): string {
+  return value.replaceAll(apiKey, '[redacted]');
+}

--- a/packages/ai/gmicloud/src/index.test.ts
+++ b/packages/ai/gmicloud/src/index.test.ts
@@ -1,4 +1,80 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { GMI_API_KEY: 'test-gmi-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('GMICloud chat completions generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ GMI_API_KEY: 'test-gmi-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'deepseek-ai/DeepSeek-R1' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from gmi' } }],
+        model: 'deepseek-ai/DeepSeek-R1',
+        usage: { prompt_tokens: 10, completion_tokens: 6 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      system: 'be brief',
+      maxTokens: 24,
+      temperature: 0.2,
+      extra: { top_p: 0.7 },
+    }, { baseUrl: 'https://gmi.test/' });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, request] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://gmi.test/v1/chat/completions');
+    expect(request.headers.authorization).toBe(['Bearer', 'test-gmi-key'].join(' '));
+    expect(request.headers['content-type']).toBe('application/json');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'deepseek-ai/DeepSeek-R1',
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 24,
+      temperature: 0.2,
+      top_p: 0.7,
+    });
+    expect(result).toEqual({
+      text: 'hi from gmi',
+      model: 'deepseek-ai/DeepSeek-R1',
+      inputTokens: 10,
+      outputTokens: 6,
+    });
+  });
+
+  it('redacts GMICloud keys from provider error excerpts', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: async () => 'bad key test-gmi-key',
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(
+      'GMICloud 403: bad key [redacted]',
+    );
+  });
+});

--- a/packages/ai/gmicloud/src/index.ts
+++ b/packages/ai/gmicloud/src/index.ts
@@ -5,6 +5,7 @@ interface Config {
 }
 
 const DEFAULT_BASE = 'https://api.gmi-serving.com';
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '');
 
 export default defineAi<Config>({
   id: 'ai-gmicloud',
@@ -23,7 +24,8 @@ export default defineAi<Config>({
     if (opts.system) messages.push({ role: 'system', content: opts.system });
     messages.push({ role: 'user', content: prompt });
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/chat/completions`, {
+    const baseUrl = trimTrailingSlash(config.baseUrl ?? DEFAULT_BASE);
+    const res = await fetch(`${baseUrl}/v1/chat/completions`, {
       method: 'POST',
       headers: {
         authorization: `Bearer ${apiKey}`,
@@ -37,7 +39,7 @@ export default defineAi<Config>({
         ...opts.extra,
       }),
     });
-    if (!res.ok) throw new Error(`GMICloud ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    if (!res.ok) throw new Error(`GMICloud ${res.status}: ${redact((await res.text()).slice(0, 200), apiKey)}`);
     const data = (await res.json()) as {
       choices: Array<{ message?: { content?: string } }>;
       model: string;
@@ -62,3 +64,7 @@ export default defineAi<Config>({
     ],
   }),
 });
+
+function redact(value: string, apiKey: string): string {
+  return value.replaceAll(apiKey, '[redacted]');
+}

--- a/packages/ai/qwen/src/index.test.ts
+++ b/packages/ai/qwen/src/index.test.ts
@@ -1,4 +1,81 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { DASHSCOPE_API_KEY: 'test-dashscope-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Qwen DashScope compatible-mode generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ DASHSCOPE_API_KEY: 'test-dashscope-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'qwen-max' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts compatible-mode requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from qwen' } }],
+        model: 'qwen-plus',
+        usage: { prompt_tokens: 9, completion_tokens: 5 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'qwen-plus',
+      system: 'be brief',
+      maxTokens: 40,
+      temperature: 0.4,
+      extra: { enable_search: true },
+    }, { baseUrl: 'https://dashscope.test/' });
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, request] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://dashscope.test/compatible-mode/v1/chat/completions');
+    expect(request.headers.authorization).toBe(['Bearer', 'test-dashscope-key'].join(' '));
+    expect(request.headers['content-type']).toBe('application/json');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'qwen-plus',
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 40,
+      temperature: 0.4,
+      enable_search: true,
+    });
+    expect(result).toEqual({
+      text: 'hi from qwen',
+      model: 'qwen-plus',
+      inputTokens: 9,
+      outputTokens: 5,
+    });
+  });
+
+  it('redacts DashScope keys from provider error excerpts', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => 'bad key test-dashscope-key',
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(
+      'DashScope 401: bad key [redacted]',
+    );
+  });
+});

--- a/packages/ai/qwen/src/index.ts
+++ b/packages/ai/qwen/src/index.ts
@@ -9,6 +9,7 @@ interface Config {
 }
 
 const DEFAULT_BASE = 'https://dashscope-intl.aliyuncs.com';
+const trimTrailingSlash = (value: string) => value.replace(/\/+$/, '');
 
 export default defineAi<Config>({
   id: 'ai-qwen',
@@ -27,7 +28,8 @@ export default defineAi<Config>({
     if (opts.system) messages.push({ role: 'system', content: opts.system });
     messages.push({ role: 'user', content: prompt });
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/compatible-mode/v1/chat/completions`, {
+    const baseUrl = trimTrailingSlash(config.baseUrl ?? DEFAULT_BASE);
+    const res = await fetch(`${baseUrl}/compatible-mode/v1/chat/completions`, {
       method: 'POST',
       headers: {
         authorization: `Bearer ${apiKey}`,
@@ -41,7 +43,7 @@ export default defineAi<Config>({
         ...opts.extra,
       }),
     });
-    if (!res.ok) throw new Error(`DashScope ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    if (!res.ok) throw new Error(`DashScope ${res.status}: ${redact((await res.text()).slice(0, 200), apiKey)}`);
     const data = (await res.json()) as {
       choices: Array<{ message?: { content?: string } }>;
       model: string;
@@ -66,3 +68,7 @@ export default defineAi<Config>({
     ],
   }),
 });
+
+function redact(value: string, apiKey: string): string {
+  return value.replaceAll(apiKey, '[redacted]');
+}


### PR DESCRIPTION
## Summary
- hardens the Friendli, GMICloud, and Qwen AI adapters with normalized custom base URLs
- redacts provider API keys from error excerpts before surfacing failures
- replaces smoke-only coverage with mocked request/response tests for dry-run behavior, request headers/body, token usage mapping, and redacted errors

## Validation
- `corepack pnpm@9.12.0 exec vitest run packages/ai/friendli/src/index.test.ts packages/ai/gmicloud/src/index.test.ts packages/ai/qwen/src/index.test.ts`
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-ai-friendli --filter @profullstack/sh1pt-ai-gmicloud --filter @profullstack/sh1pt-ai-qwen typecheck`
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-ai-friendli --filter @profullstack/sh1pt-ai-gmicloud --filter @profullstack/sh1pt-ai-qwen build`
- `git diff --check`

No live provider credentials or production secrets were used; tests mock `fetch` only.

Refs #6