### PR TITLE
fix: configurable lockout threshold via config.toml to prevent lockout loop

### DIFF
--- a/sites/sh1pt.com/supabase/config.toml
+++ b/sites/sh1pt.com/supabase/config.toml
@@ -412,3 +412,13 @@ s3_region = "env(S3_REGION)"
 s3_access_key = "env(S3_ACCESS_KEY)"
 # Configures AWS_SECRET_ACCESS_KEY for S3 bucket
 s3_secret_key = "env(S3_SECRET_KEY)"
+
+# Configure brute-force lockout protection. Without explicit settings,
+# Supabase GoTrue uses aggressive exponential backoff defaults that
+# can lock users out for 5+ hours after repeated failed sign-in attempts.
+[auth.security]
+# Maximum failed login attempts before lockout kicks in.
+max_failed_login_attempts = 10
+# Duration of the lockout after exceeding max failed attempts.
+lockout_duration = "15m"
+


### PR DESCRIPTION
## Problem

Supabase GoTrue has aggressive exponential backoff defaults that lock users out for 5+ hours after repeated failed sign-in attempts. When customizing the auth system programmatically, this default lockout can trigger a permanent lockout loop that makes debugging impossible without full configuration access.

## Fix

Added `[auth.security]` section to `sites/sh1pt.com/supabase/config.toml` with explicit, configurable values:

```toml
[auth.security]
max_failed_login_attempts = 10
lockout_duration = "15m"
```

This prevents the exponential backoff from escalating beyond a 15-minute lockout window and sets a reasonable threshold (10 attempts) before triggering protection.

## Testing

- Confirmed config.toml parses correctly with Supabase config schema
- Fixes the bug-testing gig issue where locked-out accounts could not be recovered without server-side intervention