### PR TITLE
Implement Android TV package planning

### DIFF
--- a/packages/targets/tv-androidtv/src/index.test.ts
+++ b/packages/targets/tv-androidtv/src/index.test.ts
@@ -1,4 +1,103 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'tv', requireKind: true });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('Android TV package planning', () => {
+  it('writes an inspectable package plan with TV manifest requirements', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-androidtv-'));
+    tempDirs.push(outDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      version: '2.4.0',
+      channel: 'stable',
+    }) as any, {
+      packageName: 'com.acme.tv',
+      track: 'alpha',
+    });
+
+    const planFile = join(outDir, 'androidtv-package-plan.json');
+    expect(result.artifact).toBe(join(outDir, 'androidtv', 'com.acme.tv.aab'));
+    expect(result.meta?.planFile).toBe(planFile);
+    expect(result.meta?.track).toBe('alpha');
+
+    const plan = JSON.parse(await readFile(planFile, 'utf-8')) as {
+      packageName: string;
+      version: string;
+      track: string;
+      artifact: string;
+      manifestChecks: Array<{ requirement: string; required: boolean }>;
+      commands: string[];
+    };
+
+    expect(plan.packageName).toBe('com.acme.tv');
+    expect(plan.version).toBe('2.4.0');
+    expect(plan.track).toBe('alpha');
+    expect(plan.artifact).toBe(result.artifact);
+    expect(plan.manifestChecks).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        requirement: 'uses-feature android:name="android.software.leanback"',
+        required: true,
+      }),
+      expect.objectContaining({
+        requirement: 'category android:name="android.intent.category.LEANBACK_LAUNCHER"',
+        required: true,
+      }),
+    ]));
+    expect(plan.commands).toContain('./gradlew :app:bundleRelease');
+  });
+
+  it('maps non-stable channels to safe test tracks', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-androidtv-'));
+    tempDirs.push(outDir);
+
+    const beta = await adapter.build(fakeBuildContext({
+      outDir,
+      version: '2.4.0',
+      channel: 'beta',
+    }) as any, {
+      packageName: 'com.acme.tv',
+      track: 'production',
+      aabPath: 'dist/tv-release.aab',
+    });
+
+    expect(beta.artifact).toBe('dist/tv-release.aab');
+    expect(beta.meta?.track).toBe('beta');
+
+    const canaryShip = await adapter.ship(fakeShipContext({
+      channel: 'canary',
+      artifact: 'dist/tv-release.aab',
+      dryRun: true,
+    }) as any, {
+      packageName: 'com.acme.tv',
+      track: 'production',
+      aabPath: 'dist/tv-release.aab',
+    });
+
+    expect(canaryShip).toEqual({
+      id: 'dry-run',
+      meta: {
+        packageName: 'com.acme.tv',
+        artifact: 'dist/tv-release.aab',
+        track: 'internal',
+        commands: [
+          'play-developer-api edits.insert package=com.acme.tv',
+          'play-developer-api edits.bundles.upload artifact=dist/tv-release.aab',
+          'play-developer-api edits.tracks.update track=internal',
+          'play-developer-api edits.commit',
+        ],
+      },
+    });
+  });
+});

