### PR TITLE
Add inspectable desktop and chat target plans

### DIFF
--- a/packages/targets/chat-signal/src/index.test.ts
+++ b/packages/targets/chat-signal/src/index.test.ts
@@ -1,4 +1,41 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { contractTestTarget, fakeBuildContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'chat', requireKind: true });
+
+const sampleConfig = {
+  phoneNumber: '+14155551234',
+  runtime: 'signal-cli' as const,
+  captchaToken: 'test-captcha-token',
+  deviceName: 'sh1pt-test',
+};
+
+contractTestTarget(adapter, { sampleConfig });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Signal target planning', () => {
+  it('writes an inspectable runtime plan without storing the captcha token', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-signal-'));
+    tempDirs.push(outDir);
+
+    const result = await adapter.build(fakeBuildContext({ outDir }) as any, sampleConfig);
+    expect(result.artifact).toBe(join(outDir, 'signal-runtime', 'signal-runtime-plan.json'));
+
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan).toEqual({
+      phoneNumber: '+14155551234',
+      runtime: 'signal-cli',
+      deviceName: 'sh1pt-test',
+      captchaTokenPresent: true,
+    });
+  });
+});

--- a/packages/targets/chat-signal/src/index.ts
+++ b/packages/targets/chat-signal/src/index.ts
@@ -1,4 +1,6 @@
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 // Signal has no official bot platform and no app directory. Bots are
 // built by running `signal-cli` (or the `signald` daemon) as a registered
@@ -23,8 +25,16 @@ export default defineTarget<Config>({
   label: 'Signal (signal-cli / signald)',
   async build(ctx, config) {
     ctx.log(`prepare ${config.runtime} config for ${config.phoneNumber}`);
-    // TODO: render signal-cli / signald config + dockerfile to ctx.outDir
-    return { artifact: `${ctx.outDir}/signal-runtime/` };
+    const artifactDir = join(ctx.outDir, 'signal-runtime');
+    const planPath = join(artifactDir, 'signal-runtime-plan.json');
+    await mkdir(artifactDir, { recursive: true });
+    await writeFile(planPath, `${JSON.stringify({
+      phoneNumber: config.phoneNumber,
+      runtime: config.runtime,
+      deviceName: config.deviceName,
+      captchaTokenPresent: !!config.captchaToken,
+    }, null, 2)}\n`, 'utf-8');
+    return { artifact: planPath };
   },
   async ship(ctx, config) {
     ctx.log(`register Signal number ${config.phoneNumber} (${config.runtime})`);

--- a/packages/targets/console-steam/src/index.test.ts
+++ b/packages/targets/console-steam/src/index.test.ts
@@ -1,4 +1,44 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { contractTestTarget, fakeBuildContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'console', requireKind: true });
+
+const sampleConfig = {
+  steamAppId: 123456,
+  depotIds: [
+    { platform: 'linux' as const, depotId: 123457 },
+    { platform: 'windows' as const, depotId: 123458 },
+  ],
+  branch: 'beta',
+  binariesDir: '/tmp/builds',
+  submitDeckVerification: true,
+};
+
+contractTestTarget(adapter, { sampleConfig });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Steam target planning', () => {
+  it('writes an inspectable Steam depot build plan', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-steam-'));
+    tempDirs.push(outDir);
+
+    const result = await adapter.build(fakeBuildContext({ outDir }) as any, sampleConfig);
+    expect(result.artifact).toBe(join(outDir, 'steam', 'steam-build-plan.json'));
+
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan.steamAppId).toBe(123456);
+    expect(plan.depotIds).toEqual(sampleConfig.depotIds);
+    expect(plan.branch).toBe('beta');
+    expect(plan.binariesDir).toBe('/tmp/builds');
+    expect(plan.submitDeckVerification).toBe(true);
+  });
+});

--- a/packages/targets/console-steam/src/index.ts
+++ b/packages/targets/console-steam/src/index.ts
@@ -1,4 +1,6 @@
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 // Steam — desktop (Windows/macOS/Linux) and Steam Deck (SteamOS).
 // The Deck is Arch-based Linux; apps run natively on Linux or through
