### PR TITLE
fix: add auth.security lockout threshold config to prevent 5hr brute-…

### DIFF
--- a/sites/sh1pt.com/supabase/config.toml
+++ b/sites/sh1pt.com/supabase/config.toml
@@ -412,3 +412,13 @@ s3_region = "env(S3_REGION)"
 s3_access_key = "env(S3_ACCESS_KEY)"
 # Configures AWS_SECRET_ACCESS_KEY for S3 bucket
 s3_secret_key = "env(S3_SECRET_KEY)"
+
+# Configure brute-force lockout protection. Without explicit settings,
+# Supabase GoTrue uses aggressive exponential backoff defaults that
+# can lock users out for 5+ hours after repeated failed sign-in attempts.
+[auth.security]
+# Maximum failed login attempts before lockout kicks in.
+max_failed_login_attempts = 10
+# Duration of the lockout after exceeding max failed attempts.
+lockout_duration = "15m"
+


### PR DESCRIPTION
…force lockout

Adds explicit [auth.security] section to Supabase config with max_failed_login_attempts = 10 and lockout_duration = 15m.

Without this section, Supabase GoTrue uses aggressive exponential backoff defaults that lock users out for 5+ hours after repeated failed login attempts.