### PR TITLE
Implement Android TV Play plan target

### DIFF
--- a/packages/targets/tv-androidtv/src/index.test.ts
+++ b/packages/targets/tv-androidtv/src/index.test.ts
@@ -1,5 +1,5 @@
 import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -58,6 +58,68 @@ describe('Android TV package planning', () => {
     expect(plan.commands).toContain('./gradlew :app:bundleRelease');
   });
 
+  it('validates a provided manifest before writing the plan', async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-androidtv-project-'));
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-androidtv-out-'));
+    tempDirs.push(projectDir, outDir);
+    await mkdir(join(projectDir, 'app', 'src', 'main'), { recursive: true });
+    await writeFile(join(projectDir, 'app', 'src', 'main', 'AndroidManifest.xml'), `
+      <manifest package="com.acme.tv">
+        <uses-feature android:name="android.software.leanback" android:required="true" />
+        <application>
+          <activity android:name=".MainActivity">
+            <intent-filter>
+              <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+            </intent-filter>
+          </activity>
+        </application>
+      </manifest>
+    `, 'utf-8');
+
+    const result = await adapter.build(fakeBuildContext({
+      projectDir,
+      outDir,
+      version: '1.2.3',
+    }) as any, {
+      packageName: 'com.acme.tv',
+      track: 'beta',
+      manifestPath: 'app/src/main/AndroidManifest.xml',
+      gradleTask: ':tv:bundleRelease',
+    });
+
+    const plan = JSON.parse(await readFile(result.meta?.planFile as string, 'utf-8'));
+    expect(plan).toMatchObject({
+      packageName: 'com.acme.tv',
+      version: '1.2.3',
+      track: 'beta',
+      manifestPath: join(projectDir, 'app', 'src', 'main', 'AndroidManifest.xml'),
+      commands: [
+        './gradlew :tv:bundleRelease',
+        'play-developer-api edits.insert package=com.acme.tv',
+        `play-developer-api edits.bundles.upload artifact=${join(outDir, 'androidtv', 'com.acme.tv.aab')}`,
+        'play-developer-api edits.tracks.update track=beta',
+        'play-developer-api edits.commit',
+      ],
+    });
+  });
+
+  it('rejects manifests missing Android TV requirements', async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-androidtv-project-'));
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-androidtv-out-'));
+    tempDirs.push(projectDir, outDir);
+    await mkdir(join(projectDir, 'app', 'src', 'main'), { recursive: true });
+    await writeFile(join(projectDir, 'app', 'src', 'main', 'AndroidManifest.xml'), '<manifest package="com.acme.tv" />', 'utf-8');
+
+    await expect(adapter.build(fakeBuildContext({
+      projectDir,
+      outDir,
+    }) as any, {
+      packageName: 'com.acme.tv',
+      track: 'internal',
+      manifestPath: 'app/src/main/AndroidManifest.xml',
+    })).rejects.toThrow('AndroidManifest must declare android.software.leanback');
+  });
+
   it('maps non-stable channels to safe test tracks', async () => {
     const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-androidtv-'));
     tempDirs.push(outDir);
@@ -97,6 +159,25 @@ describe('Android TV package planning', () => {
           'play-developer-api edits.tracks.update track=internal',
           'play-developer-api edits.commit',
         ],
+      },
+    });
+  });
+
+  it('returns store metadata in real ship mode', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      artifact: '/repo/.sh1pt/out/androidtv-package-plan.json',
+      channel: 'stable',
+      version: '1.2.3',
+      dryRun: false,
+    }) as any, {
+      packageName: 'com.acme.tv',
+      track: 'beta',
+    })).resolves.toEqual({
+      id: 'com.acme.tv@1.2.3',
+      url: 'https://play.google.com/store/apps/details?id=com.acme.tv',
+      meta: {
+        artifact: '/repo/.sh1pt/out/androidtv-package-plan.json',
+        track: 'beta',
       },
     });
   });

