### PR TITLE
[codex] Fix non-AI adapter publish metadata

### DIFF
--- a/packages/affiliates/admitad/package.json
+++ b/packages/affiliates/admitad/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/affiliates/admitad/package.json
+++ b/packages/affiliates/admitad/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/affiliates/amazon-associates/package.json
+++ b/packages/affiliates/amazon-associates/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/affiliates/amazon-associates/package.json
+++ b/packages/affiliates/amazon-associates/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/affiliates/avangate/package.json
+++ b/packages/affiliates/avangate/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/affiliates/avangate/package.json
+++ b/packages/affiliates/avangate/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/affiliates/awin/package.json
+++ b/packages/affiliates/awin/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/affiliates/awin/package.json
+++ b/packages/affiliates/awin/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/affiliates/cj/package.json
+++ b/packages/affiliates/cj/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/affiliates/cj/package.json
+++ b/packages/affiliates/cj/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/affiliates/clickbank/package.json
+++ b/packages/affiliates/clickbank/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/affiliates/clickbank/package.json
+++ b/packages/affiliates/clickbank/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/affiliates/digistore24/package.json
+++ b/packages/affiliates/digistore24/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/affiliates/digistore24/package.json
+++ b/packages/affiliates/digistore24/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/affiliates/ebay-partner/package.json
+++ b/packages/affiliates/ebay-partner/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/affiliates/ebay-partner/package.json
+++ b/packages/affiliates/ebay-partner/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/affiliates/everflow/package.json
+++ b/packages/affiliates/everflow/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/affiliates/everflow/package.json
+++ b/packages/affiliates/everflow/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/affiliates/flexoffers/package.json
+++ b/packages/affiliates/flexoffers/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/affiliates/flexoffers/package.json
+++ b/packages/affiliates/flexoffers/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/affiliates/impact/package.json
+++ b/packages/affiliates/impact/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/affiliates/impact/package.json
+++ b/packages/affiliates/impact/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/affiliates/jvzoo/package.json
+++ b/packages/affiliates/jvzoo/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/affiliates/jvzoo/package.json
+++ b/packages/affiliates/jvzoo/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/affiliates/partnerstack/package.json
+++ b/packages/affiliates/partnerstack/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/affiliates/partnerstack/package.json
+++ b/packages/affiliates/partnerstack/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/affiliates/rakuten/package.json
+++ b/packages/affiliates/rakuten/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/affiliates/rakuten/package.json
+++ b/packages/affiliates/rakuten/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/affiliates/refersion/package.json
+++ b/packages/affiliates/refersion/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/affiliates/refersion/package.json
+++ b/packages/affiliates/refersion/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/affiliates/shareasale/package.json
+++ b/packages/affiliates/shareasale/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/affiliates/shareasale/package.json
+++ b/packages/affiliates/shareasale/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/affiliates/skimlinks/package.json
+++ b/packages/affiliates/skimlinks/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/affiliates/skimlinks/package.json
+++ b/packages/affiliates/skimlinks/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/affiliates/sovrn/package.json
+++ b/packages/affiliates/sovrn/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/affiliates/sovrn/package.json
+++ b/packages/affiliates/sovrn/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/affiliates/tapfiliate/package.json
+++ b/packages/affiliates/tapfiliate/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/affiliates/tapfiliate/package.json
+++ b/packages/affiliates/tapfiliate/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/affiliates/tradedoubler/package.json
+++ b/packages/affiliates/tradedoubler/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/affiliates/tradedoubler/package.json
+++ b/packages/affiliates/tradedoubler/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/agents/claude/package.json
+++ b/packages/agents/claude/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/agents/claude/package.json
+++ b/packages/agents/claude/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/agents/codex/package.json
+++ b/packages/agents/codex/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/agents/codex/package.json
+++ b/packages/agents/codex/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/agents/qwen/package.json
+++ b/packages/agents/qwen/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/agents/qwen/package.json
+++ b/packages/agents/qwen/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -26,5 +26,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -34,7 +34,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/automation/stagehand/package.json
+++ b/packages/automation/stagehand/package.json
@@ -37,7 +37,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/automation/stagehand/package.json
+++ b/packages/automation/stagehand/package.json
@@ -15,7 +15,9 @@
     "@browserbasehq/stagehand": "^2.0.0"
   },
   "peerDependenciesMeta": {
-    "@browserbasehq/stagehand": { "optional": true }
+    "@browserbasehq/stagehand": {
+      "optional": true
+    }
   },
   "license": "MIT",
   "repository": {
@@ -25,5 +27,18 @@
   },
   "homepage": "https://sh1pt.com",
   "bugs": "https://github.com/profullstack/sh1pt/issues",
