### PR TITLE
Fix ugig profile endpoint

### DIFF
--- a/packages/social/ugig/src/index.test.ts
+++ b/packages/social/ugig/src/index.test.ts
@@ -1,4 +1,30 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeConnectContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'social' });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('social-ugig adapter', () => {
+  it('connects through the current ugig profile endpoint', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ profile: { id: 'user-123', username: 'safe_earn_393559' } }),
+    } as any);
+
+    const ctx = fakeConnectContext({ UGIG_TOKEN: 'test-token' });
+    const result = await adapter.connect(ctx as any, {});
+
+    expect(result.accountId).toBe('safe_earn_393559');
+    expect(fetch).toHaveBeenCalledWith(
+      'https://ugig.net/api/profile',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer test-token' },
+      }),
+    );
+  });
+});

--- a/packages/social/ugig/src/index.ts
+++ b/packages/social/ugig/src/index.ts
@@ -10,7 +10,7 @@ import { defineSocial, oauthSetup } from '@profullstack/sh1pt-core';
 //   GET  /api/gigs          — list gigs
 //   POST /api/applications  — apply to a gig
 //   POST /api/auth/login    — authenticate (email + password)
-//   GET  /api/users/me      — get authenticated user profile
+//   GET  /api/profile       — get authenticated user profile
 //
 // Rate limits: not publicly documented; avoid bursting > ~10 req/min.
 
@@ -34,12 +34,13 @@ export default defineSocial<Config>({
     const token = ctx.secret('UGIG_TOKEN');
     if (!token) throw new Error('UGIG_TOKEN not in vault — see setup()');
 
-    const res = await fetch(`${UGIG_API}/users/me`, {
+    const res = await fetch(`${UGIG_API}/profile`, {
       headers: { Authorization: `Bearer ${token}` },
     });
     if (!res.ok) throw new Error(`ugig auth check failed: HTTP ${res.status}`);
-    const data = await res.json() as { username?: string; id?: string };
-    const username = data.username ?? config.username ?? 'ugig';
+    const data = await res.json() as { profile?: { username?: string; id?: string }; username?: string; id?: string };
+    const profile = data.profile ?? data;
+    const username = profile.username ?? config.username ?? 'ugig';
     ctx.log(`ugig connected · @${username}`);
     return { accountId: username };
   },


### PR DESCRIPTION
## Summary
- Update the ugig social connector to call GET /api/profile instead of the now-failing /api/users/me endpoint.
- Read the current response shape from data.profile while keeping the old flat shape as a fallback.
- Add a regression test for the live endpoint path and nested profile response.

## Verification
- Live ugig API check: /api/users/me returned 404, while /api/profile returned the authenticated profile payload.
- corepack pnpm --filter @profullstack/sh1pt-social-ugig typecheck
- corepack pnpm exec vitest run packages/social/ugig/src/index.test.ts