### PR TITLE
Implement OpenCode agent provider

### DIFF
--- a/packages/agent-providers/opencode/src/__tests__/opencode.test.ts
+++ b/packages/agent-providers/opencode/src/__tests__/opencode.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import { createOpencodeProvider, type CommandRunner } from "../provider";
+
+describe("opencode provider", () => {
+  it("runs opencode with prompt context and configured flags", async () => {
+    const calls: Array<{ command: string; args: string[]; cwd?: string; timeoutMs: number }> = [];
+    const runner: CommandRunner = vi.fn(async (command, args, options) => {
+      calls.push({ command, args, cwd: options.cwd, timeoutMs: options.timeoutMs });
+      return { stdout: "done\n", stderr: "", exitCode: 0 };
+    });
+
+    const provider = createOpencodeProvider({
+      runner,
+      env: {
+        OPENCODE_BIN: "opencode",
+        OPENCODE_MODEL: "anthropic/claude-sonnet-4",
+        OPENCODE_AGENT: "build",
+        OPENCODE_ATTACH: "http://127.0.0.1:4096",
+        OPENCODE_DIR: "/tmp/project",
+        OPENCODE_TIMEOUT_MS: "45000",
+      },
+    });
+
+    await expect(provider.chat({
+      messages: [
+        { role: "system", content: "Be concise." },
+        { role: "user", content: "Explain the deploy plan." },
+      ],
+    })).resolves.toEqual({ content: "done" });
+
+    expect(calls).toEqual([{
+      command: "opencode",
+      args: [
+        "run",
+        "--model",
+        "anthropic/claude-sonnet-4",
+        "--agent",
+        "build",
+        "--attach",
+        "http://127.0.0.1:4096",
+        "--dir",
+        "/tmp/project",
+        "SYSTEM:\nBe concise.\n\nUSER:\nExplain the deploy plan.",
+      ],
+      cwd: "/tmp/project",
+      timeoutMs: 45000,
+    }]);
+  });
+
+  it("rejects empty chat requests before running the CLI", async () => {
+    const runner: CommandRunner = vi.fn();
+    const provider = createOpencodeProvider({ runner, env: {} });
+
+    await expect(provider.chat({ messages: [] })).rejects.toThrow("requires at least one message");
+    expect(runner).not.toHaveBeenCalled();
+  });
+
+  it("lists models from opencode output", async () => {
+    const runner: CommandRunner = vi.fn(async () => ({
+      stdout: "anthropic/claude-sonnet-4\nopenai/gpt-4.1\nopenai/gpt-4.1\n",
+      stderr: "",
+      exitCode: 0,
+    }));
+    const provider = createOpencodeProvider({
+      runner,
+      env: { OPENCODE_MODELS_PROVIDER: "anthropic" },
+    });
+
+    await expect(provider.listModels()).resolves.toEqual([
+      "anthropic/claude-sonnet-4",
+      "openai/gpt-4.1",
+    ]);
+    expect(runner).toHaveBeenCalledWith("opencode", ["models", "anthropic"], expect.any(Object));
+  });
+
+  it("reports CLI availability through healthcheck", async () => {
+    const runner: CommandRunner = vi.fn(async () => ({
+      stdout: "opencode 0.7.1\n",
+      stderr: "",
+      exitCode: 0,
+    }));
+    const provider = createOpencodeProvider({ runner, env: {} });
+
+    await expect(provider.healthcheck()).resolves.toEqual({
+      ok: true,
+      message: "opencode 0.7.1",
+    });
+    expect(runner).toHaveBeenCalledWith("opencode", ["--version"], expect.any(Object));
+  });
+
+  it("redacts sensitive values from CLI failures", async () => {
+    const runner: CommandRunner = vi.fn(async () => ({
+      stdout: "",
+      stderr: "auth failed for secret-pass",
+      exitCode: 1,
+    }));
+    const provider = createOpencodeProvider({
+      runner,
+      env: { OPENCODE_SERVER_PASSWORD: "secret-pass" },
+    });
+
+    await expect(provider.chat({
+      messages: [{ role: "user", content: "hello" }],
+    })).rejects.toThrow("auth failed for [redacted]");
+  });
+
+  it("validates timeout configuration", () => {
+    const provider = createOpencodeProvider();
+
+    expect(() => provider.validateEnv({ OPENCODE_TIMEOUT_MS: "0" })).toThrow("positive integer");
+    expect(() => provider.validateEnv({ OPENCODE_TIMEOUT_MS: "15000" })).not.toThrow();
+  });
+});