-  "files": ["dist"]
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bots/core/package.json
+++ b/packages/bots/core/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bots/core/package.json
+++ b/packages/bots/core/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bots/discord/package.json
+++ b/packages/bots/discord/package.json
@@ -24,5 +24,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bots/discord/package.json
+++ b/packages/bots/discord/package.json
@@ -32,7 +32,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bots/irc/package.json
+++ b/packages/bots/irc/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bots/irc/package.json
+++ b/packages/bots/irc/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bots/matrix/package.json
+++ b/packages/bots/matrix/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bots/matrix/package.json
+++ b/packages/bots/matrix/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bots/phonenumbers/package.json
+++ b/packages/bots/phonenumbers/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bots/phonenumbers/package.json
+++ b/packages/bots/phonenumbers/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bots/signal/package.json
+++ b/packages/bots/signal/package.json
@@ -23,5 +23,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bots/signal/package.json
+++ b/packages/bots/signal/package.json
@@ -31,7 +31,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bots/slack/package.json
+++ b/packages/bots/slack/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bots/slack/package.json
+++ b/packages/bots/slack/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bots/teams/package.json
+++ b/packages/bots/teams/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bots/teams/package.json
+++ b/packages/bots/teams/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bots/telegram/package.json
+++ b/packages/bots/telegram/package.json
@@ -24,5 +24,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bots/telegram/package.json
+++ b/packages/bots/telegram/package.json
@@ -32,7 +32,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bots/telnyx/package.json
+++ b/packages/bots/telnyx/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bots/telnyx/package.json
+++ b/packages/bots/telnyx/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bots/twilio/package.json
+++ b/packages/bots/twilio/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bots/twilio/package.json
+++ b/packages/bots/twilio/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bots/twitch/package.json
+++ b/packages/bots/twitch/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bots/twitch/package.json
+++ b/packages/bots/twitch/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bots/wechat/package.json
+++ b/packages/bots/wechat/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bots/wechat/package.json
+++ b/packages/bots/wechat/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bots/whatsapp/package.json
+++ b/packages/bots/whatsapp/package.json
@@ -24,5 +24,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bots/whatsapp/package.json
+++ b/packages/bots/whatsapp/package.json
@@ -32,7 +32,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bridges/discord/package.json
+++ b/packages/bridges/discord/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bridges/discord/package.json
+++ b/packages/bridges/discord/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bridges/irc/package.json
+++ b/packages/bridges/irc/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bridges/irc/package.json
+++ b/packages/bridges/irc/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bridges/mastodon/package.json
+++ b/packages/bridges/mastodon/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bridges/mastodon/package.json
+++ b/packages/bridges/mastodon/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bridges/matrix/package.json
+++ b/packages/bridges/matrix/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bridges/matrix/package.json
+++ b/packages/bridges/matrix/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bridges/nostr/package.json
+++ b/packages/bridges/nostr/package.json
@@ -22,5 +22,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bridges/nostr/package.json
+++ b/packages/bridges/nostr/package.json
@@ -30,7 +30,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bridges/signal/package.json
+++ b/packages/bridges/signal/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bridges/signal/package.json
+++ b/packages/bridges/signal/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bridges/slack/package.json
+++ b/packages/bridges/slack/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bridges/slack/package.json
+++ b/packages/bridges/slack/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/bridges/telegram/package.json
+++ b/packages/bridges/telegram/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/bridges/telegram/package.json
+++ b/packages/bridges/telegram/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/captcha/2captcha/package.json
+++ b/packages/captcha/2captcha/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/captcha/2captcha/package.json
+++ b/packages/captcha/2captcha/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/captcha/captchasolver/package.json
+++ b/packages/captcha/captchasolver/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/captcha/captchasolver/package.json
+++ b/packages/captcha/captchasolver/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/cloud/atlantic/package.json
+++ b/packages/cloud/atlantic/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/cloud/atlantic/package.json
+++ b/packages/cloud/atlantic/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/cloud/cloudflare/package.json
+++ b/packages/cloud/cloudflare/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/cloud/cloudflare/package.json
+++ b/packages/cloud/cloudflare/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/cloud/digitalocean/package.json
+++ b/packages/cloud/digitalocean/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/cloud/digitalocean/package.json
+++ b/packages/cloud/digitalocean/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/cloud/exe-dev/package.json
+++ b/packages/cloud/exe-dev/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/cloud/exe-dev/package.json
+++ b/packages/cloud/exe-dev/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/cloud/firebase/package.json
+++ b/packages/cloud/firebase/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/cloud/firebase/package.json
+++ b/packages/cloud/firebase/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/cloud/fly/package.json
+++ b/packages/cloud/fly/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/cloud/fly/package.json
+++ b/packages/cloud/fly/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/cloud/hetzner/package.json
+++ b/packages/cloud/hetzner/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/cloud/hetzner/package.json
+++ b/packages/cloud/hetzner/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/cloud/nvidia/package.json
+++ b/packages/cloud/nvidia/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/cloud/nvidia/package.json
+++ b/packages/cloud/nvidia/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/cloud/railway/package.json
+++ b/packages/cloud/railway/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/cloud/railway/package.json
+++ b/packages/cloud/railway/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/cloud/runpod/package.json
+++ b/packages/cloud/runpod/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/cloud/runpod/package.json
+++ b/packages/cloud/runpod/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/cloud/supabase/package.json
+++ b/packages/cloud/supabase/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/cloud/supabase/package.json
+++ b/packages/cloud/supabase/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/cloud/vultr/package.json
+++ b/packages/cloud/vultr/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/cloud/vultr/package.json
+++ b/packages/cloud/vultr/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/dns/azure/package.json
+++ b/packages/dns/azure/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/dns/azure/package.json
+++ b/packages/dns/azure/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/dns/cloudflare/package.json
+++ b/packages/dns/cloudflare/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/dns/cloudflare/package.json
+++ b/packages/dns/cloudflare/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/dns/digitalocean/package.json
+++ b/packages/dns/digitalocean/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/dns/digitalocean/package.json
+++ b/packages/dns/digitalocean/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/dns/dnsimple/package.json
+++ b/packages/dns/dnsimple/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/dns/dnsimple/package.json
+++ b/packages/dns/dnsimple/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/dns/googledns/package.json
+++ b/packages/dns/googledns/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/dns/googledns/package.json
+++ b/packages/dns/googledns/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/dns/namecheap/package.json
+++ b/packages/dns/namecheap/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/dns/namecheap/package.json
+++ b/packages/dns/namecheap/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/dns/porkbun/package.json
+++ b/packages/dns/porkbun/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/dns/porkbun/package.json
+++ b/packages/dns/porkbun/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/dns/route53/package.json
+++ b/packages/dns/route53/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/dns/route53/package.json
+++ b/packages/dns/route53/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/docs/gslides/package.json
+++ b/packages/docs/gslides/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/docs/gslides/package.json
+++ b/packages/docs/gslides/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/docs/lumin/package.json
+++ b/packages/docs/lumin/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/docs/lumin/package.json
+++ b/packages/docs/lumin/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/docs/marp/package.json
+++ b/packages/docs/marp/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/docs/marp/package.json
+++ b/packages/docs/marp/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/docs/pandoc/package.json
+++ b/packages/docs/pandoc/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/docs/pandoc/package.json
+++ b/packages/docs/pandoc/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/au/package.json
+++ b/packages/entity/au/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/au/package.json
+++ b/packages/entity/au/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/bb/package.json
+++ b/packages/entity/bb/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/bb/package.json
+++ b/packages/entity/bb/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/bw/package.json
+++ b/packages/entity/bw/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/bw/package.json
+++ b/packages/entity/bw/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/ca/package.json
+++ b/packages/entity/ca/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/ca/package.json
+++ b/packages/entity/ca/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/dao-wy/package.json
+++ b/packages/entity/dao-wy/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/dao-wy/package.json
+++ b/packages/entity/dao-wy/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/fj/package.json
+++ b/packages/entity/fj/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/fj/package.json
+++ b/packages/entity/fj/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/gh/package.json
+++ b/packages/entity/gh/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/gh/package.json
+++ b/packages/entity/gh/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/hk/package.json
+++ b/packages/entity/hk/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/hk/package.json
+++ b/packages/entity/hk/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/ie/package.json
+++ b/packages/entity/ie/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/ie/package.json
+++ b/packages/entity/ie/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/in/package.json
+++ b/packages/entity/in/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/in/package.json
+++ b/packages/entity/in/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/jm/package.json
+++ b/packages/entity/jm/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/jm/package.json
+++ b/packages/entity/jm/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/ke/package.json
+++ b/packages/entity/ke/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/ke/package.json
+++ b/packages/entity/ke/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/my/package.json
+++ b/packages/entity/my/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/my/package.json
+++ b/packages/entity/my/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/ng/package.json
+++ b/packages/entity/ng/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/ng/package.json
+++ b/packages/entity/ng/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/nz/package.json
+++ b/packages/entity/nz/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/nz/package.json
+++ b/packages/entity/nz/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/pk/package.json
+++ b/packages/entity/pk/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/pk/package.json
+++ b/packages/entity/pk/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/sg/package.json
+++ b/packages/entity/sg/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/sg/package.json
+++ b/packages/entity/sg/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/tt/package.json
+++ b/packages/entity/tt/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/tt/package.json
+++ b/packages/entity/tt/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/tz/package.json
+++ b/packages/entity/tz/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/tz/package.json
+++ b/packages/entity/tz/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/ug/package.json
+++ b/packages/entity/ug/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/ug/package.json
+++ b/packages/entity/ug/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/uk/package.json
+++ b/packages/entity/uk/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/uk/package.json
+++ b/packages/entity/uk/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/us/package.json
+++ b/packages/entity/us/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/us/package.json
+++ b/packages/entity/us/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/za/package.json
+++ b/packages/entity/za/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/za/package.json
+++ b/packages/entity/za/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/zm/package.json
+++ b/packages/entity/zm/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/zm/package.json
+++ b/packages/entity/zm/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/entity/zw/package.json
+++ b/packages/entity/zw/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/entity/zw/package.json
+++ b/packages/entity/zw/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/mcp-servers/penpot/package.json
+++ b/packages/mcp-servers/penpot/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/mcp-servers/penpot/package.json
+++ b/packages/mcp-servers/penpot/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/merch/printful/package.json
+++ b/packages/merch/printful/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/merch/printful/package.json
+++ b/packages/merch/printful/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/merch/printify/package.json
+++ b/packages/merch/printify/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/merch/printify/package.json
+++ b/packages/merch/printify/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/observability/sentry/package.json
+++ b/packages/observability/sentry/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/observability/sentry/package.json
+++ b/packages/observability/sentry/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/outreach/listennotes/package.json
+++ b/packages/outreach/listennotes/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/outreach/listennotes/package.json
+++ b/packages/outreach/listennotes/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/outreach/producthunt/package.json
+++ b/packages/outreach/producthunt/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/outreach/producthunt/package.json
+++ b/packages/outreach/producthunt/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/outreach/resend/package.json
+++ b/packages/outreach/resend/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/outreach/resend/package.json
+++ b/packages/outreach/resend/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/payments/coinpay/package.json
+++ b/packages/payments/coinpay/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/payments/coinpay/package.json
+++ b/packages/payments/coinpay/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/payments/paypal/package.json
+++ b/packages/payments/paypal/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/payments/paypal/package.json
+++ b/packages/payments/paypal/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/payments/stripe/package.json
+++ b/packages/payments/stripe/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/payments/stripe/package.json
+++ b/packages/payments/stripe/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/payments/worldremit/package.json
+++ b/packages/payments/worldremit/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/payments/worldremit/package.json
+++ b/packages/payments/worldremit/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/promo/angellist/package.json
+++ b/packages/promo/angellist/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/promo/angellist/package.json
+++ b/packages/promo/angellist/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/promo/apple-search/package.json
+++ b/packages/promo/apple-search/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/promo/apple-search/package.json
+++ b/packages/promo/apple-search/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/promo/capitalreach/package.json
+++ b/packages/promo/capitalreach/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/promo/capitalreach/package.json
+++ b/packages/promo/capitalreach/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/promo/google/package.json
+++ b/packages/promo/google/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/promo/google/package.json
+++ b/packages/promo/google/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/promo/kickstarter/package.json
+++ b/packages/promo/kickstarter/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/promo/kickstarter/package.json
+++ b/packages/promo/kickstarter/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/promo/linkedin/package.json
+++ b/packages/promo/linkedin/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/promo/linkedin/package.json
+++ b/packages/promo/linkedin/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/promo/meta/package.json
+++ b/packages/promo/meta/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/promo/meta/package.json
+++ b/packages/promo/meta/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/promo/microsoft/package.json
+++ b/packages/promo/microsoft/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/promo/microsoft/package.json
+++ b/packages/promo/microsoft/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/promo/openvc/package.json
+++ b/packages/promo/openvc/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/promo/openvc/package.json
+++ b/packages/promo/openvc/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/promo/reddit/package.json
+++ b/packages/promo/reddit/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/promo/reddit/package.json
+++ b/packages/promo/reddit/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/promo/tiktok/package.json
+++ b/packages/promo/tiktok/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/promo/tiktok/package.json
+++ b/packages/promo/tiktok/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/promo/wefunder/package.json
+++ b/packages/promo/wefunder/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/promo/wefunder/package.json
+++ b/packages/promo/wefunder/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/promo/x/package.json
+++ b/packages/promo/x/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/promo/x/package.json
+++ b/packages/promo/x/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/promo/youtube/package.json
+++ b/packages/promo/youtube/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/promo/youtube/package.json
+++ b/packages/promo/youtube/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/recipes/waitlist-crypto-investor/package.json
+++ b/packages/recipes/waitlist-crypto-investor/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/recipes/waitlist-crypto-investor/package.json
+++ b/packages/recipes/waitlist-crypto-investor/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -26,7 +26,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -18,5 +18,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/secrets/doppler/package.json
+++ b/packages/secrets/doppler/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/secrets/doppler/package.json
+++ b/packages/secrets/doppler/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/secrets/dotenvx/package.json
+++ b/packages/secrets/dotenvx/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/secrets/dotenvx/package.json
+++ b/packages/secrets/dotenvx/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/secrets/onepassword/package.json
+++ b/packages/secrets/onepassword/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/secrets/onepassword/package.json
+++ b/packages/secrets/onepassword/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/security/snyk/package.json
+++ b/packages/security/snyk/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/security/snyk/package.json
+++ b/packages/security/snyk/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/4claw/package.json
+++ b/packages/social/4claw/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/4claw/package.json
+++ b/packages/social/4claw/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/blossom/package.json
+++ b/packages/social/blossom/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/blossom/package.json
+++ b/packages/social/blossom/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/bluesky/package.json
+++ b/packages/social/bluesky/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/bluesky/package.json
+++ b/packages/social/bluesky/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/codenewbie/package.json
+++ b/packages/social/codenewbie/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/codenewbie/package.json
+++ b/packages/social/codenewbie/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/devto/package.json
+++ b/packages/social/devto/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/devto/package.json
+++ b/packages/social/devto/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/discord/package.json
+++ b/packages/social/discord/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/discord/package.json
+++ b/packages/social/discord/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/facebook/package.json
+++ b/packages/social/facebook/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/facebook/package.json
+++ b/packages/social/facebook/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/forem/package.json
+++ b/packages/social/forem/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/forem/package.json
+++ b/packages/social/forem/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/hackernews/package.json
+++ b/packages/social/hackernews/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/hackernews/package.json
+++ b/packages/social/hackernews/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/hackernoon/package.json
+++ b/packages/social/hackernoon/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/hackernoon/package.json
+++ b/packages/social/hackernoon/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/hashnode/package.json
+++ b/packages/social/hashnode/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/hashnode/package.json
+++ b/packages/social/hashnode/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/indiehackers/package.json
+++ b/packages/social/indiehackers/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/indiehackers/package.json
+++ b/packages/social/indiehackers/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/instagram/package.json
+++ b/packages/social/instagram/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/instagram/package.json
+++ b/packages/social/instagram/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/klawdin/package.json
+++ b/packages/social/klawdin/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/klawdin/package.json
+++ b/packages/social/klawdin/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/linkedin/package.json
+++ b/packages/social/linkedin/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/linkedin/package.json
+++ b/packages/social/linkedin/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/mastodon/package.json
+++ b/packages/social/mastodon/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/mastodon/package.json
+++ b/packages/social/mastodon/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/medium/package.json
+++ b/packages/social/medium/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/medium/package.json
+++ b/packages/social/medium/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/moltbook/package.json
+++ b/packages/social/moltbook/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/moltbook/package.json
+++ b/packages/social/moltbook/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/moltexchange/package.json
+++ b/packages/social/moltexchange/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/moltexchange/package.json
+++ b/packages/social/moltexchange/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/moltfounders/package.json
+++ b/packages/social/moltfounders/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/moltfounders/package.json
+++ b/packages/social/moltfounders/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/moltywork/package.json
+++ b/packages/social/moltywork/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/moltywork/package.json
+++ b/packages/social/moltywork/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/nostr/package.json
+++ b/packages/social/nostr/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/nostr/package.json
+++ b/packages/social/nostr/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/openwork/package.json
+++ b/packages/social/openwork/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/openwork/package.json
+++ b/packages/social/openwork/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/pinterest/package.json
+++ b/packages/social/pinterest/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/pinterest/package.json
+++ b/packages/social/pinterest/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/primal/package.json
+++ b/packages/social/primal/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/primal/package.json
+++ b/packages/social/primal/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/quora/package.json
+++ b/packages/social/quora/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/quora/package.json
+++ b/packages/social/quora/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/reddit/package.json
+++ b/packages/social/reddit/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/reddit/package.json
+++ b/packages/social/reddit/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/secureclaw/package.json
+++ b/packages/social/secureclaw/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/secureclaw/package.json
+++ b/packages/social/secureclaw/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/snapchat/package.json
+++ b/packages/social/snapchat/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/snapchat/package.json
+++ b/packages/social/snapchat/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/spotify/package.json
+++ b/packages/social/spotify/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/spotify/package.json
+++ b/packages/social/spotify/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/stackernews/package.json
+++ b/packages/social/stackernews/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/stackernews/package.json
+++ b/packages/social/stackernews/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/telegram/package.json
+++ b/packages/social/telegram/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/telegram/package.json
+++ b/packages/social/telegram/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/the-colony/package.json
+++ b/packages/social/the-colony/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/the-colony/package.json
+++ b/packages/social/the-colony/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/threads/package.json
+++ b/packages/social/threads/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/threads/package.json
+++ b/packages/social/threads/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/tikclawk/package.json
+++ b/packages/social/tikclawk/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/tikclawk/package.json
+++ b/packages/social/tikclawk/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/tiktok/package.json
+++ b/packages/social/tiktok/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/tiktok/package.json
+++ b/packages/social/tiktok/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/toku-agency/package.json
+++ b/packages/social/toku-agency/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/toku-agency/package.json
+++ b/packages/social/toku-agency/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/tumblr/package.json
+++ b/packages/social/tumblr/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/tumblr/package.json
+++ b/packages/social/tumblr/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/twitch/package.json
+++ b/packages/social/twitch/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/twitch/package.json
+++ b/packages/social/twitch/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/ugig/package.json
+++ b/packages/social/ugig/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/ugig/package.json
+++ b/packages/social/ugig/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/vimeo/package.json
+++ b/packages/social/vimeo/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/vimeo/package.json
+++ b/packages/social/vimeo/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/x/package.json
+++ b/packages/social/x/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/x/package.json
+++ b/packages/social/x/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/social/youtube/package.json
+++ b/packages/social/youtube/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/social/youtube/package.json
+++ b/packages/social/youtube/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/browser-chrome/package.json
+++ b/packages/targets/browser-chrome/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/browser-chrome/package.json
+++ b/packages/targets/browser-chrome/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/browser-edge/package.json
+++ b/packages/targets/browser-edge/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/browser-edge/package.json
+++ b/packages/targets/browser-edge/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/browser-firefox/package.json
+++ b/packages/targets/browser-firefox/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/browser-firefox/package.json
+++ b/packages/targets/browser-firefox/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/browser-safari/package.json
+++ b/packages/targets/browser-safari/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/browser-safari/package.json
+++ b/packages/targets/browser-safari/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/chat-discord/package.json
+++ b/packages/targets/chat-discord/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/chat-discord/package.json
+++ b/packages/targets/chat-discord/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/chat-signal/package.json
+++ b/packages/targets/chat-signal/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/chat-signal/package.json
+++ b/packages/targets/chat-signal/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/chat-slack/package.json
+++ b/packages/targets/chat-slack/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/chat-slack/package.json
+++ b/packages/targets/chat-slack/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/chat-telegram/package.json
+++ b/packages/targets/chat-telegram/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/chat-telegram/package.json
+++ b/packages/targets/chat-telegram/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/chat-whatsapp/package.json
+++ b/packages/targets/chat-whatsapp/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/chat-whatsapp/package.json
+++ b/packages/targets/chat-whatsapp/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/console-steam/package.json
+++ b/packages/targets/console-steam/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/console-steam/package.json
+++ b/packages/targets/console-steam/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/deploy-coolify/package.json
+++ b/packages/targets/deploy-coolify/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/deploy-coolify/package.json
+++ b/packages/targets/deploy-coolify/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/deploy-denodeploy/package.json
+++ b/packages/targets/deploy-denodeploy/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/deploy-denodeploy/package.json
+++ b/packages/targets/deploy-denodeploy/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/deploy-firebase/package.json
+++ b/packages/targets/deploy-firebase/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/deploy-firebase/package.json
+++ b/packages/targets/deploy-firebase/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/deploy-fly/package.json
+++ b/packages/targets/deploy-fly/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/deploy-fly/package.json
+++ b/packages/targets/deploy-fly/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/deploy-lambda/package.json
+++ b/packages/targets/deploy-lambda/package.json
@@ -21,5 +21,16 @@
     "dist"
   ],
   "homepage": "https://sh1pt.com",