@@ -20,8 +22,17 @@ export default defineTarget<Config>({
   async build(ctx, config) {
     const platforms = config.depotIds.map((d) => d.platform).join(',');
     ctx.log(`prepare Steam depots · platforms=${platforms}`);
-    // TODO: generate app_build.vdf + per-depot depot_build_*.vdf referencing config.binariesDir
-    return { artifact: config.binariesDir };
+    const artifactDir = join(ctx.outDir, 'steam');
+    const planPath = join(artifactDir, 'steam-build-plan.json');
+    await mkdir(artifactDir, { recursive: true });
+    await writeFile(planPath, `${JSON.stringify({
+      steamAppId: config.steamAppId,
+      depotIds: config.depotIds,
+      branch: config.branch,
+      binariesDir: config.binariesDir,
+      submitDeckVerification: !!config.submitDeckVerification,
+    }, null, 2)}\n`, 'utf-8');
+    return { artifact: planPath };
   },
   async ship(ctx, config) {
     ctx.log(`steamcmd run_app_build · app=${config.steamAppId} · branch=${config.branch}`);

--- a/packages/targets/desktop-linux/src/index.test.ts
+++ b/packages/targets/desktop-linux/src/index.test.ts
@@ -1,4 +1,51 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { contractTestTarget, fakeBuildContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'desktop', requireKind: true });
+
+const sampleConfig = {
+  appId: 'com.acme.app',
+  formats: ['appimage' as const, 'flatpak' as const, 'deb' as const],
+  architectures: ['x64' as const],
+  flatpak: { remote: 'flathub' },
+  apt: { repo: 'acme/stable' },
+  direct: { host: 'github-releases' as const, project: 'acme/app' },
+};
+
+contractTestTarget(adapter, { sampleConfig });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Linux desktop target planning', () => {
+  it('writes an inspectable multi-format package plan', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-linux-'));
+    tempDirs.push(outDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      version: '1.2.3',
+      channel: 'stable',
+    }) as any, sampleConfig);
+    expect(result.artifact).toBe(join(outDir, 'linux', 'linux-package-plan.json'));
+
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan).toMatchObject({
+      appId: 'com.acme.app',
+      version: '1.2.3',
+      channel: 'stable',
+      formats: ['appimage', 'flatpak', 'deb'],
+      architectures: ['x64'],
+      flatpak: { remote: 'flathub' },
+      apt: { repo: 'acme/stable' },
+      direct: { host: 'github-releases', project: 'acme/app' },
+    });
+  });
+});

--- a/packages/targets/desktop-linux/src/index.ts
+++ b/packages/targets/desktop-linux/src/index.ts
@@ -1,4 +1,6 @@
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 type Format = 'appimage' | 'snap' | 'flatpak' | 'deb' | 'rpm' | 'tar.gz';
 
