### PR TITLE
Implement tvOS package planning

### DIFF
--- a/packages/targets/tv-tvos/src/index.test.ts
+++ b/packages/targets/tv-tvos/src/index.test.ts
@@ -1,4 +1,101 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'tv', requireKind: true });
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('tvOS package planning', () => {
+  it('writes an inspectable tvOS archive and export plan', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-tvos-'));
+    tempDirs.push(outDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      version: '3.1.0',
+      channel: 'stable',
+    }) as any, {
+      bundleId: 'com.acme.tvos',
+      teamId: 'TEAM123456',
+      scheme: 'AcmeTV',
+    });
+
+    const planFile = join(outDir, 'tvos-package-plan.json');
+    expect(result.artifact).toBe(join(outDir, 'tvos', 'com.acme.tvos.ipa'));
+    expect(result.meta?.planFile).toBe(planFile);
+    expect(result.meta?.destination).toBe('app-store');
+
+    const plan = JSON.parse(await readFile(planFile, 'utf-8')) as {
+      bundleId: string;
+      teamId: string;
+      version: string;
+      scheme: string;
+      destination: string;
+      archivePath: string;
+      exportOptions: string;
+      requirements: string[];
+      commands: string[];
+    };
+
+    expect(plan.bundleId).toBe('com.acme.tvos');
+    expect(plan.teamId).toBe('TEAM123456');
+    expect(plan.version).toBe('3.1.0');
+    expect(plan.scheme).toBe('AcmeTV');
+    expect(plan.destination).toBe('app-store');
+    expect(plan.archivePath).toBe(join(outDir, 'tvos', 'com.acme.tvos.xcarchive'));
+    expect(plan.exportOptions).toBe(join(outDir, 'tvos', 'ExportOptions.plist'));
+    expect(plan.requirements).toContain('macOS runner with Xcode and the tvOS SDK installed');
+    expect(plan.commands[0]).toContain('xcodebuild -scheme AcmeTV -sdk appletvos archive');
+    expect(plan.commands[1]).toContain('xcodebuild -exportArchive');
+  });
+
+  it('keeps TestFlight group routing visible in dry-run shipping', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-tvos-'));
+    tempDirs.push(outDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      version: '3.1.0',
+      channel: 'beta',
+    }) as any, {
+      bundleId: 'com.acme.tvos',
+      teamId: 'TEAM123456',
+      testflightGroups: ['qa', 'founders'],
+      ipaPath: 'dist/tvos.ipa',
+    });
+
+    expect(result.artifact).toBe('dist/tvos.ipa');
+    expect(result.meta?.destination).toBe('testflight:qa,founders');
+
+    const ship = await adapter.ship(fakeShipContext({
+      channel: 'beta',
+      artifact: 'dist/tvos.ipa',
+      dryRun: true,
+    }) as any, {
+      bundleId: 'com.acme.tvos',
+      teamId: 'TEAM123456',
+      testflightGroups: ['qa', 'founders'],
+      ipaPath: 'dist/tvos.ipa',
+    });
+
+    expect(ship).toEqual({
+      id: 'dry-run',
+      meta: {
+        bundleId: 'com.acme.tvos',
+        artifact: 'dist/tvos.ipa',
+        destination: 'testflight:qa,founders',
+        commands: [
+          'xcrun altool --upload-app --type tvos --file dist/tvos.ipa',
+        ],
+      },
+    });
+  });
+});