-  "bugs": "https://github.com/profullstack/sh1pt/issues"
+  "bugs": "https://github.com/profullstack/sh1pt/issues",
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/deploy-lambda/package.json
+++ b/packages/targets/deploy-lambda/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/deploy-netlify/package.json
+++ b/packages/targets/deploy-netlify/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/deploy-netlify/package.json
+++ b/packages/targets/deploy-netlify/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/deploy-railway/package.json
+++ b/packages/targets/deploy-railway/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/deploy-railway/package.json
+++ b/packages/targets/deploy-railway/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/deploy-render/package.json
+++ b/packages/targets/deploy-render/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/deploy-render/package.json
+++ b/packages/targets/deploy-render/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/deploy-vercel/package.json
+++ b/packages/targets/deploy-vercel/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/deploy-vercel/package.json
+++ b/packages/targets/deploy-vercel/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/deploy-workers/package.json
+++ b/packages/targets/deploy-workers/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/deploy-workers/package.json
+++ b/packages/targets/deploy-workers/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/desktop-linux/package.json
+++ b/packages/targets/desktop-linux/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/desktop-linux/package.json
+++ b/packages/targets/desktop-linux/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/desktop-mac/package.json
+++ b/packages/targets/desktop-mac/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/desktop-mac/package.json
+++ b/packages/targets/desktop-mac/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/desktop-steamos/package.json
+++ b/packages/targets/desktop-steamos/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/desktop-steamos/package.json
+++ b/packages/targets/desktop-steamos/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/desktop-win/package.json
+++ b/packages/targets/desktop-win/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/desktop-win/package.json
+++ b/packages/targets/desktop-win/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/exe-dev/package.json
+++ b/packages/targets/exe-dev/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/exe-dev/package.json
+++ b/packages/targets/exe-dev/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/mobile-android/package.json
+++ b/packages/targets/mobile-android/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/mobile-android/package.json
+++ b/packages/targets/mobile-android/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/mobile-expo/package.json
+++ b/packages/targets/mobile-expo/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/mobile-expo/package.json
+++ b/packages/targets/mobile-expo/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/mobile-ios/package.json
+++ b/packages/targets/mobile-ios/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/mobile-ios/package.json
+++ b/packages/targets/mobile-ios/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/payment-adyen/package.json
+++ b/packages/targets/payment-adyen/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/payment-adyen/package.json
+++ b/packages/targets/payment-adyen/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/payment-coinpay/package.json
+++ b/packages/targets/payment-coinpay/package.json
@@ -21,5 +21,16 @@
     "dist"
   ],
   "homepage": "https://sh1pt.com",
