### PR TITLE
[codex] Fix AI adapter publish metadata

### DIFF
--- a/packages/ai/ai21/package.json
+++ b/packages/ai/ai21/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/ai21/package.json
+++ b/packages/ai/ai21/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/ai21/package.json
+++ b/packages/ai/ai21/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/aionlabs/package.json
+++ b/packages/ai/aionlabs/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/aionlabs/package.json
+++ b/packages/ai/aionlabs/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/aionlabs/package.json
+++ b/packages/ai/aionlabs/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/akashml/package.json
+++ b/packages/ai/akashml/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/akashml/package.json
+++ b/packages/ai/akashml/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/akashml/package.json
+++ b/packages/ai/akashml/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/alibaba-cloud/package.json
+++ b/packages/ai/alibaba-cloud/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/alibaba-cloud/package.json
+++ b/packages/ai/alibaba-cloud/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/alibaba-cloud/package.json
+++ b/packages/ai/alibaba-cloud/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/amazon-bedrock/package.json
+++ b/packages/ai/amazon-bedrock/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/amazon-bedrock/package.json
+++ b/packages/ai/amazon-bedrock/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/amazon-bedrock/package.json
+++ b/packages/ai/amazon-bedrock/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/arcee/package.json
+++ b/packages/ai/arcee/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/arcee/package.json
+++ b/packages/ai/arcee/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/arcee/package.json
+++ b/packages/ai/arcee/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/atlascloud/package.json
+++ b/packages/ai/atlascloud/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/atlascloud/package.json
+++ b/packages/ai/atlascloud/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/atlascloud/package.json
+++ b/packages/ai/atlascloud/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/azure/package.json
+++ b/packages/ai/azure/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/azure/package.json
+++ b/packages/ai/azure/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/azure/package.json
+++ b/packages/ai/azure/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/baidu/package.json
+++ b/packages/ai/baidu/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/baidu/package.json
+++ b/packages/ai/baidu/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/baidu/package.json
+++ b/packages/ai/baidu/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/baseten/package.json
+++ b/packages/ai/baseten/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/baseten/package.json
+++ b/packages/ai/baseten/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/baseten/package.json
+++ b/packages/ai/baseten/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/cerebras/package.json
+++ b/packages/ai/cerebras/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/cerebras/package.json
+++ b/packages/ai/cerebras/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/cerebras/package.json
+++ b/packages/ai/cerebras/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/chutes/package.json
+++ b/packages/ai/chutes/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/chutes/package.json
+++ b/packages/ai/chutes/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/chutes/package.json
+++ b/packages/ai/chutes/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/clarifai/package.json
+++ b/packages/ai/clarifai/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/clarifai/package.json
+++ b/packages/ai/clarifai/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/clarifai/package.json
+++ b/packages/ai/clarifai/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/claude/package.json
+++ b/packages/ai/claude/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/claude/package.json
+++ b/packages/ai/claude/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/claude/package.json
+++ b/packages/ai/claude/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/cloudflare/package.json
+++ b/packages/ai/cloudflare/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/cloudflare/package.json
+++ b/packages/ai/cloudflare/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/cloudflare/package.json
+++ b/packages/ai/cloudflare/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/cohere/package.json
+++ b/packages/ai/cohere/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/cohere/package.json
+++ b/packages/ai/cohere/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/cohere/package.json
+++ b/packages/ai/cohere/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/deepinfra/package.json
+++ b/packages/ai/deepinfra/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/deepinfra/package.json
+++ b/packages/ai/deepinfra/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/deepinfra/package.json
+++ b/packages/ai/deepinfra/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/deepseek/package.json
+++ b/packages/ai/deepseek/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/deepseek/package.json
+++ b/packages/ai/deepseek/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/deepseek/package.json
+++ b/packages/ai/deepseek/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/featherless/package.json
+++ b/packages/ai/featherless/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/featherless/package.json
+++ b/packages/ai/featherless/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/featherless/package.json
+++ b/packages/ai/featherless/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/fireworks/package.json
+++ b/packages/ai/fireworks/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/fireworks/package.json
+++ b/packages/ai/fireworks/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/fireworks/package.json
+++ b/packages/ai/fireworks/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/friendli/package.json
+++ b/packages/ai/friendli/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/friendli/package.json
+++ b/packages/ai/friendli/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/friendli/package.json
+++ b/packages/ai/friendli/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/gemini/package.json
+++ b/packages/ai/gemini/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/gemini/package.json
+++ b/packages/ai/gemini/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/gemini/package.json
+++ b/packages/ai/gemini/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/gmicloud/package.json
+++ b/packages/ai/gmicloud/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/gmicloud/package.json
+++ b/packages/ai/gmicloud/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/gmicloud/package.json
+++ b/packages/ai/gmicloud/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/google-vertex/package.json
+++ b/packages/ai/google-vertex/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/google-vertex/package.json
+++ b/packages/ai/google-vertex/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/google-vertex/package.json
+++ b/packages/ai/google-vertex/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/groq/package.json
+++ b/packages/ai/groq/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/groq/package.json
+++ b/packages/ai/groq/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/groq/package.json
+++ b/packages/ai/groq/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/inception/package.json
+++ b/packages/ai/inception/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/inception/package.json
+++ b/packages/ai/inception/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/inception/package.json
+++ b/packages/ai/inception/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/inceptron/package.json
+++ b/packages/ai/inceptron/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/inceptron/package.json
+++ b/packages/ai/inceptron/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/inceptron/package.json
+++ b/packages/ai/inceptron/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/infermatic/package.json
+++ b/packages/ai/infermatic/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/infermatic/package.json
+++ b/packages/ai/infermatic/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/infermatic/package.json
+++ b/packages/ai/infermatic/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/inflection/package.json
+++ b/packages/ai/inflection/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/inflection/package.json
+++ b/packages/ai/inflection/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/inflection/package.json
+++ b/packages/ai/inflection/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/ionet/package.json
+++ b/packages/ai/ionet/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/ionet/package.json
+++ b/packages/ai/ionet/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/ionet/package.json
+++ b/packages/ai/ionet/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/kimi/package.json
+++ b/packages/ai/kimi/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/kimi/package.json
+++ b/packages/ai/kimi/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/kimi/package.json
+++ b/packages/ai/kimi/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/liquid/package.json
+++ b/packages/ai/liquid/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/liquid/package.json
+++ b/packages/ai/liquid/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/liquid/package.json
+++ b/packages/ai/liquid/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/litellm/package.json
+++ b/packages/ai/litellm/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/litellm/package.json
+++ b/packages/ai/litellm/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/litellm/package.json
+++ b/packages/ai/litellm/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/mancer/package.json
+++ b/packages/ai/mancer/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/mancer/package.json
+++ b/packages/ai/mancer/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/mancer/package.json
+++ b/packages/ai/mancer/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/minimax/package.json
+++ b/packages/ai/minimax/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/minimax/package.json
+++ b/packages/ai/minimax/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/minimax/package.json
+++ b/packages/ai/minimax/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/mistral/package.json
+++ b/packages/ai/mistral/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/mistral/package.json
+++ b/packages/ai/mistral/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/mistral/package.json
+++ b/packages/ai/mistral/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/moonshot/package.json
+++ b/packages/ai/moonshot/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/moonshot/package.json
+++ b/packages/ai/moonshot/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/moonshot/package.json
+++ b/packages/ai/moonshot/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/morph/package.json
+++ b/packages/ai/morph/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/morph/package.json
+++ b/packages/ai/morph/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/morph/package.json
+++ b/packages/ai/morph/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/nebius/package.json
+++ b/packages/ai/nebius/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/nebius/package.json
+++ b/packages/ai/nebius/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/nebius/package.json
+++ b/packages/ai/nebius/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/nextbit/package.json
+++ b/packages/ai/nextbit/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/nextbit/package.json
+++ b/packages/ai/nextbit/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/nextbit/package.json
+++ b/packages/ai/nextbit/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/novita/package.json
+++ b/packages/ai/novita/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/novita/package.json
+++ b/packages/ai/novita/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/novita/package.json
+++ b/packages/ai/novita/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/openai/package.json
+++ b/packages/ai/openai/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/openai/package.json
+++ b/packages/ai/openai/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/openai/package.json
+++ b/packages/ai/openai/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/openinference/package.json
+++ b/packages/ai/openinference/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/openinference/package.json
+++ b/packages/ai/openinference/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/openinference/package.json
+++ b/packages/ai/openinference/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/parasail/package.json
+++ b/packages/ai/parasail/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/parasail/package.json
+++ b/packages/ai/parasail/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/parasail/package.json
+++ b/packages/ai/parasail/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/perceptron/package.json
+++ b/packages/ai/perceptron/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/perceptron/package.json
+++ b/packages/ai/perceptron/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/perceptron/package.json
+++ b/packages/ai/perceptron/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/perplexity/package.json
+++ b/packages/ai/perplexity/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/perplexity/package.json
+++ b/packages/ai/perplexity/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/perplexity/package.json
+++ b/packages/ai/perplexity/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/phala/package.json
+++ b/packages/ai/phala/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/phala/package.json
+++ b/packages/ai/phala/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/phala/package.json
+++ b/packages/ai/phala/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/qwen/package.json
+++ b/packages/ai/qwen/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/qwen/package.json
+++ b/packages/ai/qwen/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/qwen/package.json
+++ b/packages/ai/qwen/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/reka/package.json
+++ b/packages/ai/reka/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/reka/package.json
+++ b/packages/ai/reka/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/reka/package.json
+++ b/packages/ai/reka/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/relace/package.json
+++ b/packages/ai/relace/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/relace/package.json
+++ b/packages/ai/relace/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/relace/package.json
+++ b/packages/ai/relace/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/sambanova/package.json
+++ b/packages/ai/sambanova/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/sambanova/package.json
+++ b/packages/ai/sambanova/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/sambanova/package.json
+++ b/packages/ai/sambanova/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/siliconflow/package.json
+++ b/packages/ai/siliconflow/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/siliconflow/package.json
+++ b/packages/ai/siliconflow/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/siliconflow/package.json
+++ b/packages/ai/siliconflow/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/stepfun/package.json
+++ b/packages/ai/stepfun/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/stepfun/package.json
+++ b/packages/ai/stepfun/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/stepfun/package.json
+++ b/packages/ai/stepfun/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/switchpoint/package.json
+++ b/packages/ai/switchpoint/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/switchpoint/package.json
+++ b/packages/ai/switchpoint/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/switchpoint/package.json
+++ b/packages/ai/switchpoint/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/together/package.json
+++ b/packages/ai/together/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/together/package.json
+++ b/packages/ai/together/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/together/package.json
+++ b/packages/ai/together/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/venice/package.json
+++ b/packages/ai/venice/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/venice/package.json
+++ b/packages/ai/venice/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/venice/package.json
+++ b/packages/ai/venice/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/wandb/package.json
+++ b/packages/ai/wandb/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/wandb/package.json
+++ b/packages/ai/wandb/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/wandb/package.json
+++ b/packages/ai/wandb/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/xai/package.json
+++ b/packages/ai/xai/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/xai/package.json
+++ b/packages/ai/xai/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/xai/package.json
+++ b/packages/ai/xai/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/xiaomi/package.json
+++ b/packages/ai/xiaomi/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/xiaomi/package.json
+++ b/packages/ai/xiaomi/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/xiaomi/package.json
+++ b/packages/ai/xiaomi/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/ai/zai/package.json
+++ b/packages/ai/zai/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.15",
   "type": "module",
   "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/ai/zai/package.json
+++ b/packages/ai/zai/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/ai/zai/package.json
+++ b/packages/ai/zai/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add publishConfig metadata for all AI adapter packages so packed/published manifests point to compiled `dist` files
- add root-level `types: ./src/index.ts` to match the monorepo manifest pattern and address review feedback

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter ./packages/ai/** typecheck`
- `corepack pnpm --filter @profullstack/sh1pt-ai-openai build`
- `corepack pnpm --filter @profullstack/sh1pt-ai-ai21 build`
- representative `pnpm pack` checks for openai and ai21 showed published manifests rewrite main/types/exports to dist
- every `packages/ai/*/package.json` has root `types: ./src/index.ts`
- `git diff --check -- packages/ai`