### PR TITLE
fix(bot): inherit workspace tsconfig in nested packages

### DIFF
--- a/packages/bot/core/tsconfig.json
+++ b/packages/bot/core/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"

--- a/packages/bot/discord/tsconfig.json
+++ b/packages/bot/discord/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"

--- a/packages/bot/signal/tsconfig.json
+++ b/packages/bot/signal/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"

--- a/packages/bot/telegram/tsconfig.json
+++ b/packages/bot/telegram/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"

--- a/packages/bot/whatsapp/src/index.ts
+++ b/packages/bot/whatsapp/src/index.ts
@@ -27,6 +27,17 @@ export interface IncomingMessage {
 }
 
 type MessageHandler = (msg: IncomingMessage) => void | Promise<void>;
+type WhatsAppTimestamp = number | string | { toNumber?: () => number };
+
+function toUnixMs(timestamp: WhatsAppTimestamp | null | undefined): number {
+  if (typeof timestamp === "number") return timestamp * 1000;
+  if (typeof timestamp === "string") return Number(timestamp) * 1000;
+
+  const numeric = timestamp?.toNumber?.();
+  if (typeof numeric === "number") return numeric * 1000;
+
+  return Date.now();
+}
 
 export class WhatsAppBot {
   private sock: WASocket | null = null;
@@ -54,7 +65,8 @@ export class WhatsAppBot {
       for (const msg of messages) {
         if (!msg.message || msg.key.fromMe) continue;
 
-        const chatId = msg.key.remoteJid!;
+        const chatId = msg.key.remoteJid;
+        if (!chatId) continue;
         const isGroup = chatId.endsWith("@g.us");
         const text =
           msg.message.conversation ||
@@ -65,7 +77,7 @@ export class WhatsAppBot {
           source: chatId,
           sourceName: msg.pushName || "User",
           text,
-          timestamp: msg.messageTimestamp * 1000,
+          timestamp: toUnixMs(msg.messageTimestamp),
           chatId,
           isGroup,
           attachments: [],

--- a/packages/bot/whatsapp/src/index.ts
+++ b/packages/bot/whatsapp/src/index.ts
@@ -31,10 +31,13 @@ type WhatsAppTimestamp = number | string | { toNumber?: () => number };
 
 function toUnixMs(timestamp: WhatsAppTimestamp | null | undefined): number {
   if (typeof timestamp === "number") return timestamp * 1000;
-  if (typeof timestamp === "string") return Number(timestamp) * 1000;
+  if (typeof timestamp === "string") {
+    const numeric = Number(timestamp);
+    return Number.isFinite(numeric) ? numeric * 1000 : Date.now();
+  }
 
   const numeric = timestamp?.toNumber?.();
-  if (typeof numeric === "number") return numeric * 1000;
+  if (typeof numeric === "number" && Number.isFinite(numeric)) return numeric * 1000;
 
   return Date.now();
 }

--- a/packages/bot/whatsapp/tsconfig.json
+++ b/packages/bot/whatsapp/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"


### PR DESCRIPTION
## Summary
- update nested packages/bot/* tsconfigs to extend the workspace base config at ../../../tsconfig.base.json
- normalize WhatsApp Baileys message timestamps before storing them as milliseconds
- skip WhatsApp messages with no remote JID instead of relying on a non-null assertion

Fixes #452.

## Testing
- Not run locally; change was prepared through GitHub contents API in the projectless workspace.