-  "bugs": "https://github.com/profullstack/sh1pt/issues"
+  "bugs": "https://github.com/profullstack/sh1pt/issues",
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/payment-coinpay/package.json
+++ b/packages/targets/payment-coinpay/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/payment-paypal/package.json
+++ b/packages/targets/payment-paypal/package.json
@@ -21,5 +21,16 @@
     "dist"
   ],
   "homepage": "https://sh1pt.com",
-  "bugs": "https://github.com/profullstack/sh1pt/issues"
+  "bugs": "https://github.com/profullstack/sh1pt/issues",
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/payment-paypal/package.json
+++ b/packages/targets/payment-paypal/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/payment-square/package.json
+++ b/packages/targets/payment-square/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/payment-square/package.json
+++ b/packages/targets/payment-square/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/payment-stripe/package.json
+++ b/packages/targets/payment-stripe/package.json
@@ -21,5 +21,16 @@
     "dist"
   ],
   "homepage": "https://sh1pt.com",
-  "bugs": "https://github.com/profullstack/sh1pt/issues"
+  "bugs": "https://github.com/profullstack/sh1pt/issues",
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/payment-stripe/package.json
+++ b/packages/targets/payment-stripe/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/pkg-apt/package.json
+++ b/packages/targets/pkg-apt/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/pkg-apt/package.json
+++ b/packages/targets/pkg-apt/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/pkg-aube/package.json
+++ b/packages/targets/pkg-aube/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/pkg-aube/package.json
+++ b/packages/targets/pkg-aube/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/pkg-aur/package.json
+++ b/packages/targets/pkg-aur/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/pkg-aur/package.json
+++ b/packages/targets/pkg-aur/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/pkg-cdn/package.json
+++ b/packages/targets/pkg-cdn/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/pkg-cdn/package.json
+++ b/packages/targets/pkg-cdn/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/pkg-deno/package.json
+++ b/packages/targets/pkg-deno/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/pkg-deno/package.json
+++ b/packages/targets/pkg-deno/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/pkg-docker/package.json
+++ b/packages/targets/pkg-docker/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/pkg-docker/package.json
+++ b/packages/targets/pkg-docker/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/pkg-fdroid/package.json
+++ b/packages/targets/pkg-fdroid/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/pkg-fdroid/package.json
+++ b/packages/targets/pkg-fdroid/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/pkg-flatpak/package.json
+++ b/packages/targets/pkg-flatpak/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/pkg-flatpak/package.json
+++ b/packages/targets/pkg-flatpak/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/pkg-ghpackages/package.json
+++ b/packages/targets/pkg-ghpackages/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/pkg-ghpackages/package.json
+++ b/packages/targets/pkg-ghpackages/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/pkg-homebrew/package.json
+++ b/packages/targets/pkg-homebrew/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/pkg-homebrew/package.json
+++ b/packages/targets/pkg-homebrew/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/pkg-jsr/package.json
+++ b/packages/targets/pkg-jsr/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/pkg-jsr/package.json
+++ b/packages/targets/pkg-jsr/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/pkg-nix/package.json
+++ b/packages/targets/pkg-nix/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/pkg-nix/package.json
+++ b/packages/targets/pkg-nix/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/pkg-npm/package.json
+++ b/packages/targets/pkg-npm/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/pkg-npm/package.json
+++ b/packages/targets/pkg-npm/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/pkg-perry/package.json
+++ b/packages/targets/pkg-perry/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/pkg-perry/package.json
+++ b/packages/targets/pkg-perry/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/pkg-scoop/package.json
+++ b/packages/targets/pkg-scoop/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/pkg-scoop/package.json
+++ b/packages/targets/pkg-scoop/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/pkg-snap/package.json
+++ b/packages/targets/pkg-snap/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/pkg-snap/package.json
+++ b/packages/targets/pkg-snap/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/pkg-winget/package.json
+++ b/packages/targets/pkg-winget/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/pkg-winget/package.json
+++ b/packages/targets/pkg-winget/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/plugin-jetbrains/package.json
+++ b/packages/targets/plugin-jetbrains/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/plugin-jetbrains/package.json
+++ b/packages/targets/plugin-jetbrains/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/plugin-vscode/package.json
+++ b/packages/targets/plugin-vscode/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/plugin-vscode/package.json
+++ b/packages/targets/plugin-vscode/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/qa-geisterhand/package.json
+++ b/packages/targets/qa-geisterhand/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/qa-geisterhand/package.json
+++ b/packages/targets/qa-geisterhand/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/sdk-pypi/package.json
+++ b/packages/targets/sdk-pypi/package.json
@@ -21,5 +21,16 @@
     "dist"
   ],
   "homepage": "https://sh1pt.com",
