### PR TITLE
[codex] Implement remaining OpenAI-compatible AI adapters

### DIFF
--- a/packages/ai/cohere/src/index.test.ts
+++ b/packages/ai/cohere/src/index.test.ts
@@ -1,4 +1,80 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { COHERE_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Cohere OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ COHERE_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'command-a-plus-05-2026' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from cohere' } }],
+        model: 'command-a-03-2025',
+        usage: { prompt_tokens: 9, completion_tokens: 5 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'command-a-03-2025',
+      system: 'be concise',
+      maxTokens: 32,
+      temperature: 0.1,
+      extra: { top_p: 0.8 },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.cohere.ai/compatibility/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'command-a-03-2025',
+      messages: [
+        { role: 'system', content: 'be concise' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 32,
+      temperature: 0.1,
+      top_p: 0.8,
+    });
+    expect(result).toEqual({
+      text: 'hi from cohere',
+      model: 'command-a-03-2025',
+      inputTokens: 9,
+      outputTokens: 5,
+    });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => 'invalid key'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/Cohere 401: invalid key/);
+  });
+});

--- a/packages/ai/cohere/src/index.ts
+++ b/packages/ai/cohere/src/index.ts
@@ -4,26 +4,61 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.cohere.ai/compatibility/v1';
+const DEFAULT_MODEL = 'command-a-plus-05-2026';
+
 export default defineAi<Config>({
   id: 'ai-cohere',
   label: 'Cohere',
-  defaultModel: 'command-r-plus',
-  models: ['command-r-plus'],
+  defaultModel: DEFAULT_MODEL,
+  models: [DEFAULT_MODEL, 'command-a-03-2025'],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('COHERE_API_KEY');
-    if (!apiKey) throw new Error('COHERE_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-cohere · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-cohere integration not yet implemented]', model: 'command-r-plus' };
+    if (!apiKey) throw new Error('COHERE_API_KEY not in vault');
+    const model = opts.model ?? DEFAULT_MODEL;
+    ctx.log(`cohere | model=${model} | ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Cohere ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'COHERE_API_KEY',
     label: 'Cohere',
-    vendorDocUrl: 'https://dashboard.cohere.com',
+    vendorDocUrl: 'https://docs.cohere.com/v2/docs/compatibility-api',
     steps: [
       'Sign in at https://dashboard.cohere.com and create an API key',
-      'Copy the key — usually shown once',
+      'Copy the key; it is usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],
   }),

--- a/packages/ai/kimi/src/index.test.ts
+++ b/packages/ai/kimi/src/index.test.ts
@@ -1,4 +1,80 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { MOONSHOT_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Kimi OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ MOONSHOT_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'kimi-k2.6' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from kimi' } }],
+        model: 'kimi-k2.5',
+        usage: { prompt_tokens: 13, completion_tokens: 8 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'kimi-k2.5',
+      system: 'be direct',
+      maxTokens: 64,
+      temperature: 0.2,
+      extra: { thinking: { type: 'disabled' } },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.moonshot.ai/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'kimi-k2.5',
+      messages: [
+        { role: 'system', content: 'be direct' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 64,
+      temperature: 0.2,
+      thinking: { type: 'disabled' },
+    });
+    expect(result).toEqual({
+      text: 'hi from kimi',
+      model: 'kimi-k2.5',
+      inputTokens: 13,
+      outputTokens: 8,
+    });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'server error'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/Kimi 500: server error/);
+  });
+});

--- a/packages/ai/kimi/src/index.ts
+++ b/packages/ai/kimi/src/index.ts
@@ -4,26 +4,61 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.moonshot.ai/v1';
+const DEFAULT_MODEL = 'kimi-k2.6';
+
 export default defineAi<Config>({
   id: 'ai-kimi',
   label: 'Kimi (Moonshot)',
-  defaultModel: 'kimi-k2-0905-preview',
-  models: ['kimi-k2-0905-preview'],
+  defaultModel: DEFAULT_MODEL,
+  models: [DEFAULT_MODEL, 'kimi-k2.5', 'kimi-k2-thinking', 'kimi-k2-turbo-preview'],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('MOONSHOT_API_KEY');
-    if (!apiKey) throw new Error('MOONSHOT_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-kimi · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-kimi integration not yet implemented]', model: 'kimi-k2-0905-preview' };
+    if (!apiKey) throw new Error('MOONSHOT_API_KEY not in vault');
+    const model = opts.model ?? DEFAULT_MODEL;
+    ctx.log(`kimi | model=${model} | ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Kimi ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'MOONSHOT_API_KEY',
     label: 'Kimi (Moonshot)',
-    vendorDocUrl: 'https://platform.moonshot.ai',
+    vendorDocUrl: 'https://platform.kimi.ai/docs/api/overview',
     steps: [
       'Sign in at https://platform.moonshot.ai and create an API key',
-      'Copy the key — usually shown once',
+      'Copy the key; it is usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],
   }),

--- a/packages/ai/novita/src/index.test.ts
+++ b/packages/ai/novita/src/index.test.ts
@@ -1,4 +1,79 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { NOVITA_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('NovitaAI OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ NOVITA_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'meta-llama/llama-3.3-70b-instruct' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from novita' } }],
+        model: 'meta-llama/llama-3.3-70b-instruct',
+        usage: { prompt_tokens: 7, completion_tokens: 3 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      system: 'be helpful',
+      maxTokens: 20,
+      temperature: 0.4,
+      extra: { top_p: 0.9 },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.novita.ai/openai/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'meta-llama/llama-3.3-70b-instruct',
+      messages: [
+        { role: 'system', content: 'be helpful' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 20,
+      temperature: 0.4,
+      top_p: 0.9,
+    });
+    expect(result).toEqual({
+      text: 'hi from novita',
+      model: 'meta-llama/llama-3.3-70b-instruct',
+      inputTokens: 7,
+      outputTokens: 3,
+    });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => 'rate limited'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/NovitaAI 429: rate limited/);
+  });
+});