--- a/packages/agent-providers/opencode/src/provider.ts
+++ b/packages/agent-providers/opencode/src/provider.ts
@@ -1,30 +1,227 @@
 import {
-  AgentProviderAdapter,
-  AgentProviderNotImplementedError,
+  AgentProviderConfigError,
+  AgentProviderRequestError,
 } from "@profullstack/sh1pt-agent-provider-shared";
+import type { AgentProviderAdapter } from "@profullstack/sh1pt-agent-provider-shared";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 
-export const opencodeProvider: AgentProviderAdapter = {
+const execFileAsync = promisify(execFile);
+
+export interface CommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface CommandRunnerOptions {
+  cwd?: string;
+  env: Record<string, string | undefined>;
+  timeoutMs: number;
+}
+
+export type CommandRunner = (
+  command: string,
+  args: string[],
+  options: CommandRunnerOptions,
+) => Promise<CommandResult>;
+
+export interface OpencodeProviderOptions {
+  env?: Record<string, string | undefined>;
+  runner?: CommandRunner;
+}
+
+interface OpencodeConfig {
+  bin: string;
+  model?: string;
+  agent?: string;
+  attach?: string;
+  dir?: string;
+  modelsProvider?: string;
+  timeoutMs: number;
+}
+
+export function createOpencodeProvider(options: OpencodeProviderOptions = {}): AgentProviderAdapter {
+  const env = options.env ?? process.env;
+  const runner = options.runner ?? runCommand;
+
+  return {
   id: "opencode",
   displayName: "OpenCode",
   capabilities: { chat: true },
 
   getRequiredEnv() {
-    return [];
+    return [
+      { key: "OPENCODE_BIN", required: false },
+      { key: "OPENCODE_MODEL", required: false },
+      { key: "OPENCODE_AGENT", required: false },
+      { key: "OPENCODE_ATTACH", required: false },
+      { key: "OPENCODE_DIR", required: false },
+      { key: "OPENCODE_MODELS_PROVIDER", required: false },
+      { key: "OPENCODE_TIMEOUT_MS", required: false },
+    ];
   },
 
-  validateEnv() {
-    // no-op for now
+  validateEnv(candidateEnv) {
+    resolveConfig(candidateEnv);
   },
 
   async listModels() {
-    throw new AgentProviderNotImplementedError("opencode.listModels");
+    const config = resolveConfig(env);
+    const args = ["models"];
+    if (config.modelsProvider) args.push(config.modelsProvider);
+    const result = await runOpencode(config, runner, args, env);
+    return parseModels(result.stdout);
   },
 
-  async chat() {
-    throw new AgentProviderNotImplementedError("opencode.chat");
+  async chat(req) {
+    const config = resolveConfig(env);
+    const prompt = renderPrompt(req.messages);
+    if (!prompt) {
+      throw new AgentProviderConfigError("opencode.chat requires at least one message with content");
+    }
+
+    const args = ["run"];
+    if (config.model) args.push("--model", config.model);
+    if (config.agent) args.push("--agent", config.agent);
+    if (config.attach) args.push("--attach", config.attach);
+    if (config.dir) args.push("--dir", config.dir);
+    args.push(prompt);
+
+    const result = await runOpencode(config, runner, args, env);
+    const content = result.stdout.trim();
+    if (!content) throw new AgentProviderRequestError("OpenCode CLI returned an empty response");
+    return { content };
   },
 
   async healthcheck() {
-    throw new AgentProviderNotImplementedError("opencode.healthcheck");
+    const config = resolveConfig(env);
+    const result = await runOpencode(config, runner, ["--version"], env);
+    return { ok: true, message: result.stdout.trim() || "opencode available" };
   },
 };
+}
+
+export const opencodeProvider = createOpencodeProvider();
+
+function resolveConfig(env: Record<string, string | undefined>): OpencodeConfig {
+  const timeoutMs = parseTimeout(env.OPENCODE_TIMEOUT_MS);
+  return {
+    bin: env.OPENCODE_BIN?.trim() || "opencode",
+    model: nonEmpty(env.OPENCODE_MODEL),
+    agent: nonEmpty(env.OPENCODE_AGENT),
+    attach: nonEmpty(env.OPENCODE_ATTACH),
+    dir: nonEmpty(env.OPENCODE_DIR),
+    modelsProvider: nonEmpty(env.OPENCODE_MODELS_PROVIDER),
+    timeoutMs,
+  };
+}
+
+function parseTimeout(value: string | undefined): number {
+  if (!value) return 120_000;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new AgentProviderConfigError("OPENCODE_TIMEOUT_MS must be a positive integer");
+  }
+  return parsed;
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function renderPrompt(messages: { role: string; content: string }[]): string {
+  return messages
+    .map((message) => {
+      const content = message.content.trim();
+      if (!content) return "";
+      return `${message.role.toUpperCase()}:\n${content}`;
+    })
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+async function runOpencode(
+  config: OpencodeConfig,
+  runner: CommandRunner,
+  args: string[],
+  env: Record<string, string | undefined>,
+): Promise<CommandResult> {
+  try {
+    const result = await runner(config.bin, args, {
+      cwd: config.dir,
+      env: { ...process.env, ...env },
+      timeoutMs: config.timeoutMs,
+    });
+    if (result.exitCode !== 0) {
+      const detail = formatFailure(result, env);
+      throw new AgentProviderRequestError(`OpenCode CLI exited ${result.exitCode}${detail}`);
+    }
+    return result;
+  } catch (error) {
+    if (error instanceof AgentProviderRequestError) throw error;
+    const result = commandErrorResult(error);
+    const detail = formatFailure(result, env);
+    throw new AgentProviderRequestError(`OpenCode CLI failed${detail}`);
+  }
+}
+
+async function runCommand(
+  command: string,
+  args: string[],
+  options: CommandRunnerOptions,
+): Promise<CommandResult> {
+  const result = await execFileAsync(resolveExecutable(command), args, {
+    cwd: options.cwd,
+    env: options.env,
+    timeout: options.timeoutMs,
+    maxBuffer: 1024 * 1024,
+    windowsHide: true,
+  });
+  return {
+    stdout: String(result.stdout ?? ""),
+    stderr: String(result.stderr ?? ""),
+    exitCode: 0,
+  };
+}
+
+function resolveExecutable(command: string): string {
+  if (process.platform !== "win32") return command;
+  if (/[\\/]/.test(command) || /\.(?:bat|cmd|exe)$/i.test(command)) return command;
+  return `${command}.cmd`;
+}
+
+function commandErrorResult(error: unknown): CommandResult {
+  const candidate = error as { stdout?: unknown; stderr?: unknown; code?: unknown };
+  return {
+    stdout: String(candidate.stdout ?? ""),
+    stderr: String(candidate.stderr ?? ""),
+    exitCode: typeof candidate.code === "number" ? candidate.code : 1,
+  };
+}
+
+function formatFailure(result: CommandResult, env: Record<string, string | undefined>): string {
+  const text = sanitizeCliOutput([result.stderr, result.stdout].filter(Boolean).join("\n"), env);
+  return text ? `: ${text}` : "";
+}
+
+function sanitizeCliOutput(text: string, env: Record<string, string | undefined>): string {
+  let sanitized = text.replace(/(Bearer\s+)[^\s]+/gi, "$1[redacted]");
+  for (const key of ["OPENCODE_SERVER_PASSWORD", "OPENCODE_API_KEY"]) {
+    const value = env[key];
+    if (value && value.length >= 4) {
+      sanitized = sanitized.split(value).join("[redacted]");
+    }
+  }
+  return sanitized.trim().slice(0, 1000);
+}
+
+function parseModels(stdout: string): string[] {
+  const models = new Set<string>();
+  for (const line of stdout.split(/\r?\n/)) {
+    const matches = line.matchAll(/\b[a-z0-9][a-z0-9_.-]*\/[a-zA-Z0-9][a-zA-Z0-9_.:/+-]*/g);
+    for (const match of matches) models.add(match[0]);
+  }
+  return [...models].sort();
+}

--- a/packages/agent-providers/opencode/tsconfig.json
+++ b/packages/agent-providers/opencode/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist"
   },

--- a/packages/agent-providers/openrouter/src/provider.ts
+++ b/packages/agent-providers/openrouter/src/provider.ts
@@ -1,8 +1,8 @@
 import {
-  AgentProviderAdapter,
   AgentProviderNotImplementedError,
   AgentProviderConfigError,
 } from "@profullstack/sh1pt-agent-provider-shared";
+import type { AgentProviderAdapter } from "@profullstack/sh1pt-agent-provider-shared";
 
 export const openrouterProvider: AgentProviderAdapter = {
   id: "openrouter",

--- a/packages/agent-providers/shared/src/registry.ts
+++ b/packages/agent-providers/shared/src/registry.ts
@@ -1,4 +1,4 @@
-import { AgentProviderAdapter } from "./types";
+import type { AgentProviderAdapter } from "./types";
 
 const registry = new Map<string, AgentProviderAdapter>();
 

--- a/packages/agent-providers/shared/src/types.ts
+++ b/packages/agent-providers/shared/src/types.ts
@@ -37,7 +37,7 @@ export interface AgentProviderAdapter {
   getRequiredEnv(): AgentProviderEnvRequirement[];
   validateEnv(env: Record<string, string | undefined>): void;
 
-  listModels(): Promise<never>;
+  listModels(): Promise<string[]>;
   chat(req: AgentProviderChatRequest): Promise<AgentProviderChatResponse>;
   healthcheck(): Promise<AgentProviderHealthcheckResult>;
 }


### PR DESCRIPTION
## Summary

- replaces the placeholder OpenCode agent provider with a CLI-backed adapter
- supports `opencode run` chat calls with optional model, agent, attach URL, working directory, binary, and timeout env config
- adds `opencode models` parsing and `opencode --version` healthcheck support
- keeps CLI error output bounded and redacts server password / bearer-token echoes
- fixes the OpenCode package tsconfig base path and adjacent type-only imports needed by the shared agent-provider contract

## Validation

- `corepack pnpm@9.12.0 exec vitest run packages/agent-providers/shared/src/__tests__/registry.test.ts packages/agent-providers/openrouter/src/__tests__/openrouter.test.ts packages/agent-providers/opencode/src/__tests__/opencode.test.ts`
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-agent-provider-opencode typecheck`
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-agent-provider-opencode build`
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-agent-provider-shared typecheck`
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-agent-provider-openrouter typecheck`
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-agent-provider-shared build`
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-agent-provider-openrouter build`
- `git diff --check`

Source used: official OpenCode CLI docs for `run`, `models`, and `--version`: https://opencode.ai/docs/cli/

No real OpenCode credentials, provider keys, server password, or production secrets were used; tests use an injected mocked command runner.

Refs #6