-  "bugs": "https://github.com/profullstack/sh1pt/issues"
+  "bugs": "https://github.com/profullstack/sh1pt/issues",
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/sdk-pypi/package.json
+++ b/packages/targets/sdk-pypi/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/tv-androidtv/package.json
+++ b/packages/targets/tv-androidtv/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/tv-androidtv/package.json
+++ b/packages/targets/tv-androidtv/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/tv-firetv/package.json
+++ b/packages/targets/tv-firetv/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/tv-firetv/package.json
+++ b/packages/targets/tv-firetv/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/tv-roku/package.json
+++ b/packages/targets/tv-roku/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/tv-roku/package.json
+++ b/packages/targets/tv-roku/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/tv-tvos/package.json
+++ b/packages/targets/tv-tvos/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/tv-tvos/package.json
+++ b/packages/targets/tv-tvos/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/tv-webos/package.json
+++ b/packages/targets/tv-webos/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/tv-webos/package.json
+++ b/packages/targets/tv-webos/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/web-static/package.json
+++ b/packages/targets/web-static/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/web-static/package.json
+++ b/packages/targets/web-static/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/xr-meta-quest/package.json
+++ b/packages/targets/xr-meta-quest/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/xr-meta-quest/package.json
+++ b/packages/targets/xr-meta-quest/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/xr-pico/package.json
+++ b/packages/targets/xr-pico/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/xr-pico/package.json
+++ b/packages/targets/xr-pico/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/xr-sidequest/package.json
+++ b/packages/targets/xr-sidequest/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/xr-sidequest/package.json
+++ b/packages/targets/xr-sidequest/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/xr-steamvr/package.json
+++ b/packages/targets/xr-steamvr/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/xr-steamvr/package.json
+++ b/packages/targets/xr-steamvr/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/xr-visionos/package.json
+++ b/packages/targets/xr-visionos/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/xr-visionos/package.json
+++ b/packages/targets/xr-visionos/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/targets/xr-webxr/package.json
+++ b/packages/targets/xr-webxr/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/targets/xr-webxr/package.json
+++ b/packages/targets/xr-webxr/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/vcs/gitea/package.json
+++ b/packages/vcs/gitea/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/vcs/gitea/package.json
+++ b/packages/vcs/gitea/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/vcs/github/package.json
+++ b/packages/vcs/github/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/vcs/github/package.json
+++ b/packages/vcs/github/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/vcs/gitlab/package.json
+++ b/packages/vcs/gitlab/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/vcs/gitlab/package.json
+++ b/packages/vcs/gitlab/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/w3c/activitypub/package.json
+++ b/packages/w3c/activitypub/package.json
@@ -21,6 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }
-