@@ -21,14 +23,22 @@ export default defineTarget<Config>({
   async build(ctx, config) {
     const arches = config.architectures ?? ['x64', 'arm64'];
     ctx.log(`build ${config.formats.join(',')} · arches=${arches.join(',')}`);
-    // TODO, per format:
-    //  - appimage: appimagetool → .AppImage
-    //  - snap:     snapcraft build → .snap
-    //  - flatpak:  flatpak-builder → .flatpak
-    //  - deb:      dpkg-deb or fpm → .deb
-    //  - rpm:      rpmbuild or fpm → .rpm
-    //  - tar.gz:   tar czf bin + desktop entry + icon
-    return { artifact: `${ctx.outDir}/linux/` };
+    const artifactDir = join(ctx.outDir, 'linux');
+    const planPath = join(artifactDir, 'linux-package-plan.json');
+    await mkdir(artifactDir, { recursive: true });
+    await writeFile(planPath, `${JSON.stringify({
+      appId: config.appId,
+      version: ctx.version,
+      channel: ctx.channel,
+      formats: config.formats,
+      architectures: arches,
+      snap: config.snap,
+      flatpak: config.flatpak,
+      apt: config.apt,
+      rpm: config.rpm,
+      direct: config.direct,
+    }, null, 2)}\n`, 'utf-8');
+    return { artifact: planPath };
   },
   async ship(ctx, config) {
     const channels = config.formats

--- a/packages/targets/desktop-mac/src/index.test.ts
+++ b/packages/targets/desktop-mac/src/index.test.ts
@@ -1,4 +1,46 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { contractTestTarget, fakeBuildContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'desktop', requireKind: true });
+
+const sampleConfig = {
+  bundleId: 'com.acme.app',
+  teamId: 'ABCDE12345',
+  scheme: 'AcmeApp',
+  distribution: 'both' as const,
+  entitlements: 'AcmeApp.entitlements',
+  signingIdentity: 'Developer ID Application: ACME Inc (ABCDE12345)',
+};
+
+contractTestTarget(adapter, { sampleConfig });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('macOS target planning', () => {
+  it('writes an inspectable archive/export plan', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-macos-'));
+    tempDirs.push(outDir);
+
+    const result = await adapter.build(fakeBuildContext({ outDir }) as any, sampleConfig);
+    expect(result.artifact).toBe(join(outDir, 'macos', 'macos-build-plan.json'));
+
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan).toMatchObject({
+      bundleId: 'com.acme.app',
+      teamId: 'ABCDE12345',
+      scheme: 'AcmeApp',
+      distribution: 'both',
+      entitlements: 'AcmeApp.entitlements',
+      signingIdentity: 'Developer ID Application: ACME Inc (ABCDE12345)',
+      outputArtifact: 'app.pkg',
+    });
+  });
+});

--- a/packages/targets/desktop-mac/src/index.ts
+++ b/packages/targets/desktop-mac/src/index.ts
@@ -1,4 +1,6 @@
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 interface Config {
   bundleId: string;
@@ -16,14 +18,19 @@ export default defineTarget<Config>({
   label: 'macOS (Mac App Store / notarized DMG)',
   async build(ctx, config) {
     ctx.log(`xcodebuild archive · distribution=${config.distribution}`);
-    // TODO:
-    //  - xcodebuild archive → exportArchive
-    //  - if 'dmg' or 'both': create-dmg + notarytool submit --wait + staple
-    //  - if 'mas' or 'both': export as mac-app-store .pkg for App Store Connect
-    // Requires macOS runner; cloud builds route to a mac worker.
-    return {
-      artifact: config.distribution === 'dmg' ? `${ctx.outDir}/app.dmg` : `${ctx.outDir}/app.pkg`,
-    };
+    const artifactDir = join(ctx.outDir, 'macos');
+    const planPath = join(artifactDir, 'macos-build-plan.json');
+    await mkdir(artifactDir, { recursive: true });
+    await writeFile(planPath, `${JSON.stringify({
+      bundleId: config.bundleId,
+      teamId: config.teamId,
+      scheme: config.scheme,
+      distribution: config.distribution,
+      entitlements: config.entitlements,
+      signingIdentity: config.signingIdentity,
+      outputArtifact: config.distribution === 'dmg' ? 'app.dmg' : 'app.pkg',
+    }, null, 2)}\n`, 'utf-8');
+    return { artifact: planPath };
   },
   async ship(ctx, config) {
     const targets = config.distribution === 'both' ? ['App Store', 'DMG host'] : [config.distribution === 'mas' ? 'App Store' : 'DMG host'];

--- a/packages/targets/desktop-steamos/src/index.test.ts
+++ b/packages/targets/desktop-steamos/src/index.test.ts
@@ -1,4 +1,53 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { contractTestTarget, fakeBuildContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'desktop', requireKind: true });
+
+const sampleConfig = {
+  appId: 'com.acme.deckapp',
+  sourceDir: '/tmp/builds/deckapp',
+  distribution: 'self-hosted' as const,
+  gamingModeLauncher: {
+    enabled: true,
+    artwork: { hero: 'hero.png', logo: 'logo.png', grid: 'grid.png' },
+  },
+  flatpakManifest: 'com.acme.deckapp.yml',
+  selfHosted: { uploadTo: 'github-pages' as const },
+};
+
+contractTestTarget(adapter, { sampleConfig });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('SteamOS target planning', () => {
+  it('writes an inspectable Flatpak and launcher plan', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-steamos-'));
+    tempDirs.push(outDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      version: '2.0.0',
+    }) as any, sampleConfig);
+    expect(result.artifact).toBe(join(outDir, 'steamos', 'steamos-flatpak-plan.json'));
+
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan).toMatchObject({
+      appId: 'com.acme.deckapp',
+      version: '2.0.0',
+      sourceDir: '/tmp/builds/deckapp',
+      distribution: 'self-hosted',
+      flatpakManifest: 'com.acme.deckapp.yml',
+      gamingModeLauncher: sampleConfig.gamingModeLauncher,
+      selfHosted: { uploadTo: 'github-pages' },
+      outputArtifact: 'com.acme.deckapp.flatpak',
+    });
+  });
+});

