### PR TITLE
fix: change null to undefined for SocialPlatform type in promote.ts

### DIFF
--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -317,7 +317,7 @@ socialCmd
       console.log(kleur.cyan('dry-run: social post preview\n'));
       for (const name of names) {
         const pkg = `@profullstack/sh1pt-social-${name}`;
-        let adapter: SocialPlatform<unknown> | null = null;
+        let adapter: SocialPlatform<unknown> | undefined;
         try {
           adapter = await loadInstalledPackage<SocialPlatform<unknown>>(pkg);
         } catch {
@@ -341,7 +341,7 @@ socialCmd
     let anyPosted = false;
     for (const name of names) {
       const pkg = `@profullstack/sh1pt-social-${name}`;
-      let adapter: SocialPlatform<unknown> | null = null;
+      let adapter: SocialPlatform<unknown> | undefined;
       try {
         adapter = await loadInstalledPackage<SocialPlatform<unknown>>(pkg);
       } catch {


### PR DESCRIPTION
The `promote.ts` file initializes adapter variables as `null` but the `SocialPlatform<unknown>` type expects `undefined`, not `null`. This fixes type consistency by changing `= null` to `= undefined` for all `SocialPlatform<unknown>` typed variables.

Bug: Type mismatch — `null` assigned to a variable typed as `undefined | SocialPlatform<unknown>`.