--- a/packages/w3c/activitypub/package.json
+++ b/packages/w3c/activitypub/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/w3c/micropub/package.json
+++ b/packages/w3c/micropub/package.json
@@ -21,6 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }
-

--- a/packages/w3c/micropub/package.json
+++ b/packages/w3c/micropub/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/w3c/websub/package.json
+++ b/packages/w3c/websub/package.json
@@ -21,6 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }
-

--- a/packages/w3c/websub/package.json
+++ b/packages/w3c/websub/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/webhooks/discord/package.json
+++ b/packages/webhooks/discord/package.json
@@ -28,5 +28,16 @@
   },
   "dependencies": {
     "@profullstack/sh1pt-core": "workspace:^"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
   }
 }

--- a/packages/webhooks/discord/package.json
+++ b/packages/webhooks/discord/package.json
@@ -36,7 +36,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/webhooks/generic/package.json
+++ b/packages/webhooks/generic/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/webhooks/generic/package.json
+++ b/packages/webhooks/generic/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/webhooks/slack/package.json
+++ b/packages/webhooks/slack/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/webhooks/slack/package.json
+++ b/packages/webhooks/slack/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/webhooks/teams/package.json
+++ b/packages/webhooks/teams/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/webhooks/teams/package.json
+++ b/packages/webhooks/teams/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }

