### PR TITLE
fix(dns): narrow Google DNS delete record inputs

### DIFF
--- a/packages/dns/googledns/src/index.ts
+++ b/packages/dns/googledns/src/index.ts
@@ -124,13 +124,18 @@ export default defineDns<Config>({
     const project = config.projectId ?? _secret('GOOGLE_PROJECT_ID');
     if (!project) throw new Error('GOOGLE_PROJECT_ID not set');
     const [type, name] = recordId.split('/');
+    if (!type || !name) {
+      throw new Error('Google Cloud DNS deleteRecord: invalid record id');
+    }
     // Need to fetch the rrset to get current rrdatas for the deletion entry.
     const existing = (await this.listRecords(zoneId, config)).filter(
       r => r.type === type && (r.name === name || r.name === name.replace(/\.$/, '')),
     );
     if (existing.length === 0) return;
     const fqdn = name.endsWith('.') ? name : `${name}.`;
-    const ttl = existing[0].ttl;
+    const first = existing[0];
+    if (!first) return;
+    const ttl = first.ttl;
     const res = await fetch(`${API}/projects/${project}/managedZones/${zoneId}/changes`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },

--- a/packages/dns/googledns/src/index.ts
+++ b/packages/dns/googledns/src/index.ts
@@ -134,7 +134,9 @@ export default defineDns<Config>({
     if (existing.length === 0) return;
     const fqdn = name.endsWith('.') ? name : `${name}.`;
     const first = existing[0];
-    if (!first) return;
+    if (!first) {
+      throw new Error('Google Cloud DNS deleteRecord: matching record unavailable');
+    }
     const ttl = first.ttl;
     const res = await fetch(`${API}/projects/${project}/managedZones/${zoneId}/changes`, {
       method: 'POST',


### PR DESCRIPTION
Fixes #454.

`deleteRecord()` now narrows the parsed `recordId` pieces before using them and stores the first matching record in a local variable before reading its `ttl`. This addresses the strict/noUncheckedIndexedAccess typecheck failures without changing the successful deletion path.

Verification: targeted static inspection of the failing lines. I could not run `corepack pnpm --dir packages/dns/googledns typecheck` in this projectless workspace because the full dependency checkout is not present here.