### PR TITLE
Fix devto missing article id handling

### DIFF
--- a/packages/social/devto/src/index.test.ts
+++ b/packages/social/devto/src/index.test.ts
@@ -77,4 +77,23 @@ describe('social-devto posting', () => {
     await expect(adapter.post(ctx as any, { title: 'Release shipped', body: 'Article body' }, {}))
       .rejects.toThrow('Title has already been taken');
   });
+
+  it('throws when DEV omits the article id from a successful response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        url: 'https://dev.to/sh1pt/release-shipped',
+        published_at: '2026-05-11T20:00:00Z',
+      }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ DEVTO_API_KEY: 'dev-key' }),
+      dryRun: false,
+    };
+
+    await expect(adapter.post(ctx as any, { title: 'Release shipped', body: 'Article body' }, {}))
+      .rejects.toThrow('dev.to publish response did not include an article id');
+  });
 });

--- a/packages/social/devto/src/index.ts
+++ b/packages/social/devto/src/index.ts
@@ -37,6 +37,7 @@ export default defineSocial<Config>({
     }
 
     const article = await res.json() as DevtoArticle;
+    if (article.id === undefined) throw new Error('dev.to publish response did not include an article id');
     return {
       id: String(article.id),
       url: article.url ?? 'https://dev.to/',


### PR DESCRIPTION
## Summary
- Throw when dev.to reports a successful article creation response without an article id
- Prevent returning `id: "undefined"` for malformed API responses
- Add a regression test matching the existing Forem/CodeNewbie guard behavior

## Tests
- corepack pnpm --filter @profullstack/sh1pt-social-devto typecheck
- corepack pnpm exec vitest run packages/social/devto/src/index.test.ts