--- a/packages/targets/tv-tvos/src/index.ts
+++ b/packages/targets/tv-tvos/src/index.ts
@@ -1,3 +1,5 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
 
 interface Config {
@@ -5,6 +7,51 @@ interface Config {
   teamId: string;
   scheme?: string;
   testflightGroups?: string[];
+  ipaPath?: string;
+}
+
+const PLAN_FILE = 'tvos-package-plan.json';
+
+function scheme(config: Config): string {
+  return config.scheme ?? 'default';
+}
+
+function artifactPath(ctx: { outDir: string }, config: Config): string {
+  return config.ipaPath ?? join(ctx.outDir, 'tvos', `${config.bundleId}.ipa`);
+}
+
+function destination(channel: string, config: Config): string {
+  if (channel === 'stable') return 'app-store';
+  const groups = config.testflightGroups?.length ? config.testflightGroups.join(',') : 'internal';
+  return `testflight:${groups}`;
+}
+
+function buildPlan(ctx: { outDir: string; version: string; channel: string }, config: Config) {
+  const artifact = artifactPath(ctx, config);
+  const archivePath = join(ctx.outDir, 'tvos', `${config.bundleId}.xcarchive`);
+  const exportOptions = join(ctx.outDir, 'tvos', 'ExportOptions.plist');
+  return {
+    bundleId: config.bundleId,
+    teamId: config.teamId,
+    version: ctx.version,
+    channel: ctx.channel,
+    scheme: scheme(config),
+    artifact,
+    archivePath,
+    exportOptions,
+    destination: destination(ctx.channel, config),
+    planFile: join(ctx.outDir, PLAN_FILE),
+    requirements: [
+      'macOS runner with Xcode and the tvOS SDK installed',
+      'App Store Connect API key, key id, and issuer id in the sh1pt vault',
+      'tvOS app record enabled for the bundle id in App Store Connect',
+    ],
+    commands: [
+      `xcodebuild -scheme ${scheme(config)} -sdk appletvos archive -archivePath ${archivePath}`,
+      `xcodebuild -exportArchive -archivePath ${archivePath} -exportOptionsPlist ${exportOptions} -exportPath ${join(ctx.outDir, 'tvos')}`,
+      `xcrun altool --upload-app --type tvos --file ${artifact}`,
+    ],
+  };
 }
 
 export default defineTarget<Config>({
@@ -12,16 +59,34 @@ export default defineTarget<Config>({
   kind: 'tv',
   label: 'App Store (Apple TV / tvOS)',
   async build(ctx, config) {
-    ctx.log(`xcodebuild archive · tvOS · scheme=${config.scheme ?? 'default'}`);
-    // TODO: xcodebuild -sdk appletvos archive → exportArchive → .ipa
-    // Requires macOS runner with tvOS SDK.
-    return { artifact: `${ctx.outDir}/app-tvos.ipa` };
+    const plan = buildPlan(ctx, config);
+    ctx.log(`tvos plan ${config.bundleId} scheme=${plan.scheme}`);
+    await mkdir(ctx.outDir, { recursive: true });
+    await writeFile(plan.planFile, `${JSON.stringify(plan, null, 2)}\n`, 'utf-8');
+    return {
+      artifact: plan.artifact,
+      meta: {
+        planFile: plan.planFile,
+        destination: plan.destination,
+        archivePath: plan.archivePath,
+      },
+    };
   },
   async ship(ctx, config) {
-    const destination = ctx.channel === 'stable' ? 'App Store (tvOS)' : `TestFlight:${config.testflightGroups?.join(',') ?? 'internal'}`;
-    ctx.log(`upload to ${destination} via App Store Connect API`);
-    if (ctx.dryRun) return { id: 'dry-run' };
-    // TODO: altool upload using APP_STORE_CONNECT_KEY from secrets
+    const plan = buildPlan(ctx, config);
+    ctx.log(`upload ${config.bundleId}@${ctx.version} to ${plan.destination} via App Store Connect API`);
+    if (ctx.dryRun) {
+      return {
+        id: 'dry-run',
+        meta: {
+          bundleId: config.bundleId,
+          artifact: ctx.artifact,
+          destination: plan.destination,
+          commands: plan.commands.slice(2),
+        },
+      };
+    }
+    // TODO: upload through App Store Connect API credentials from the vault.
     return { id: `${config.bundleId}@${ctx.version}` };
   },
   async status(id) {
@@ -29,12 +94,14 @@ export default defineTarget<Config>({
   },
 
   setup: manualSetup({
-    label: "Apple TV (tvOS)",
-    vendorDocUrl: "https://developer.apple.com/",
+    label: 'Apple TV (tvOS)',
+    vendorDocUrl: 'https://developer.apple.com/app-store-connect/api/',
     steps: [
-      "Same Apple Developer Program as iOS/macOS ($99/yr + D-U-N-S)",
-      "App Store Connect \u2192 enable tvOS as a platform for your app",
-      "Reuse APP_STORE_CONNECT_KEY_ID and APP_STORE_CONNECT_ISSUER_ID",
+      'Join the Apple Developer Program and enable tvOS for the app in App Store Connect.',
+      'Create an App Store Connect API key with app management access.',
+      'Run: sh1pt secret set APP_STORE_CONNECT_KEY_ID <key-id>',
+      'Run: sh1pt secret set APP_STORE_CONNECT_ISSUER_ID <issuer-id>',
+      'Run: sh1pt secret set APP_STORE_CONNECT_KEY <private-key>',
     ],
   }),
 });


### PR DESCRIPTION
## Summary
- replace the tvOS target stub with an inspectable package plan written to `tvos-package-plan.json`
- expose archive/export paths, App Store/TestFlight destination routing, and required App Store Connect setup notes
- return dry-run ship metadata for upload commands without requiring Apple credentials
- add focused tests for package-plan generation and TestFlight group routing

Relates to #6.

Payment details: I can provide crypto payout details privately after acceptance; no wallet is included in the public PR.

## Validation
- `corepack pnpm vitest run packages/targets/tv-tvos/src/index.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt-target-tv-tvos typecheck`
- `corepack pnpm --filter @profullstack/sh1pt-target-tv-tvos build`
- `git diff --check`

## Notes
This is scoped to `packages/targets/tv-tvos` and does not overlap with the Android TV or Fire TV PRs.