--- a/packages/ai/novita/src/index.ts
+++ b/packages/ai/novita/src/index.ts
@@ -4,26 +4,61 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.novita.ai/openai/v1';
+const DEFAULT_MODEL = 'meta-llama/llama-3.3-70b-instruct';
+
 export default defineAi<Config>({
   id: 'ai-novita',
   label: 'NovitaAI',
-  defaultModel: 'meta-llama/llama-3.3-70b-instruct',
-  models: ['meta-llama/llama-3.3-70b-instruct'],
+  defaultModel: DEFAULT_MODEL,
+  models: [DEFAULT_MODEL],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('NOVITA_API_KEY');
-    if (!apiKey) throw new Error('NOVITA_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-novita · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-novita integration not yet implemented]', model: 'meta-llama/llama-3.3-70b-instruct' };
+    if (!apiKey) throw new Error('NOVITA_API_KEY not in vault');
+    const model = opts.model ?? DEFAULT_MODEL;
+    ctx.log(`novita | model=${model} | ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`NovitaAI ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'NOVITA_API_KEY',
     label: 'NovitaAI',
-    vendorDocUrl: 'https://novita.ai',
+    vendorDocUrl: 'https://novita.ai/docs/api-reference/model-apis-llm-create-chat-completion',
     steps: [
       'Sign in at https://novita.ai and create an API key',
-      'Copy the key — usually shown once',
+      'Copy the key; it is usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],
   }),

--- a/packages/ai/parasail/src/index.test.ts
+++ b/packages/ai/parasail/src/index.test.ts
@@ -1,4 +1,79 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { PARASAIL_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Parasail OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ PARASAIL_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'parasail-llama-33-70b-fp8' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from parasail' } }],
+        model: 'parasail-llama-33-70b-fp8',
+        usage: { prompt_tokens: 10, completion_tokens: 4 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      system: 'be concise',
+      maxTokens: 40,
+      temperature: 0.2,
+      extra: { top_p: 0.7 },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.parasail.io/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'parasail-llama-33-70b-fp8',
+      messages: [
+        { role: 'system', content: 'be concise' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 40,
+      temperature: 0.2,
+      top_p: 0.7,
+    });
+    expect(result).toEqual({
+      text: 'hi from parasail',
+      model: 'parasail-llama-33-70b-fp8',
+      inputTokens: 10,
+      outputTokens: 4,
+    });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: async () => 'unavailable'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/Parasail 503: unavailable/);
+  });
+});

