### PR TITLE
Harden Qwen agent headless runs

### DIFF
--- a/packages/agents/qwen/src/index.test.ts
+++ b/packages/agents/qwen/src/index.test.ts
@@ -1,4 +1,35 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { describe, expect, it } from 'vitest';
 import adapter from './index.js';
+import { hasHeadlessAuth, qwenArgs, qwenPrompt } from './index.js';
 
 smokeTest(adapter, { idPrefix: 'agent' });
+
+describe('agent-qwen headless helpers', () => {
+  it('builds non-interactive qwen args without logging credentials', () => {
+    expect(qwenArgs({
+      prompt: 'Review the changed files',
+      files: ['packages/agents/qwen/src/index.ts', 'README.md'],
+    }, {
+      authType: 'openai',
+      model: 'qwen3-coder-plus',
+    })).toEqual([
+      '--auth-type',
+      'openai',
+      '--model',
+      'qwen3-coder-plus',
+      '-p',
+      'Review the changed files\n\nRelevant files:\n@packages/agents/qwen/src/index.ts\n@README.md',
+    ]);
+  });
+
+  it('leaves prompts unchanged when no file focus is supplied', () => {
+    expect(qwenPrompt({ prompt: 'Ship it' })).toBe('Ship it');
+  });
+
+  it('checks configured headless auth env keys', () => {
+    expect(hasHeadlessAuth({}, { OPENAI_API_KEY: 'sk-test' })).toBe(true);
+    expect(hasHeadlessAuth({ authEnvKey: 'CUSTOM_QWEN_KEY' }, { OPENAI_API_KEY: 'sk-test' })).toBe(false);
+    expect(hasHeadlessAuth({ authEnvKey: 'CUSTOM_QWEN_KEY' }, { CUSTOM_QWEN_KEY: 'qwen-test' })).toBe(true);
+  });
+});

--- a/packages/agents/qwen/src/index.ts
+++ b/packages/agents/qwen/src/index.ts
@@ -1,8 +1,18 @@
-import { defineAgent, exec, ensureCli, manualSetup } from '@profullstack/sh1pt-core';
+import { defineAgent, exec, ensureCli, manualSetup, type AgentRunContext } from '@profullstack/sh1pt-core';
 
 interface Config {
   model?: string;            // 'qwen2.5-coder', 'qwen3-coder', etc.
+  authType?: 'openai' | 'anthropic' | 'gemini' | 'qwen-oauth';
+  authEnvKey?: string;       // defaults to common Qwen Code headless env vars
 }
+
+const DEFAULT_AUTH_ENV_KEYS = [
+  'OPENAI_API_KEY',
+  'DASHSCOPE_API_KEY',
+  'QWEN_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'GEMINI_API_KEY',
+];
 
 export default defineAgent<Config>({
   id: 'agent-qwen',
@@ -10,41 +20,67 @@ export default defineAgent<Config>({
   binary: 'qwen',
   capabilities: ['generate-project', 'edit-files', 'run-commands', 'multi-turn'],
 
-  async check() {
+  async check(_ctx, config) {
     try {
       const result = await exec('qwen', ['--version'], { log: () => {}, throwOnNonZero: false });
+      const authenticated = hasHeadlessAuth(config, process.env);
       return {
         installed: result.exitCode === 0,
         version: result.stdout.trim() || undefined,
-        authenticated: true, // real impl: check DashScope API key
+        authenticated,
         installHint: 'mise use npm:@qwen-code/qwen-code',
+        authHint: authenticated ? undefined : headlessAuthHint(config),
       };
     } catch {
       return {
         installed: false,
         authenticated: false,
         installHint: 'mise use npm:@qwen-code/qwen-code',
-        authHint: 'set DASHSCOPE_API_KEY env var (Alibaba DashScope console)',
+        authHint: headlessAuthHint(config),
       };
     }
   },
 
   async run(ctx, config) {
     await ensureCli('qwen', 'Install: mise use npm:@qwen-code/qwen-code', ctx.log);
-    const args = [
-      ...(config.model ? ['--model', config.model] : []),
-      '--prompt', ctx.prompt,
-    ];
+    const args = qwenArgs(ctx, config);
+    ctx.log(`qwen ${args.slice(0, -1).join(' ')} <prompt>`);
     const { exitCode } = await exec('qwen', args, { cwd: ctx.cwd, log: ctx.log });
     return { exitCode };
   },
 
   setup: manualSetup({
     label: "Qwen Code",
-    vendorDocUrl: "https://github.com/QwenLM/Qwen-Agent",
+    vendorDocUrl: "https://qwenlm.github.io/qwen-code-docs/en/cli/index",
     steps: [
       "Install with mise: mise use npm:@qwen-code/qwen-code",
+      "For headless sh1pt runs, set OPENAI_API_KEY plus optional OPENAI_BASE_URL / OPENAI_MODEL, or use the configured auth env key",
       "sh1pt invokes whichever qwen CLI is on your PATH",
     ],
   }),
 });
+
+export function qwenArgs(ctx: Pick<AgentRunContext, 'prompt' | 'files'>, config: Config): string[] {
+  return [
+    ...(config.authType ? ['--auth-type', config.authType] : []),
+    ...(config.model ? ['--model', config.model] : []),
+    '-p',
+    qwenPrompt(ctx),
+  ];
+}
+
+export function qwenPrompt(ctx: Pick<AgentRunContext, 'prompt' | 'files'>): string {
+  if (!ctx.files?.length) return ctx.prompt;
+  const fileRefs = ctx.files.map((file) => `@${file}`).join('\n');
+  return `${ctx.prompt}\n\nRelevant files:\n${fileRefs}`;
+}
+
+export function hasHeadlessAuth(config: Config, env: Record<string, string | undefined>): boolean {
+  const keys = config.authEnvKey ? [config.authEnvKey] : DEFAULT_AUTH_ENV_KEYS;
+  return keys.some((key) => Boolean(env[key]?.trim()));
+}
+
+function headlessAuthHint(config: Config): string {
+  if (config.authEnvKey) return `set ${config.authEnvKey} for Qwen Code headless runs`;
+  return 'set OPENAI_API_KEY with optional OPENAI_BASE_URL / OPENAI_MODEL, or configure authEnvKey for another Qwen Code provider';
+}


### PR DESCRIPTION
## Summary

- hardens the Qwen Code agent adapter for non-interactive/headless sh1pt runs
- uses `qwen -p <prompt>` and optional `--auth-type` / `--model` flags from the Qwen Code CLI docs
- appends focused files as Qwen `@file` prompt references when sh1pt passes `ctx.files`
- stops logging the full prompt by logging `<prompt>` instead
- reports authentication as present only when a configured headless auth env key is available
- updates setup guidance to the Qwen Code CLI docs and headless env-auth flow

## Validation

- `corepack pnpm@9.12.0 exec vitest run packages/agents/qwen/src/index.test.ts`
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-agent-qwen typecheck`
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-agent-qwen build`
- `git diff --check`

Sources used:
- Qwen Code CLI docs for non-interactive `-p/--prompt`: https://qwenlm.github.io/qwen-code-docs/en/cli/index
- Qwen Code auth docs for headless environment variables: https://qwenlm.github.io/qwen-code-docs/en/cli/authentication/

No live Qwen, OpenAI, DashScope, Anthropic, or Gemini credentials were used.

Refs #6