--- a/packages/targets/desktop-steamos/src/index.ts
+++ b/packages/targets/desktop-steamos/src/index.ts
@@ -1,4 +1,6 @@
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 
 // SteamOS / Steam Deck — Desktop Mode path that bypasses Steam entirely.
 // The Deck runs KDE Plasma on Arch in Desktop Mode and installs Flatpaks
@@ -29,11 +31,20 @@ export default defineTarget<Config>({
   label: 'SteamOS / Steam Deck (Desktop Mode / Flatpak)',
   async build(ctx, config) {
     ctx.log(`flatpak-builder · appId=${config.appId}`);
-    // TODO:
-    //  - flatpak-builder --repo=repo build-dir <manifest>
-    //  - flatpak build-bundle repo <appId>.flatpak <appId>
-    //  - if gamingModeLauncher: generate Steam shortcuts.vdf entry + artwork
-    return { artifact: `${ctx.outDir}/${config.appId}.flatpak` };
+    const artifactDir = join(ctx.outDir, 'steamos');
+    const planPath = join(artifactDir, 'steamos-flatpak-plan.json');
+    await mkdir(artifactDir, { recursive: true });
+    await writeFile(planPath, `${JSON.stringify({
+      appId: config.appId,
+      version: ctx.version,
+      sourceDir: config.sourceDir,
+      distribution: config.distribution,
+      flatpakManifest: config.flatpakManifest,
+      gamingModeLauncher: config.gamingModeLauncher,
+      selfHosted: config.selfHosted,
+      outputArtifact: `${config.appId}.flatpak`,
+    }, null, 2)}\n`, 'utf-8');
+    return { artifact: planPath };
   },
   async ship(ctx, config) {
     const dest = config.distribution === 'flathub' ? 'Flathub PR' : `self-hosted (${config.selfHosted?.uploadTo})`;


### PR DESCRIPTION
## Summary
- makes chat-signal, console-steam, desktop-linux, desktop-mac, and desktop-steamos build steps emit inspectable JSON plans under `ctx.outDir`
- keeps Signal captcha handling non-secret in generated artifacts by storing only a presence flag
- adds target contract coverage plus focused plan-file tests for each changed target

## Validation
- `corepack pnpm@9.12.0 exec vitest run packages/targets/chat-signal/src/index.test.ts packages/targets/console-steam/src/index.test.ts packages/targets/desktop-linux/src/index.test.ts packages/targets/desktop-mac/src/index.test.ts packages/targets/desktop-steamos/src/index.test.ts`
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-target-chat-signal --filter @profullstack/sh1pt-target-console-steam --filter @profullstack/sh1pt-target-desktop-linux --filter @profullstack/sh1pt-target-desktop-mac --filter @profullstack/sh1pt-target-desktop-steamos typecheck`
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-target-chat-signal --filter @profullstack/sh1pt-target-console-steam --filter @profullstack/sh1pt-target-desktop-linux --filter @profullstack/sh1pt-target-desktop-mac --filter @profullstack/sh1pt-target-desktop-steamos build`
- `git diff --check`

No live provider credentials or production secrets were used.

Refs #6