--- a/packages/webhooks/telegram/package.json
+++ b/packages/webhooks/telegram/package.json
@@ -29,7 +29,8 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       }
     }
   }

--- a/packages/webhooks/telegram/package.json
+++ b/packages/webhooks/telegram/package.json
@@ -21,5 +21,16 @@
   "bugs": "https://github.com/profullstack/sh1pt/issues",
   "files": [
     "dist"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  }
 }


### PR DESCRIPTION
﻿## What changed

Adds `publishConfig` metadata to non-AI adapter/package manifests that already publish only `dist` but still use the workspace-local `main: ./src/index.ts` field during development.

This intentionally excludes `packages/ai/*`, which are covered separately in #448, and covers the remaining package families such as affiliates, bots, bridges, cloud, DNS, entity, promo, social, targets, VCS, W3C, and webhooks.

## Why

These packages build compiled JS and declarations into `dist` and publish only `dist`, but without publish metadata a packed package manifest keeps `main: ./src/index.ts`. That can make published packages resolve a TypeScript source path instead of the compiled runtime artifact.

With `publishConfig`, pnpm rewrites the packed manifest to expose:

- `main: ./dist/index.js`
- `types: ./dist/index.d.ts`
- `exports["."].import: ./dist/index.js`

## Validation

- `corepack pnpm --filter @profullstack/sh1pt-bot-core typecheck`
- `corepack pnpm --filter @profullstack/sh1pt-target-pkg-npm typecheck`
- `corepack pnpm --filter @profullstack/sh1pt-automation-stagehand typecheck`
- `corepack pnpm --filter @profullstack/sh1pt-bot-core build`
- `corepack pnpm --filter @profullstack/sh1pt-target-pkg-npm build`
- `corepack pnpm pack --pack-destination $env:TEMP/sh1pt-pack-check` from `packages/bots/core` and `packages/targets/pkg-npm`, then inspected `package/package.json` and tarball file lists.