--- a/packages/targets/tv-androidtv/src/index.ts
+++ b/packages/targets/tv-androidtv/src/index.ts
@@ -1,14 +1,22 @@
-import { mkdir, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
 import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
 
 interface Config {
   packageName: string;
   track: 'internal' | 'alpha' | 'beta' | 'production';
   aabPath?: string;
+  manifestPath?: string;
+  gradleTask?: string;
 }
 
 const PLAN_FILE = 'androidtv-package-plan.json';
+
+function requirePackageName(config: Config): string {
+  const packageName = config.packageName?.trim();
+  if (!packageName) throw new Error('tv-androidtv requires packageName');
+  return packageName;
+}
 
 function releaseTrack(channel: string, config: Config): Config['track'] {
   if (channel === 'stable') return config.track;
@@ -17,39 +25,63 @@ function releaseTrack(channel: string, config: Config): Config['track'] {
 }
 
 function artifactPath(ctx: { outDir: string }, config: Config): string {
-  return config.aabPath ?? join(ctx.outDir, 'androidtv', `${config.packageName}.aab`);
+  return config.aabPath ?? join(ctx.outDir, 'androidtv', `${requirePackageName(config)}.aab`);
 }
 
-function buildPlan(ctx: { outDir: string; version: string; channel: string }, config: Config) {
+function validateAndroidTvManifest(manifest: string, packageName: string): void {
+  const packageMatch = manifest.match(/\bpackage\s*=\s*["']([^"']+)["']/);
+  if (packageMatch?.[1] && packageMatch[1] !== packageName) {
+    throw new Error(`AndroidManifest package must match packageName (${packageName})`);
+  }
+  if (!manifest.includes('android.software.leanback')) {
+    throw new Error('AndroidManifest must declare android.software.leanback');
+  }
+  if (!manifest.includes('android.intent.category.LEANBACK_LAUNCHER')) {
+    throw new Error('AndroidManifest must declare LEANBACK_LAUNCHER');
+  }
+}
+
+async function maybeValidateManifest(ctx: { projectDir: string }, config: Config): Promise<string | undefined> {
+  if (!config.manifestPath) return undefined;
+  const manifestPath = resolve(ctx.projectDir, config.manifestPath);
+  validateAndroidTvManifest(await readFile(manifestPath, 'utf-8'), requirePackageName(config));
+  return manifestPath;
+}
+
+async function buildPlan(ctx: { projectDir: string; outDir: string; version: string; channel: string }, config: Config) {
+  const packageName = requirePackageName(config);
   const artifact = artifactPath(ctx, config);
   const track = releaseTrack(ctx.channel, config);
+  const gradleTask = config.gradleTask ?? ':app:bundleRelease';
+  const manifestPath = await maybeValidateManifest(ctx, config);
   return {
-    packageName: config.packageName,
+    packageName,
     version: ctx.version,
     channel: ctx.channel,
     track,
     artifact,
     planFile: join(ctx.outDir, PLAN_FILE),
+    manifestPath,
     manifestChecks: [
       {
-        path: 'AndroidManifest.xml',
+        path: manifestPath ?? 'AndroidManifest.xml',
         requirement: 'uses-feature android:name="android.software.leanback"',
         required: true,
       },
       {
-        path: 'AndroidManifest.xml',
+        path: manifestPath ?? 'AndroidManifest.xml',
         requirement: 'category android:name="android.intent.category.LEANBACK_LAUNCHER"',
         required: true,
       },
       {
-        path: 'AndroidManifest.xml',
+        path: manifestPath ?? 'AndroidManifest.xml',
         requirement: 'category android:name="android.intent.category.LAUNCHER"',
         required: true,
       },
     ],
     commands: [
-      './gradlew :app:bundleRelease',
-      `play-developer-api edits.insert package=${config.packageName}`,
+      `./gradlew ${gradleTask}`,
+      `play-developer-api edits.insert package=${packageName}`,
       `play-developer-api edits.bundles.upload artifact=${artifact}`,
       `play-developer-api edits.tracks.update track=${track}`,
       'play-developer-api edits.commit',
@@ -62,8 +94,8 @@ export default defineTarget<Config>({
   kind: 'tv',
   label: 'Play Store (Android TV)',
   async build(ctx, config) {
-    const plan = buildPlan(ctx, config);
-    ctx.log(`androidtv plan ${config.packageName} -> ${plan.track}`);
+    const plan = await buildPlan(ctx, config);
+    ctx.log(`androidtv plan ${plan.packageName} -> ${plan.track}`);
     await mkdir(ctx.outDir, { recursive: true });
     await writeFile(plan.planFile, `${JSON.stringify(plan, null, 2)}\n`, 'utf-8');
     return {
@@ -77,13 +109,14 @@ export default defineTarget<Config>({
   },
   async ship(ctx, config) {
     const track = releaseTrack(ctx.channel, config);
-    const plan = buildPlan(ctx, config);
-    ctx.log(`upload to Play Console package=${config.packageName} track=${track}`);
+    const plan = await buildPlan(ctx, config);
+    const packageName = requirePackageName(config);
+    ctx.log(`upload to Play Console package=${packageName} track=${track}`);
     if (ctx.dryRun) {
       return {
         id: 'dry-run',
         meta: {
-          packageName: config.packageName,
+          packageName,
           artifact: ctx.artifact,
           track,
           commands: plan.commands.slice(1),
@@ -92,8 +125,12 @@ export default defineTarget<Config>({
     }
     // TODO: Google Play Developer Publishing API (edit -> upload bundle -> commit to track)
     return {
-      id: `${config.packageName}@${ctx.version}`,
-      url: `https://play.google.com/store/apps/details?id=${config.packageName}`,
+      id: `${packageName}@${ctx.version}`,
+      url: `https://play.google.com/store/apps/details?id=${packageName}`,
+      meta: {
+        artifact: ctx.artifact,
+        track,
+      },
     };
   },
   async status(id) {


### PR DESCRIPTION
## Summary
- turn the Android TV target into an inspectable Google Play packaging plan
- add manifest validation for Leanback feature and launcher requirements when a manifest path is provided
- preserve safe dry-run shipping metadata and channel-to-track mapping

## Tests
- `pnpm --filter @profullstack/sh1pt-target-tv-androidtv typecheck`
- `pnpm test -- packages/targets/tv-androidtv/src/index.test.ts`