### PR TITLE
[codex] Fix Google DNS delete typecheck

### DIFF
--- a/packages/dns/googledns/src/index.test.ts
+++ b/packages/dns/googledns/src/index.test.ts
@@ -1,7 +1,73 @@
 import { contractTestDns } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import dns from './index.js';
 
 contractTestDns(dns, {
   sampleConfig: {},
   requiredSecrets: ['GOOGLE_ACCESS_TOKEN', 'GOOGLE_PROJECT_ID'],
+});
+
+const ctx = (secrets: Record<string, string> = {
+  GOOGLE_ACCESS_TOKEN: 'google-token',
+  GOOGLE_PROJECT_ID: 'project-1',
+}) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+});
+
+const jsonResponse = (body: unknown, ok = true, status = ok ? 200 : 400) => ({
+  ok,
+  status,
+  json: async () => body,
+});
+
+describe('Google Cloud DNS adapter', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('rejects malformed record ids before deleting records', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({})));
+
+    await dns.connect(ctx(), {});
+
+    await expect(dns.deleteRecord('zone-1', 'A', {}))
+      .rejects.toThrow('Invalid Google Cloud DNS record id: A');
+  });
+
+  it('deletes the matching rrset with the current TTL and values', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({
+        rrsets: [
+          { name: 'api.example.com.', type: 'A', ttl: 600, rrdatas: ['1.1.1.1', '2.2.2.2'] },
+          { name: 'api.example.com.', type: 'TXT', ttl: 300, rrdatas: ['keep-me'] },
+        ],
+      }))
+      .mockResolvedValueOnce(jsonResponse({ id: 'change-1' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await dns.connect(ctx(), {});
+    await dns.deleteRecord('zone-1', 'A/api.example.com.', {});
+
+    expect(fetchMock.mock.calls[0]?.[0])
+      .toBe('https://dns.googleapis.com/dns/v1/projects/project-1/managedZones/zone-1/rrsets');
+    expect(fetchMock.mock.calls[1]?.[0])
+      .toBe('https://dns.googleapis.com/dns/v1/projects/project-1/managedZones/zone-1/changes');
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
+      method: 'POST',
+      headers: expect.objectContaining({ Authorization: 'Bearer google-token' }),
+    });
+    expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1].body))).toEqual({
+      kind: 'dns#change',
+      deletions: [
+        {
+          name: 'api.example.com.',
+          type: 'A',
+          ttl: 600,
+          rrdatas: ['1.1.1.1', '2.2.2.2'],
+        },
+      ],
+      additions: [],
+    });
+  });
 });

--- a/packages/dns/googledns/src/index.ts
+++ b/packages/dns/googledns/src/index.ts
@@ -124,13 +124,18 @@ export default defineDns<Config>({
     const project = config.projectId ?? _secret('GOOGLE_PROJECT_ID');
     if (!project) throw new Error('GOOGLE_PROJECT_ID not set');
     const [type, name] = recordId.split('/');
+    if (!type || !name) {
+      throw new Error(`Invalid Google Cloud DNS record id: ${recordId}`);
+    }
     // Need to fetch the rrset to get current rrdatas for the deletion entry.
     const existing = (await this.listRecords(zoneId, config)).filter(
       r => r.type === type && (r.name === name || r.name === name.replace(/\.$/, '')),
     );
     if (existing.length === 0) return;
     const fqdn = name.endsWith('.') ? name : `${name}.`;
-    const ttl = existing[0].ttl;
+    const first = existing[0];
+    if (!first) return;
+    const ttl = first.ttl;
     const res = await fetch(`${API}/projects/${project}/managedZones/${zoneId}/changes`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary

Fixes #454.

`packages/dns/googledns` failed strict typecheck in `deleteRecord()` because `recordId.split('/')` was destructured directly while `noUncheckedIndexedAccess` is enabled. TypeScript correctly treated the split `type`/`name` pieces, and the first matching record, as possibly missing.

This PR validates the `<type>/<fqdn>` record id shape before issuing a delete and narrows the first matching rrset before reading its TTL. It also adds focused tests for malformed record ids and for the Google Cloud DNS delete change payload.

## Validation

- `corepack pnpm --dir packages/dns/googledns typecheck`
- `.
ode_modules\.bin\vitest.cmd run packages\dns\googledns\src\index.test.ts`
- `git diff --check`
