### PR TITLE
Fix Windows CLI shim execution

### DIFF
--- a/packages/core/src/exec.test.ts
+++ b/packages/core/src/exec.test.ts
@@ -14,12 +14,17 @@ afterEach(async () => {
 
 describe('exec', () => {
   it('preserves percent-wrapped arguments on Windows shell execution', async () => {
-    const result = await exec(process.execPath, ['-e', 'console.log(process.argv[1])', '%SH1PT_EXEC_LITERAL%'], {
+    const binDir = await mkdtemp(join(tmpdir(), 'sh1pt-exec-bin-'));
+    tempDirs.push(binDir);
+    await installEchoArgsCli(binDir, 'sh1pt-echo-args');
+    process.env.PATH = `${binDir}${delimiter}${oldPath ?? ''}`;
+
+    const result = await exec('sh1pt-echo-args', ['%SH1PT_EXEC_LITERAL%', 'C:\\tmp\\path\\'], {
       log: () => {},
     });
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout.trim()).toBe('%SH1PT_EXEC_LITERAL%');
+    expect(JSON.parse(result.stdout.trim())).toEqual(['%SH1PT_EXEC_LITERAL%', 'C:\\tmp\\path\\']);
   });
 });
 
@@ -43,4 +48,24 @@ async function installFailingCli(binDir: string, name: string): Promise<void> {
 
   const script = join(binDir, name);
   await writeFile(script, '#!/usr/bin/env sh\nexit 127\n', { encoding: 'utf-8', mode: 0o755 });
+}
+
+async function installEchoArgsCli(binDir: string, name: string): Promise<void> {
+  const helper = join(binDir, 'echo-args.js');
+  await writeFile(helper, 'console.log(JSON.stringify(process.argv.slice(2)));\n', 'utf-8');
+
+  if (process.platform === 'win32') {
+    await writeFile(
+      join(binDir, `${name}.cmd`),
+      `@echo off\r\n"${process.execPath}" "%~dp0echo-args.js" %*\r\n`,
+      'utf-8',
+    );
+    return;
+  }
+
+  const script = join(binDir, name);
+  await writeFile(script, `#!/usr/bin/env sh\n"${process.execPath}" "${helper}" "$@"\n`, {
+    encoding: 'utf-8',
+    mode: 0o755,
+  });
 }

--- a/packages/core/src/exec.test.ts
+++ b/packages/core/src/exec.test.ts
@@ -22,6 +22,7 @@ describe('exec', () => {
     process.env.PATH = `${binDir}${delimiter}${oldPath ?? ''}`;
 
     const result = await exec('sh1pt-echo-args', ['%SH1PT_EXEC_LITERAL%', 'C:\\tmp\\path\\'], {
+      env: { SH1PT_EXEC_LITERAL: 'expanded-value' },
       log: () => {},
     });
 

--- a/packages/core/src/exec.test.ts
+++ b/packages/core/src/exec.test.ts
@@ -1,0 +1,46 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ensureCli, exec } from './exec.js';
+
+const tempDirs: string[] = [];
+const oldPath = process.env.PATH;
+
+afterEach(async () => {
+  process.env.PATH = oldPath;
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('exec', () => {
+  it('preserves percent-wrapped arguments on Windows shell execution', async () => {
+    const result = await exec(process.execPath, ['-e', 'console.log(process.argv[1])', '%SH1PT_EXEC_LITERAL%'], {
+      log: () => {},
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('%SH1PT_EXEC_LITERAL%');
+  });
+});
+
+describe('ensureCli', () => {
+  it('throws when a command exits non-zero instead of reporting it as installed', async () => {
+    const binDir = await mkdtemp(join(tmpdir(), 'sh1pt-exec-bin-'));
+    tempDirs.push(binDir);
+    await installFailingCli(binDir, 'sh1pt-missing-version');
+    process.env.PATH = `${binDir}${delimiter}${oldPath ?? ''}`;
+
+    await expect(ensureCli('sh1pt-missing-version', 'install it', () => {}))
+      .rejects.toThrow('sh1pt-missing-version not installed. install it');
+  });
+});
+
+async function installFailingCli(binDir: string, name: string): Promise<void> {
+  if (process.platform === 'win32') {
+    await writeFile(join(binDir, `${name}.cmd`), '@echo off\r\nexit /b 9009\r\n', 'utf-8');
+    return;
+  }
+
+  const script = join(binDir, name);
+  await writeFile(script, '#!/usr/bin/env sh\nexit 127\n', { encoding: 'utf-8', mode: 0o755 });
+}

--- a/packages/core/src/exec.test.ts
+++ b/packages/core/src/exec.test.ts
@@ -21,13 +21,25 @@ describe('exec', () => {
     await installEchoArgsCli(binDir, 'sh1pt-echo-args');
     process.env.PATH = `${binDir}${delimiter}${oldPath ?? ''}`;
 
-    const result = await exec('sh1pt-echo-args', ['%SH1PT_EXEC_LITERAL%', 'C:\\tmp\\path\\'], {
+    const result = await exec('sh1pt-echo-args', [
+      '%SH1PT_EXEC_LITERAL%',
+      'C:\\tmp\\path\\',
+      'Foo & Bar',
+      'hello!world',
+      'quoted "value"',
+    ], {
       env: { SH1PT_EXEC_LITERAL: 'expanded-value' },
       log: () => {},
     });
 
     expect(result.exitCode).toBe(0);
-    expect(JSON.parse(result.stdout.trim())).toEqual(['%SH1PT_EXEC_LITERAL%', 'C:\\tmp\\path\\']);
+    expect(JSON.parse(result.stdout.trim())).toEqual([
+      '%SH1PT_EXEC_LITERAL%',
+      'C:\\tmp\\path\\',
+      'Foo & Bar',
+      'hello!world',
+      'quoted "value"',
+    ]);
   });
 });
 

--- a/packages/core/src/exec.test.ts
+++ b/packages/core/src/exec.test.ts
@@ -6,6 +6,8 @@ import { ensureCli, exec } from './exec.js';
 
 const tempDirs: string[] = [];
 const oldPath = process.env.PATH;
+const itOnWindows = process.platform === 'win32' ? it : it.skip;
+const itOnNonWindows = process.platform === 'win32' ? it.skip : it;
 
 afterEach(async () => {
   process.env.PATH = oldPath;
@@ -29,7 +31,7 @@ describe('exec', () => {
 });
 
 describe('ensureCli', () => {
-  it('throws when a command exits non-zero instead of reporting it as installed', async () => {
+  itOnWindows('throws when Windows reports a command-not-found exit', async () => {
     const binDir = await mkdtemp(join(tmpdir(), 'sh1pt-exec-bin-'));
     tempDirs.push(binDir);
     await installFailingCli(binDir, 'sh1pt-missing-version');
@@ -37,6 +39,16 @@ describe('ensureCli', () => {
 
     await expect(ensureCli('sh1pt-missing-version', 'install it', () => {}))
       .rejects.toThrow('sh1pt-missing-version not installed. install it');
+  });
+
+  itOnNonWindows('keeps non-Windows non-zero version exits distinct from missing commands', async () => {
+    const binDir = await mkdtemp(join(tmpdir(), 'sh1pt-exec-bin-'));
+    tempDirs.push(binDir);
+    await installFailingCli(binDir, 'sh1pt-installed-failing-version');
+    process.env.PATH = `${binDir}${delimiter}${oldPath ?? ''}`;
+
+    await expect(ensureCli('sh1pt-installed-failing-version', 'install it', () => {}))
+      .resolves.toBeUndefined();
   });
 });
 

--- a/packages/core/src/exec.ts
+++ b/packages/core/src/exec.ts
@@ -28,11 +28,14 @@ export async function exec(cmd: string, args: string[], opts: ExecOptions): Prom
   }
 
   return new Promise<ExecResult>((resolve, reject) => {
-    const child = spawn(cmd, args, {
+    const spawnOptions = {
       cwd: opts.cwd,
       env: { ...process.env, ...extraEnv },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
+      stdio: 'pipe' as const,
+    };
+    const child = process.platform === 'win32'
+      ? spawn(windowsCommandLine(cmd, args), { ...spawnOptions, shell: true })
+      : spawn(cmd, args, spawnOptions);
 
     let stdout = '';
     let stderr = '';
@@ -67,6 +70,15 @@ export async function exec(cmd: string, args: string[], opts: ExecOptions): Prom
       }
     });
   });
+}
+
+function windowsCommandLine(cmd: string, args: string[]): string {
+  return [cmd, ...args].map(windowsShellQuote).join(' ');
+}
+
+function windowsShellQuote(value: string): string {
+  if (/^[A-Za-z0-9_/:=.+@-]+$/.test(value)) return value;
+  return `"${value.replace(/"/g, '\\"')}"`;
 }
 
 export async function ensureCli(cmd: string, installHint: string, log: LogFn): Promise<void> {

--- a/packages/core/src/exec.ts
+++ b/packages/core/src/exec.ts
@@ -83,7 +83,7 @@ function shouldUseWindowsCmd(cmd: string): boolean {
 export async function ensureCli(cmd: string, installHint: string, log: LogFn): Promise<void> {
   try {
     const result = await exec(cmd, ['--version'], { log: () => {}, throwOnNonZero: false });
-    if (result.exitCode !== 0) throw new Error(`command not found: ${cmd}`);
+    if (isWindowsCommandNotFound(result)) throw new Error(`command not found: ${cmd}`);
   } catch (err) {
     if (err instanceof Error && err.message.startsWith('command not found')) {
       log(`${cmd} not found on PATH`, 'error');
@@ -91,4 +91,12 @@ export async function ensureCli(cmd: string, installHint: string, log: LogFn): P
     }
     throw err;
   }
+}
+
+function isWindowsCommandNotFound(result: ExecResult): boolean {
+  if (process.platform !== 'win32' || result.exitCode === 0) return false;
+
+  const output = `${result.stderr}\n${result.stdout}`;
+  return result.exitCode === 9009
+    || output.includes('is not recognized as an internal or external command');
 }

--- a/packages/core/src/exec.ts
+++ b/packages/core/src/exec.ts
@@ -34,8 +34,8 @@ export async function exec(cmd: string, args: string[], opts: ExecOptions): Prom
       env: { ...process.env, ...extraEnv },
       stdio: ['ignore', 'pipe', 'pipe'],
     };
-    const child = shouldUseWindowsShell(cmd)
-      ? spawn(windowsCommandLine(cmd, args), { ...spawnOptions, shell: true })
+    const child = shouldUseWindowsCmd(cmd)
+      ? spawn('cmd.exe', ['/d', '/s', '/c', cmd, ...args], spawnOptions)
       : spawn(cmd, args, spawnOptions);
 
     let stdout = '';
@@ -73,20 +73,11 @@ export async function exec(cmd: string, args: string[], opts: ExecOptions): Prom
   });
 }
 
-function shouldUseWindowsShell(cmd: string): boolean {
+function shouldUseWindowsCmd(cmd: string): boolean {
   return process.platform === 'win32'
     && !cmd.includes('/')
     && !cmd.includes('\\')
     && !/\.(?:exe|com)$/i.test(cmd);
-}
-
-function windowsCommandLine(cmd: string, args: string[]): string {
-  return [cmd, ...args].map(windowsShellQuote).join(' ');
-}
-
-function windowsShellQuote(value: string): string {
-  if (/^[A-Za-z0-9_/:=.+@-]+$/.test(value)) return value;
-  return `"${value.replace(/(\\*)"/g, '$1$1\\"').replace(/\\+$/, '$&$&')}"`;
 }
 
 export async function ensureCli(cmd: string, installHint: string, log: LogFn): Promise<void> {

--- a/packages/core/src/exec.ts
+++ b/packages/core/src/exec.ts
@@ -34,9 +34,14 @@ export async function exec(cmd: string, args: string[], opts: ExecOptions): Prom
       env: { ...process.env, ...extraEnv },
       stdio: ['ignore', 'pipe', 'pipe'],
     };
-    const child = shouldUseWindowsCmd(cmd)
-      ? spawn('cmd.exe', ['/d', '/s', '/c', windowsCommandLine(cmd, args)], {
+    const useWindowsCmd = shouldUseWindowsCmd(cmd);
+    const windowsCommand = useWindowsCmd
+      ? windowsCommandLine(cmd, args, spawnOptions.env)
+      : { command: '', env: spawnOptions.env };
+    const child = useWindowsCmd
+      ? spawn('cmd.exe', ['/d', '/s', '/v:on', '/c', windowsCommand.command], {
         ...spawnOptions,
+        env: windowsCommand.env,
         windowsVerbatimArguments: true,
       })
       : spawn(cmd, args, spawnOptions);
@@ -83,18 +88,25 @@ function shouldUseWindowsCmd(cmd: string): boolean {
     && !/\.(?:exe|com)$/i.test(cmd);
 }
 
-function windowsCommandLine(cmd: string, args: string[]): string {
-  return [cmd, ...args].map(windowsCmdArg).join(' ');
+function windowsCommandLine(
+  cmd: string,
+  args: string[],
+  env: NodeJS.ProcessEnv | undefined,
+): { command: string; env: NodeJS.ProcessEnv } {
+  const nextEnv: NodeJS.ProcessEnv = { ...env };
+  const argRefs = args.map((arg, index) => {
+    const name = `SH1PT_EXEC_ARG_${index}`;
+    nextEnv[name] = windowsEnvArg(arg);
+    return `"!${name}!"`;
+  });
+  return { command: [cmd, ...argRefs].join(' '), env: nextEnv };
 }
 
-function windowsCmdArg(value: string): string {
-  let escaped = value.replace(/([%^&|<>()])/g, '^$1');
-  if (!/[\s"]/.test(escaped)) return escaped;
-
-  escaped = escaped
+function windowsEnvArg(value: string): string {
+  return value
     .replace(/(\\*)"/g, '$1$1\\"')
-    .replace(/\\+$/, '$&$&');
-  return `"${escaped}"`;
+    .replace(/\\+$/, '$&$&')
+    .replace(/!/g, '^!');
 }
 
 export async function ensureCli(cmd: string, installHint: string, log: LogFn): Promise<void> {

--- a/packages/core/src/exec.ts
+++ b/packages/core/src/exec.ts
@@ -35,7 +35,10 @@ export async function exec(cmd: string, args: string[], opts: ExecOptions): Prom
       stdio: ['ignore', 'pipe', 'pipe'],
     };
     const child = shouldUseWindowsCmd(cmd)
-      ? spawn('cmd.exe', ['/d', '/s', '/c', cmd, ...args], spawnOptions)
+      ? spawn('cmd.exe', ['/d', '/s', '/c', windowsCommandLine(cmd, args)], {
+        ...spawnOptions,
+        windowsVerbatimArguments: true,
+      })
       : spawn(cmd, args, spawnOptions);
 
     let stdout = '';
@@ -78,6 +81,20 @@ function shouldUseWindowsCmd(cmd: string): boolean {
     && !cmd.includes('/')
     && !cmd.includes('\\')
     && !/\.(?:exe|com)$/i.test(cmd);
+}
+
+function windowsCommandLine(cmd: string, args: string[]): string {
+  return [cmd, ...args].map(windowsCmdArg).join(' ');
+}
+
+function windowsCmdArg(value: string): string {
+  let escaped = value.replace(/([%^&|<>()])/g, '^$1');
+  if (!/[\s"]/.test(escaped)) return escaped;
+
+  escaped = escaped
+    .replace(/(\\*)"/g, '$1$1\\"')
+    .replace(/\\+$/, '$&$&');
+  return `"${escaped}"`;
 }
 
 export async function ensureCli(cmd: string, installHint: string, log: LogFn): Promise<void> {

--- a/packages/core/src/exec.ts
+++ b/packages/core/src/exec.ts
@@ -34,7 +34,7 @@ export async function exec(cmd: string, args: string[], opts: ExecOptions): Prom
       env: { ...process.env, ...extraEnv },
       stdio: ['ignore', 'pipe', 'pipe'],
     };
-    const child = process.platform === 'win32'
+    const child = shouldUseWindowsShell(cmd)
       ? spawn(windowsCommandLine(cmd, args), { ...spawnOptions, shell: true })
       : spawn(cmd, args, spawnOptions);
 
@@ -73,6 +73,13 @@ export async function exec(cmd: string, args: string[], opts: ExecOptions): Prom
   });
 }
 
+function shouldUseWindowsShell(cmd: string): boolean {
+  return process.platform === 'win32'
+    && !cmd.includes('/')
+    && !cmd.includes('\\')
+    && !/\.(?:exe|com)$/i.test(cmd);
+}
+
 function windowsCommandLine(cmd: string, args: string[]): string {
   return [cmd, ...args].map(windowsShellQuote).join(' ');
 }
@@ -84,7 +91,8 @@ function windowsShellQuote(value: string): string {
 
 export async function ensureCli(cmd: string, installHint: string, log: LogFn): Promise<void> {
   try {
-    await exec(cmd, ['--version'], { log: () => {}, throwOnNonZero: false });
+    const result = await exec(cmd, ['--version'], { log: () => {}, throwOnNonZero: false });
+    if (result.exitCode !== 0) throw new Error(`command not found: ${cmd}`);
   } catch (err) {
     if (err instanceof Error && err.message.startsWith('command not found')) {
       log(`${cmd} not found on PATH`, 'error');

--- a/packages/core/src/exec.ts
+++ b/packages/core/src/exec.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import type { SpawnOptions } from 'node:child_process';
 import type { BuildContext } from './target.js';
 
 type LogFn = BuildContext['log'];
@@ -28,10 +29,10 @@ export async function exec(cmd: string, args: string[], opts: ExecOptions): Prom
   }
 
   return new Promise<ExecResult>((resolve, reject) => {
-    const spawnOptions = {
+    const spawnOptions: SpawnOptions = {
       cwd: opts.cwd,
       env: { ...process.env, ...extraEnv },
-      stdio: 'pipe' as const,
+      stdio: ['ignore', 'pipe', 'pipe'],
     };
     const child = process.platform === 'win32'
       ? spawn(windowsCommandLine(cmd, args), { ...spawnOptions, shell: true })
@@ -40,13 +41,13 @@ export async function exec(cmd: string, args: string[], opts: ExecOptions): Prom
     let stdout = '';
     let stderr = '';
 
-    child.stdout.on('data', (chunk: Buffer) => {
+    child.stdout?.on('data', (chunk: Buffer) => {
       const text = chunk.toString();
       stdout += text;
       for (const line of text.split('\n')) if (line) opts.log(line);
     });
 
-    child.stderr.on('data', (chunk: Buffer) => {
+    child.stderr?.on('data', (chunk: Buffer) => {
       const text = chunk.toString();
       stderr += text;
       for (const line of text.split('\n')) if (line) opts.log(line, 'warn');
@@ -78,7 +79,7 @@ function windowsCommandLine(cmd: string, args: string[]): string {
 
 function windowsShellQuote(value: string): string {
   if (/^[A-Za-z0-9_/:=.+@-]+$/.test(value)) return value;
-  return `"${value.replace(/"/g, '\\"')}"`;
+  return `"${value.replace(/(\\*)"/g, '$1$1\\"').replace(/\\+$/, '$&$&')}"`;
 }
 
 export async function ensureCli(cmd: string, installHint: string, log: LogFn): Promise<void> {

--- a/packages/docs/pandoc/src/index.test.ts
+++ b/packages/docs/pandoc/src/index.test.ts
@@ -1,7 +1,7 @@
 import { contractTestDocs } from '@profullstack/sh1pt-core/testing';
 import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import docs from './index.js';
 
@@ -48,7 +48,7 @@ describe('docs-pandoc generation', () => {
     const binDir = await mkdtemp(join(tmpdir(), 'sh1pt-pandoc-bin-'));
     tempDirs.push(outDir, binDir);
     await installFakePandoc(binDir);
-    process.env.PATH = `${binDir}:${oldPath ?? ''}`;
+    process.env.PATH = `${binDir}${delimiter}${oldPath ?? ''}`;
 
     const result = await docs.generate({ secret: () => undefined, log: () => {}, dryRun: false }, {
       kind: 'whitepaper',
@@ -90,6 +90,22 @@ describe('docs-pandoc generation', () => {
 });
 
 async function installFakePandoc(binDir: string): Promise<void> {
+  if (process.platform === 'win32') {
+    const helper = join(binDir, 'pandoc.js');
+    await writeFile(helper, [
+      'const { writeFileSync } = require("node:fs");',
+      'const { dirname, join } = require("node:path");',
+      'const args = process.argv.slice(2);',
+      'const outIndex = args.indexOf("-o");',
+      'const out = outIndex >= 0 ? args[outIndex + 1] : "";',
+      'if (!out) throw new Error("missing -o");',
+      'writeFileSync(join(dirname(out), "pandoc-args.json"), JSON.stringify(args));',
+      'writeFileSync(out, "fake pandoc output\\n");',
+    ].join('\n'), 'utf-8');
+    await writeFile(join(binDir, 'pandoc.cmd'), `@echo off\r\n"${process.execPath}" "%~dp0\\pandoc.js" %*\r\n`, 'utf-8');
+    return;
+  }
+
   const script = join(binDir, 'pandoc');
   await writeFile(script, [
     '#!/usr/bin/env bash',

--- a/packages/docs/pandoc/src/index.test.ts
+++ b/packages/docs/pandoc/src/index.test.ts
@@ -102,7 +102,7 @@ async function installFakePandoc(binDir: string): Promise<void> {
       'writeFileSync(join(dirname(out), "pandoc-args.json"), JSON.stringify(args));',
       'writeFileSync(out, "fake pandoc output\\n");',
     ].join('\n'), 'utf-8');
-    await writeFile(join(binDir, 'pandoc.cmd'), `@echo off\r\n"${process.execPath}" "%~dp0\\pandoc.js" %*\r\n`, 'utf-8');
+    await writeFile(join(binDir, 'pandoc.cmd'), `@echo off\r\n"${process.execPath}" "%~dp0pandoc.js" %*\r\n`, 'utf-8');
     return;
   }
 


### PR DESCRIPTION
## Summary
- Run shared `exec()` commands through the Windows shell on Windows so `.cmd` shims such as `npx`, `vsce`, `jsr`, and `pandoc` resolve correctly
- Keep non-Windows execution unchanged
- Make the docs-pandoc fake CLI test install a Windows-compatible shim and use the platform PATH delimiter

## Why
On Windows, `child_process.spawn('npx', ...)` and `spawn('pandoc', ...)` fail with `ENOENT` in this environment because command shims are exposed as `.cmd` files. That means target/doc adapters that rely on external CLIs cannot execute even when the CLI is installed on PATH.

## Validation
- `pnpm exec vitest run packages/docs/pandoc/src/index.test.ts` -> 5 passed
- `pnpm --filter @profullstack/sh1pt-core typecheck`
- `pnpm --filter @profullstack/sh1pt-docs-pandoc typecheck`

For the ugig bug-fix bounty: this fixes a Windows CLI execution bug found while testing the repository locally.