### PR TITLE
fix(stripe): accept any matching webhook v1 signature

### DIFF
--- a/packages/payments/stripe/src/index.test.ts
+++ b/packages/payments/stripe/src/index.test.ts
@@ -112,6 +112,15 @@ describe('payment-stripe', () => {
     );
 
     expect(webhook.type).toBe('checkout.session.completed');
+
+    const webhookWithMatchingSignatureLast = await adapter.verifyWebhook(
+      ctx({ STRIPE_WEBHOOK_SECRET: secret }),
+      raw,
+      `t=${timestamp},v1=${'0'.repeat(64)},v1=${signature}`,
+      {},
+    );
+
+    expect(webhookWithMatchingSignatureLast.type).toBe('checkout.session.completed');
   });
 
   it('rejects invalid Stripe webhook signatures', async () => {

--- a/packages/payments/stripe/src/index.test.ts
+++ b/packages/payments/stripe/src/index.test.ts
@@ -96,6 +96,24 @@ describe('payment-stripe', () => {
     });
   });
 
+  it('accepts any matching Stripe v1 signature when multiple are present', async () => {
+    const raw = JSON.stringify({ type: 'checkout.session.completed' });
+    const secret = 'whsec_test';
+    const timestamp = '1700000000';
+    const signature = createHmac('sha256', secret)
+      .update(`${timestamp}.${raw}`)
+      .digest('hex');
+
+    const webhook = await adapter.verifyWebhook(
+      ctx({ STRIPE_WEBHOOK_SECRET: secret }),
+      raw,
+      `t=${timestamp},v1=${signature},v1=${'0'.repeat(64)}`,
+      {},
+    );
+
+    expect(webhook.type).toBe('checkout.session.completed');
+  });
+
   it('rejects invalid Stripe webhook signatures', async () => {
     await expect(adapter.verifyWebhook(
       ctx({ STRIPE_WEBHOOK_SECRET: 'whsec_test' }),

--- a/packages/payments/stripe/src/index.ts
+++ b/packages/payments/stripe/src/index.ts
@@ -162,25 +162,30 @@ async function readStripeJson<T>(res: Response): Promise<T> {
 }
 
 function verifyStripeSignature(rawBody: string, header: string, secret: string): void {
-  const parts = Object.fromEntries(
-    header.split(',').map((part) => {
-      const [key, value] = part.split('=');
-      return [key, value];
-    }),
-  );
-  const timestamp = parts.t;
-  const signature = parts.v1;
-  if (!timestamp || !signature) throw new Error('Stripe-Signature missing t or v1');
+  let timestamp: string | undefined;
+  const signatures: string[] = [];
+
+  for (const part of header.split(',')) {
+    const [key, value] = part.split('=');
+    if (key === 't') timestamp = value;
+    if (key === 'v1' && value) signatures.push(value);
+  }
+
+  if (!timestamp || signatures.length === 0) throw new Error('Stripe-Signature missing t or v1');
 
   const expected = createHmac('sha256', secret)
     .update(`${timestamp}.${rawBody}`)
     .digest('hex');
 
-  const actualBuffer = Buffer.from(signature, 'hex');
   const expectedBuffer = Buffer.from(expected, 'hex');
-  if (actualBuffer.length !== expectedBuffer.length || !timingSafeEqual(actualBuffer, expectedBuffer)) {
-    throw new Error('Invalid Stripe webhook signature');
+  for (const signature of signatures) {
+    const actualBuffer = Buffer.from(signature, 'hex');
+    if (actualBuffer.length === expectedBuffer.length && timingSafeEqual(actualBuffer, expectedBuffer)) {
+      return;
+    }
   }
+
+  throw new Error('Invalid Stripe webhook signature');
 }
 
 function normalizeStripeStatus(status: unknown): Webhook['status'] | undefined {


### PR DESCRIPTION
## Summary
- preserve all v1 values from Stripe-Signature instead of collapsing duplicate keys
- accept the webhook when any provided v1 signature matches the expected HMAC
- add a regression test for rotated/multiple v1 signatures

## Why
Stripe can include multiple v1 signatures during webhook secret rotation. The previous Object.fromEntries parsing only kept the last v1 value, so a valid signature could be ignored if another v1 appeared later.

## Testing
- Not run locally: this Codex environment does not have npm/corepack/pnpm installed.

uGig gig: abd6b2a0-e728-48cf-a46f-f99e419ed94e