### PR TITLE
fix: correct tsconfig.base.json extends paths for bot packages (#452)

### DIFF
--- a/packages/bot/core/tsconfig.json
+++ b/packages/bot/core/tsconfig.json
@@ -1,8 +1,10 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }

--- a/packages/bot/discord/tsconfig.json
+++ b/packages/bot/discord/tsconfig.json
@@ -1,8 +1,10 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }

--- a/packages/bot/signal/tsconfig.json
+++ b/packages/bot/signal/tsconfig.json
@@ -1,8 +1,10 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }

--- a/packages/bot/telegram/tsconfig.json
+++ b/packages/bot/telegram/tsconfig.json
@@ -1,8 +1,10 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }

--- a/packages/bot/whatsapp/tsconfig.json
+++ b/packages/bot/whatsapp/tsconfig.json
@@ -1,8 +1,10 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }


### PR DESCRIPTION
## Summary

Fixed the `extends` paths in bot package tsconfig files from `../../tsconfig.base.json` to `../../../tsconfig.base.json`.

Fixes #452