### PR TITLE
fix(bot): align nested tsconfig base paths

### DIFF
--- a/packages/bot/core/tsconfig.json
+++ b/packages/bot/core/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"

--- a/packages/bot/discord/tsconfig.json
+++ b/packages/bot/discord/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"

--- a/packages/bot/signal/tsconfig.json
+++ b/packages/bot/signal/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"

--- a/packages/bot/telegram/tsconfig.json
+++ b/packages/bot/telegram/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"

--- a/packages/bot/whatsapp/src/index.ts
+++ b/packages/bot/whatsapp/src/index.ts
@@ -45,10 +45,11 @@ export class WhatsAppBot {
   async start(): Promise<void> {
     const { state, saveState } = useMultiFileAuthState("./auth");
 
-    this.sock = makeBaileysBot(state, {
-      print: console.log,
+    this.sock = makeBaileysBot({
+      auth: state,
       browser: ["sh1pt-bot", "Chrome", "120"],
     });
+    this.sock.ev.on("creds.update", saveState);
 
     this.sock.ev.on("messages.upsert", async ({ messages }) => {
       for (const msg of messages) {

--- a/packages/bot/whatsapp/tsconfig.json
+++ b/packages/bot/whatsapp/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"


### PR DESCRIPTION
Fixes #452.

Summary:
- correct the nested packages/bot/* tsconfig base path from ../../tsconfig.base.json to ../../../tsconfig.base.json
- fix the WhatsApp Baileys socket initialization exposed once the package inherits the real strict base config
- wire creds.update to the existing auth-state save callback

Validation:
- corepack pnpm --dir packages/bot/core typecheck
- corepack pnpm --dir packages/bot/discord typecheck
- corepack pnpm --dir packages/bot/signal typecheck
- corepack pnpm --dir packages/bot/telegram typecheck
- corepack pnpm --dir packages/bot/whatsapp typecheck
- git diff --check

Submitted for the ugig bounty/gig: Need someone to test submit bugs and PRs to fix those bugs.

Solana wallet for bounty payout:
Dy4yMkjCfupxaURt6iTMUrxqSDEmAJPPkKF66QahxJZD