--- a/packages/ai/parasail/src/index.ts
+++ b/packages/ai/parasail/src/index.ts
@@ -4,26 +4,61 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.parasail.io/v1';
+const DEFAULT_MODEL = 'parasail-llama-33-70b-fp8';
+
 export default defineAi<Config>({
   id: 'ai-parasail',
   label: 'Parasail',
-  defaultModel: 'PARASAIL_API_KEY',
-  models: ['PARASAIL_API_KEY'],
+  defaultModel: DEFAULT_MODEL,
+  models: [DEFAULT_MODEL],
 
-  async generate(ctx, prompt, _opts, _config) {
-    const apiKey = ctx.secret('https://parasail.io');
-    if (!apiKey) throw new Error('https://parasail.io not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-parasail · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-parasail integration not yet implemented]', model: 'PARASAIL_API_KEY' };
+  async generate(ctx, prompt, opts, config) {
+    const apiKey = ctx.secret('PARASAIL_API_KEY');
+    if (!apiKey) throw new Error('PARASAIL_API_KEY not in vault');
+    const model = opts.model ?? DEFAULT_MODEL;
+    ctx.log(`parasail | model=${model} | ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Parasail ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
-    secretKey: 'https://parasail.io',
+    secretKey: 'PARASAIL_API_KEY',
     label: 'Parasail',
-    vendorDocUrl: '',
+    vendorDocUrl: 'https://docs.parasail.io/parasail-docs/cookbooks/chat-completions',
     steps: [
-      'Sign in at  and create an API key',
-      'Copy the key — usually shown once',
+      'Sign in at https://parasail.io and create an API key',
+      'Copy the key; it is usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],
   }),

--- a/packages/ai/venice/src/index.test.ts
+++ b/packages/ai/venice/src/index.test.ts
@@ -1,4 +1,80 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { VENICE_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Venice OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ VENICE_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'venice-uncensored-1-2' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from venice' } }],
+        model: 'venice-uncensored',
+        usage: { prompt_tokens: 11, completion_tokens: 6 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'venice-uncensored',
+      system: 'be direct',
+      maxTokens: 48,
+      temperature: 0.5,
+      extra: { venice_parameters: { include_venice_system_prompt: false } },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.venice.ai/api/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'venice-uncensored',
+      messages: [
+        { role: 'system', content: 'be direct' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 48,
+      temperature: 0.5,
+      venice_parameters: { include_venice_system_prompt: false },
+    });
+    expect(result).toEqual({
+      text: 'hi from venice',
+      model: 'venice-uncensored',
+      inputTokens: 11,
+      outputTokens: 6,
+    });
+  });
+
+  it('includes status and response body excerpt on errors', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 402,
+      text: async () => 'payment required'.repeat(30),
+    }));
+
+    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/Venice 402: payment required/);
+  });
+});

--- a/packages/ai/venice/src/index.ts
+++ b/packages/ai/venice/src/index.ts
@@ -4,26 +4,61 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.venice.ai/api/v1';
+const DEFAULT_MODEL = 'venice-uncensored-1-2';
+
 export default defineAi<Config>({
   id: 'ai-venice',
   label: 'Venice AI',
-  defaultModel: 'llama-3.3-70b',
-  models: ['llama-3.3-70b'],
+  defaultModel: DEFAULT_MODEL,
+  models: [DEFAULT_MODEL, 'venice-uncensored', 'llama-3.3-70b'],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('VENICE_API_KEY');
-    if (!apiKey) throw new Error('VENICE_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-venice · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-venice integration not yet implemented]', model: 'llama-3.3-70b' };
+    if (!apiKey) throw new Error('VENICE_API_KEY not in vault');
+    const model = opts.model ?? DEFAULT_MODEL;
+    ctx.log(`venice | model=${model} | ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Venice ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'VENICE_API_KEY',
     label: 'Venice AI',
-    vendorDocUrl: 'https://venice.ai',
+    vendorDocUrl: 'https://docs.venice.ai/api-reference/api-spec',
     steps: [
       'Sign in at https://venice.ai and create an API key',
-      'Copy the key — usually shown once',
+      'Copy the key; it is usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],
   }),


### PR DESCRIPTION
## Summary
- replace five AI adapter stubs (Kimi, Cohere, NovitaAI, Venice, Parasail) with OpenAI-compatible chat-completions implementations
- preserve dry-run short-circuiting and pass through system/user messages, max token, temperature, and `opts.extra`
- map provider response text/model/token usage and surface HTTP status/body excerpts on errors
- add focused tests for dry-run, request shape, response mapping, and error handling for each adapter

Closes #450.

## Sources checked
- Kimi OpenAI-compatible docs: https://platform.kimi.ai/docs/api/overview
- Cohere Compatibility API: https://docs.cohere.com/v2/docs/compatibility-api
- NovitaAI chat completions: https://novita.ai/docs/api-reference/model-apis-llm-create-chat-completion
- Venice API OpenAI compatibility: https://docs.venice.ai/api-reference/api-spec
- Parasail chat completions: https://docs.parasail.io/parasail-docs/cookbooks/chat-completions

## Validation
- `./node_modules/.bin/vitest.cmd run packages/ai/kimi/src/index.test.ts packages/ai/cohere/src/index.test.ts packages/ai/novita/src/index.test.ts packages/ai/venice/src/index.test.ts packages/ai/parasail/src/index.test.ts`
- `./node_modules/.bin/tsc.cmd -p packages/ai/kimi/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc.cmd -p packages/ai/cohere/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc.cmd -p packages/ai/novita/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc.cmd -p packages/ai/venice/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc.cmd -p packages/ai/parasail/tsconfig.json --noEmit`
- `git diff --check`