--- a/packages/targets/tv-androidtv/src/index.ts
+++ b/packages/targets/tv-androidtv/src/index.ts
@@ -1,11 +1,60 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
 
 interface Config {
-  packageName: string;                                   // e.g. com.acme.myapp
-  // Play Console "form factor" registration — Android TV gates via the
-  // leanback launcher intent and the android.software.leanback feature.
+  packageName: string;
   track: 'internal' | 'alpha' | 'beta' | 'production';
   aabPath?: string;
+}
+
+const PLAN_FILE = 'androidtv-package-plan.json';
+
+function releaseTrack(channel: string, config: Config): Config['track'] {
+  if (channel === 'stable') return config.track;
+  if (channel === 'beta') return 'beta';
+  return 'internal';
+}
+
+function artifactPath(ctx: { outDir: string }, config: Config): string {
+  return config.aabPath ?? join(ctx.outDir, 'androidtv', `${config.packageName}.aab`);
+}
+
+function buildPlan(ctx: { outDir: string; version: string; channel: string }, config: Config) {
+  const artifact = artifactPath(ctx, config);
+  const track = releaseTrack(ctx.channel, config);
+  return {
+    packageName: config.packageName,
+    version: ctx.version,
+    channel: ctx.channel,
+    track,
+    artifact,
+    planFile: join(ctx.outDir, PLAN_FILE),
+    manifestChecks: [
+      {
+        path: 'AndroidManifest.xml',
+        requirement: 'uses-feature android:name="android.software.leanback"',
+        required: true,
+      },
+      {
+        path: 'AndroidManifest.xml',
+        requirement: 'category android:name="android.intent.category.LEANBACK_LAUNCHER"',
+        required: true,
+      },
+      {
+        path: 'AndroidManifest.xml',
+        requirement: 'category android:name="android.intent.category.LAUNCHER"',
+        required: true,
+      },
+    ],
+    commands: [
+      './gradlew :app:bundleRelease',
+      `play-developer-api edits.insert package=${config.packageName}`,
+      `play-developer-api edits.bundles.upload artifact=${artifact}`,
+      `play-developer-api edits.tracks.update track=${track}`,
+      'play-developer-api edits.commit',
+    ],
+  };
 }
 
 export default defineTarget<Config>({
@@ -13,19 +62,35 @@ export default defineTarget<Config>({
   kind: 'tv',
   label: 'Play Store (Android TV)',
   async build(ctx, config) {
-    ctx.log(`gradle :app:bundleRelease · track=${config.track}`);
-    // TODO:
-    //  - verify AndroidManifest declares:
-    //    * <uses-feature android:name="android.software.leanback" android:required="true"/>
-    //    * <category android:name="android.intent.category.LEANBACK_LAUNCHER"/>
-    //  - gradle bundleRelease → signed .aab
-    return { artifact: config.aabPath ?? `${ctx.outDir}/app-release.aab` };
+    const plan = buildPlan(ctx, config);
+    ctx.log(`androidtv plan ${config.packageName} -> ${plan.track}`);
+    await mkdir(ctx.outDir, { recursive: true });
+    await writeFile(plan.planFile, `${JSON.stringify(plan, null, 2)}\n`, 'utf-8');
+    return {
+      artifact: plan.artifact,
+      meta: {
+        planFile: plan.planFile,
+        track: plan.track,
+        manifestChecks: plan.manifestChecks,
+      },
+    };
   },
   async ship(ctx, config) {
-    const track = ctx.channel === 'stable' ? config.track : ctx.channel === 'beta' ? 'beta' : 'internal';
-    ctx.log(`upload to Play Console · package=${config.packageName} · track=${track}`);
-    if (ctx.dryRun) return { id: 'dry-run' };
-    // TODO: Google Play Developer Publishing API (edit → upload bundle → commit to track)
+    const track = releaseTrack(ctx.channel, config);
+    const plan = buildPlan(ctx, config);
+    ctx.log(`upload to Play Console package=${config.packageName} track=${track}`);
+    if (ctx.dryRun) {
+      return {
+        id: 'dry-run',
+        meta: {
+          packageName: config.packageName,
+          artifact: ctx.artifact,
+          track,
+          commands: plan.commands.slice(1),
+        },
+      };
+    }
+    // TODO: Google Play Developer Publishing API (edit -> upload bundle -> commit to track)
     return {
       id: `${config.packageName}@${ctx.version}`,
       url: `https://play.google.com/store/apps/details?id=${config.packageName}`,
@@ -36,12 +101,12 @@ export default defineTarget<Config>({
   },
 
   setup: manualSetup({
-    label: "Android TV (Google Play Console)",
-    vendorDocUrl: "https://play.google.com/console",
+    label: 'Android TV (Google Play Console)',
+    vendorDocUrl: 'https://play.google.com/console',
     steps: [
-      "Same Google Play Console flow as mobile Android \u2014 $25 one-time + identity verification",
-      "Add Android TV as a distribution channel in the app listing",
-      "Run: sh1pt secret set PLAY_CONSOLE_SERVICE_ACCOUNT_JSON <path-to-json>",
+      'Use the same Google Play Console flow as mobile Android, with Android TV enabled as a form factor.',
+      'Declare android.software.leanback plus LAUNCHER and LEANBACK_LAUNCHER in AndroidManifest.xml.',
+      'Run: sh1pt secret set PLAY_CONSOLE_SERVICE_ACCOUNT_JSON <path-to-json>',
     ],
   }),
 });


### PR DESCRIPTION
## Summary
- replace the Android TV target stub with an inspectable package plan written to `androidtv-package-plan.json`
- include required Android TV manifest checks for `android.software.leanback`, `LAUNCHER`, and `LEANBACK_LAUNCHER`
- map non-stable sh1pt channels to safe Play tracks (`beta` -> `beta`, everything else -> `internal`) and expose dry-run ship metadata
- add focused tests for package-plan generation and track mapping

Relates to #6.

Payment details: I can provide crypto payout details privately after acceptance; no wallet is included in the public PR.

## Validation
- `corepack pnpm vitest run packages/targets/tv-androidtv/src/index.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt-target-tv-androidtv typecheck`
- `corepack pnpm --filter @profullstack/sh1pt-target-tv-androidtv build`
- `git diff --check`

## Notes
I kept this scoped to `packages/targets/tv-androidtv` so it does not overlap with the existing open TV, desktop, chat, or scale PRs.