### PR TITLE
Add cloud and merch contract coverage

### DIFF
--- a/packages/cloud/firebase/src/index.test.ts
+++ b/packages/cloud/firebase/src/index.test.ts
@@ -1,4 +1,10 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { contractTestCloud, smokeTest } from '@profullstack/sh1pt-core/testing';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'cloud', requireSupports: true });
+
+contractTestCloud(adapter, {
+  sampleConfig: { projectId: 'demo-project' },
+  sampleSpec: { kind: 'managed-db', region: 'us-central1' },
+  requiredSecrets: ['FIREBASE_TOKEN'],
+});

--- a/packages/cloud/nvidia/src/index.test.ts
+++ b/packages/cloud/nvidia/src/index.test.ts
@@ -1,4 +1,20 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { contractTestCloud, fakeConnectContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'cloud', requireSupports: true });
+
+contractTestCloud(adapter, {
+  sampleConfig: { product: 'dgx-lepton', orgId: 'demo-org' },
+  sampleSpec: { kind: 'gpu', gpu: { model: 'H100', count: 1 }, maxHourlyPrice: 10 },
+  requiredSecrets: ['NGC_API_KEY'],
+});
+
+describe('NVIDIA cloud connection modes', () => {
+  it('allows API Catalog connection without an NGC key', async () => {
+    await expect(adapter.connect(fakeConnectContext() as any, {
+      product: 'api-catalog',
+      apiCatalog: { model: 'meta/llama-3.1-70b-instruct' },
+    })).resolves.toEqual({ accountId: 'nvidia' });
+  });
+});

--- a/packages/cloud/nvidia/src/index.ts
+++ b/packages/cloud/nvidia/src/index.ts
@@ -64,7 +64,7 @@ export default defineCloud<Config>({
   },
 
   setup: tokenSetup({
-    secretKey: 'NVIDIA_API_KEY',
+    secretKey: 'NGC_API_KEY',
     label: 'NVIDIA (build.nvidia.com)',
     vendorDocUrl: 'https://build.nvidia.com/',
     steps: [

--- a/packages/cloud/supabase/src/index.test.ts
+++ b/packages/cloud/supabase/src/index.test.ts
@@ -1,4 +1,10 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { contractTestCloud, smokeTest } from '@profullstack/sh1pt-core/testing';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'cloud', requireSupports: true });
+
+contractTestCloud(adapter, {
+  sampleConfig: { projectRef: 'abcdefghijklmnopqrst', orgId: 'demo-org', region: 'us-east-1' },
+  sampleSpec: { kind: 'managed-db', region: 'us-east-1' },
+  requiredSecrets: ['SUPABASE_ACCESS_TOKEN'],
+});

--- a/packages/merch/printify/src/index.test.ts
+++ b/packages/merch/printify/src/index.test.ts
@@ -1,4 +1,17 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { contractTestMerch, smokeTest } from '@profullstack/sh1pt-core/testing';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'merch', requireSupports: true });
+
+contractTestMerch(adapter, {
+  sampleConfig: { shopId: 12345, preferredPrintProvider: 678 },
+  sampleProduct: {
+    kind: 'tshirt',
+    title: 'Test shirt',
+    designs: [{ file: '/tmp/logo.png' }],
+    colors: ['black'],
+    sizes: ['M'],
+    retailPrice: 25,
+  },
+  requiredSecrets: ['PRINTIFY_TOKEN'],
+});

--- a/packages/merch/printify/src/index.ts
+++ b/packages/merch/printify/src/index.ts
@@ -24,7 +24,9 @@ export default defineMerch<Config>({
   ],
 
   async connect(ctx) {
-    if (!ctx.secret('PRINTIFY_TOKEN')) throw new Error('PRINTIFY_TOKEN not set');
+    if (!ctx.secret('PRINTIFY_TOKEN')) {
+      throw new Error('PRINTIFY_TOKEN not in vault — run `sh1pt secret set PRINTIFY_TOKEN <token>`');
+    }
     return { accountId: 'printify' };
   },
 


### PR DESCRIPTION
## Summary
- adds contract coverage for Firebase, NVIDIA, Supabase, and Printify adapters
- aligns NVIDIA setup with the runtime-required `NGC_API_KEY` secret
- gives Printify missing-token failures the standard vault hint format

## Validation
- `corepack pnpm@9.12.0 exec vitest run packages/cloud/firebase/src/index.test.ts packages/cloud/nvidia/src/index.test.ts packages/cloud/supabase/src/index.test.ts packages/merch/printify/src/index.test.ts`
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-cloud-firebase --filter @profullstack/sh1pt-cloud-nvidia --filter @profullstack/sh1pt-cloud-supabase --filter @profullstack/sh1pt-merch-printify typecheck`
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-cloud-firebase --filter @profullstack/sh1pt-cloud-nvidia --filter @profullstack/sh1pt-cloud-supabase --filter @profullstack/sh1pt-merch-printify build`
- `git diff --check`

No live provider credentials or production secrets were used.

Refs #6