### PR TITLE
Harden OpenAI-compatible AI adapter requests

### DIFF
--- a/packages/ai/cerebras/src/index.test.ts
+++ b/packages/ai/cerebras/src/index.test.ts
@@ -82,11 +82,12 @@ describe('Cerebras OpenAI-compatible generation', () => {
   });
 
   it('includes status and redacted response body excerpt on errors', async () => {
-    const apiKey = 'test-key';
+    const apiKey = 'test-key-crossing-truncation-boundary';
+    const prefix = 'x'.repeat(190);
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: false,
       status: 500,
-      text: async () => `server error ${apiKey}`.repeat(30),
+      text: async () => `${prefix}${apiKey} server error`,
     }));
 
     let error: unknown;
@@ -96,8 +97,9 @@ describe('Cerebras OpenAI-compatible generation', () => {
       error = exc;
     }
     expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain('Cerebras 500: server error');
+    expect((error as Error).message).toContain('Cerebras 500:');
     expect((error as Error).message).toContain('[redacted]');
     expect((error as Error).message).not.toContain(apiKey);
+    expect((error as Error).message).not.toContain(apiKey.slice(0, 10));
   });
 });

--- a/packages/ai/cerebras/src/index.test.ts
+++ b/packages/ai/cerebras/src/index.test.ts
@@ -68,13 +68,36 @@ describe('Cerebras OpenAI-compatible generation', () => {
     });
   });
 
-  it('includes status and response body excerpt on errors', async () => {
+  it('normalizes configured base URLs with trailing slashes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'ok' } }], model: 'llama-3.3-70b' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://proxy.example.com/' });
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://proxy.example.com/v1/chat/completions');
+  });
+
+  it('includes status and redacted response body excerpt on errors', async () => {
+    const apiKey = 'test-key';
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: false,
       status: 500,
-      text: async () => 'server error'.repeat(30),
+      text: async () => `server error ${apiKey}`.repeat(30),
     }));
 
-    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/Cerebras 500: server error/);
+    let error: unknown;
+    try {
+      await adapter.generate(ctx({ CEREBRAS_API_KEY: apiKey }), 'hello', {}, {});
+    } catch (exc) {
+      error = exc;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('Cerebras 500: server error');
+    expect((error as Error).message).toContain('[redacted]');
+    expect((error as Error).message).not.toContain(apiKey);
   });
 });

--- a/packages/ai/cerebras/src/index.ts
+++ b/packages/ai/cerebras/src/index.ts
@@ -45,7 +45,7 @@ export default defineAi<Config>({
         ...opts.extra,
       }),
     });
-    if (!res.ok) throw new Error(`Cerebras ${res.status}: ${redact((await res.text()).slice(0, 200), apiKey)}`);
+    if (!res.ok) throw new Error(`Cerebras ${res.status}: ${redact(await res.text(), apiKey).slice(0, 200)}`);
     const data = (await res.json()) as {
       choices: Array<{ message?: { content?: string } }>;
       model: string;

--- a/packages/ai/cerebras/src/index.ts
+++ b/packages/ai/cerebras/src/index.ts
@@ -6,6 +6,14 @@ interface Config {
 
 const DEFAULT_BASE = 'https://api.cerebras.ai';
 
+function chatCompletionsUrl(baseUrl?: string): string {
+  return `${(baseUrl ?? DEFAULT_BASE).replace(/\/+$/, '')}/v1/chat/completions`;
+}
+
+function redact(value: string, apiKey: string): string {
+  return apiKey ? value.split(apiKey).join('[redacted]') : value;
+}
+
 export default defineAi<Config>({
   id: 'ai-cerebras',
   label: 'Cerebras',
@@ -23,7 +31,7 @@ export default defineAi<Config>({
     if (opts.system) messages.push({ role: 'system', content: opts.system });
     messages.push({ role: 'user', content: prompt });
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/chat/completions`, {
+    const res = await fetch(chatCompletionsUrl(config.baseUrl), {
       method: 'POST',
       headers: {
         authorization: `Bearer ${apiKey}`,
@@ -37,7 +45,7 @@ export default defineAi<Config>({
         ...opts.extra,
       }),
     });
-    if (!res.ok) throw new Error(`Cerebras ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    if (!res.ok) throw new Error(`Cerebras ${res.status}: ${redact((await res.text()).slice(0, 200), apiKey)}`);
     const data = (await res.json()) as {
       choices: Array<{ message?: { content?: string } }>;
       model: string;

--- a/packages/ai/deepseek/src/index.test.ts
+++ b/packages/ai/deepseek/src/index.test.ts
@@ -68,13 +68,36 @@ describe('DeepSeek OpenAI-compatible generation', () => {
     });
   });
 
-  it('includes status and response body excerpt on errors', async () => {
+  it('normalizes configured base URLs with trailing slashes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'ok' } }], model: 'deepseek-chat' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://proxy.example.com/' });
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://proxy.example.com/v1/chat/completions');
+  });
+
+  it('includes status and redacted response body excerpt on errors', async () => {
+    const apiKey = 'test-key';
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: false,
       status: 401,
-      text: async () => 'invalid api key'.repeat(30),
+      text: async () => `invalid api key ${apiKey}`.repeat(30),
     }));
 
-    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/DeepSeek 401: invalid api key/);
+    let error: unknown;
+    try {
+      await adapter.generate(ctx({ DEEPSEEK_API_KEY: apiKey }), 'hello', {}, {});
+    } catch (exc) {
+      error = exc;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('DeepSeek 401: invalid api key');
+    expect((error as Error).message).toContain('[redacted]');
+    expect((error as Error).message).not.toContain(apiKey);
   });
 });

--- a/packages/ai/deepseek/src/index.test.ts
+++ b/packages/ai/deepseek/src/index.test.ts
@@ -82,11 +82,12 @@ describe('DeepSeek OpenAI-compatible generation', () => {
   });
 
   it('includes status and redacted response body excerpt on errors', async () => {
-    const apiKey = 'test-key';
+    const apiKey = 'test-key-crossing-truncation-boundary';
+    const prefix = 'x'.repeat(190);
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: false,
       status: 401,
-      text: async () => `invalid api key ${apiKey}`.repeat(30),
+      text: async () => `${prefix}${apiKey} invalid api key`,
     }));
 
     let error: unknown;
@@ -96,8 +97,9 @@ describe('DeepSeek OpenAI-compatible generation', () => {
       error = exc;
     }
     expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain('DeepSeek 401: invalid api key');
+    expect((error as Error).message).toContain('DeepSeek 401:');
     expect((error as Error).message).toContain('[redacted]');
     expect((error as Error).message).not.toContain(apiKey);
+    expect((error as Error).message).not.toContain(apiKey.slice(0, 10));
   });
 });

--- a/packages/ai/deepseek/src/index.ts
+++ b/packages/ai/deepseek/src/index.ts
@@ -6,6 +6,14 @@ interface Config {
 
 const DEFAULT_BASE = 'https://api.deepseek.com';
 
+function chatCompletionsUrl(baseUrl?: string): string {
+  return `${(baseUrl ?? DEFAULT_BASE).replace(/\/+$/, '')}/v1/chat/completions`;
+}
+
+function redact(value: string, apiKey: string): string {
+  return apiKey ? value.split(apiKey).join('[redacted]') : value;
+}
+
 export default defineAi<Config>({
   id: 'ai-deepseek',
   label: 'DeepSeek',
@@ -23,7 +31,7 @@ export default defineAi<Config>({
     if (opts.system) messages.push({ role: 'system', content: opts.system });
     messages.push({ role: 'user', content: prompt });
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/chat/completions`, {
+    const res = await fetch(chatCompletionsUrl(config.baseUrl), {
       method: 'POST',
       headers: {
         authorization: `Bearer ${apiKey}`,
@@ -37,7 +45,7 @@ export default defineAi<Config>({
         ...opts.extra,
       }),
     });
-    if (!res.ok) throw new Error(`DeepSeek ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    if (!res.ok) throw new Error(`DeepSeek ${res.status}: ${redact((await res.text()).slice(0, 200), apiKey)}`);
     const data = (await res.json()) as {
       choices: Array<{ message?: { content?: string } }>;
       model: string;

--- a/packages/ai/deepseek/src/index.ts
+++ b/packages/ai/deepseek/src/index.ts
@@ -45,7 +45,7 @@ export default defineAi<Config>({
         ...opts.extra,
       }),
     });
-    if (!res.ok) throw new Error(`DeepSeek ${res.status}: ${redact((await res.text()).slice(0, 200), apiKey)}`);
+    if (!res.ok) throw new Error(`DeepSeek ${res.status}: ${redact(await res.text(), apiKey).slice(0, 200)}`);
     const data = (await res.json()) as {
       choices: Array<{ message?: { content?: string } }>;
       model: string;

--- a/packages/ai/groq/src/index.test.ts
+++ b/packages/ai/groq/src/index.test.ts
@@ -68,13 +68,36 @@ describe('Groq OpenAI-compatible generation', () => {
     });
   });
 
-  it('includes status and response body excerpt on errors', async () => {
+  it('normalizes configured base URLs with trailing slashes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'ok' } }], model: 'llama-3.3-70b-versatile' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://proxy.example.com/' });
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://proxy.example.com/v1/chat/completions');
+  });
+
+  it('includes status and redacted response body excerpt on errors', async () => {
+    const apiKey = 'test-key';
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: false,
       status: 429,
-      text: async () => 'rate limited'.repeat(30),
+      text: async () => `rate limited ${apiKey}`.repeat(30),
     }));
 
-    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/Groq 429: rate limited/);
+    let error: unknown;
+    try {
+      await adapter.generate(ctx({ GROQ_API_KEY: apiKey }), 'hello', {}, {});
+    } catch (exc) {
+      error = exc;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('Groq 429: rate limited');
+    expect((error as Error).message).toContain('[redacted]');
+    expect((error as Error).message).not.toContain(apiKey);
   });
 });

--- a/packages/ai/groq/src/index.test.ts
+++ b/packages/ai/groq/src/index.test.ts
@@ -82,11 +82,12 @@ describe('Groq OpenAI-compatible generation', () => {
   });
 
   it('includes status and redacted response body excerpt on errors', async () => {
-    const apiKey = 'test-key';
+    const apiKey = 'test-key-crossing-truncation-boundary';
+    const prefix = 'x'.repeat(190);
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: false,
       status: 429,
-      text: async () => `rate limited ${apiKey}`.repeat(30),
+      text: async () => `${prefix}${apiKey} rate limited`,
     }));
 
     let error: unknown;
@@ -96,8 +97,9 @@ describe('Groq OpenAI-compatible generation', () => {
       error = exc;
     }
     expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain('Groq 429: rate limited');
+    expect((error as Error).message).toContain('Groq 429:');
     expect((error as Error).message).toContain('[redacted]');
     expect((error as Error).message).not.toContain(apiKey);
+    expect((error as Error).message).not.toContain(apiKey.slice(0, 10));
   });
 });

--- a/packages/ai/groq/src/index.ts
+++ b/packages/ai/groq/src/index.ts
@@ -6,6 +6,14 @@ interface Config {
 
 const DEFAULT_BASE = 'https://api.groq.com/openai';
 
+function chatCompletionsUrl(baseUrl?: string): string {
+  return `${(baseUrl ?? DEFAULT_BASE).replace(/\/+$/, '')}/v1/chat/completions`;
+}
+
+function redact(value: string, apiKey: string): string {
+  return apiKey ? value.split(apiKey).join('[redacted]') : value;
+}
+
 export default defineAi<Config>({
   id: 'ai-groq',
   label: 'Groq',
@@ -28,7 +36,7 @@ export default defineAi<Config>({
     if (opts.system) messages.push({ role: 'system', content: opts.system });
     messages.push({ role: 'user', content: prompt });
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/chat/completions`, {
+    const res = await fetch(chatCompletionsUrl(config.baseUrl), {
       method: 'POST',
       headers: {
         authorization: `Bearer ${apiKey}`,
@@ -42,7 +50,7 @@ export default defineAi<Config>({
         ...opts.extra,
       }),
     });
-    if (!res.ok) throw new Error(`Groq ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    if (!res.ok) throw new Error(`Groq ${res.status}: ${redact((await res.text()).slice(0, 200), apiKey)}`);
     const data = (await res.json()) as {
       choices: Array<{ message?: { content?: string } }>;
       model: string;

--- a/packages/ai/groq/src/index.ts
+++ b/packages/ai/groq/src/index.ts
@@ -50,7 +50,7 @@ export default defineAi<Config>({
         ...opts.extra,
       }),
     });
-    if (!res.ok) throw new Error(`Groq ${res.status}: ${redact((await res.text()).slice(0, 200), apiKey)}`);
+    if (!res.ok) throw new Error(`Groq ${res.status}: ${redact(await res.text(), apiKey).slice(0, 200)}`);
     const data = (await res.json()) as {
       choices: Array<{ message?: { content?: string } }>;
       model: string;

--- a/packages/ai/mistral/src/index.test.ts
+++ b/packages/ai/mistral/src/index.test.ts
@@ -82,11 +82,12 @@ describe('Mistral OpenAI-compatible generation', () => {
   });
 
   it('includes status and redacted response body excerpt on errors', async () => {
-    const apiKey = 'test-key';
+    const apiKey = 'test-key-crossing-truncation-boundary';
+    const prefix = 'x'.repeat(190);
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: false,
       status: 400,
-      text: async () => `bad request ${apiKey}`.repeat(30),
+      text: async () => `${prefix}${apiKey} bad request`,
     }));
 
     let error: unknown;
@@ -96,8 +97,9 @@ describe('Mistral OpenAI-compatible generation', () => {
       error = exc;
     }
     expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain('Mistral 400: bad request');
+    expect((error as Error).message).toContain('Mistral 400:');
     expect((error as Error).message).toContain('[redacted]');
     expect((error as Error).message).not.toContain(apiKey);
+    expect((error as Error).message).not.toContain(apiKey.slice(0, 10));
   });
 });

--- a/packages/ai/mistral/src/index.test.ts
+++ b/packages/ai/mistral/src/index.test.ts
@@ -68,13 +68,36 @@ describe('Mistral OpenAI-compatible generation', () => {
     });
   });
 
-  it('includes status and response body excerpt on errors', async () => {
+  it('normalizes configured base URLs with trailing slashes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'ok' } }], model: 'mistral-large-latest' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://proxy.example.com/' });
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://proxy.example.com/v1/chat/completions');
+  });
+
+  it('includes status and redacted response body excerpt on errors', async () => {
+    const apiKey = 'test-key';
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: false,
       status: 400,
-      text: async () => 'bad request'.repeat(30),
+      text: async () => `bad request ${apiKey}`.repeat(30),
     }));
 
-    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/Mistral 400: bad request/);
+    let error: unknown;
+    try {
+      await adapter.generate(ctx({ MISTRAL_API_KEY: apiKey }), 'hello', {}, {});
+    } catch (exc) {
+      error = exc;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('Mistral 400: bad request');
+    expect((error as Error).message).toContain('[redacted]');
+    expect((error as Error).message).not.toContain(apiKey);
   });
 });

--- a/packages/ai/mistral/src/index.ts
+++ b/packages/ai/mistral/src/index.ts
@@ -6,6 +6,14 @@ interface Config {
 
 const DEFAULT_BASE = 'https://api.mistral.ai';
 
+function chatCompletionsUrl(baseUrl?: string): string {
+  return `${(baseUrl ?? DEFAULT_BASE).replace(/\/+$/, '')}/v1/chat/completions`;
+}
+
+function redact(value: string, apiKey: string): string {
+  return apiKey ? value.split(apiKey).join('[redacted]') : value;
+}
+
 export default defineAi<Config>({
   id: 'ai-mistral',
   label: 'Mistral',
@@ -23,7 +31,7 @@ export default defineAi<Config>({
     if (opts.system) messages.push({ role: 'system', content: opts.system });
     messages.push({ role: 'user', content: prompt });
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/chat/completions`, {
+    const res = await fetch(chatCompletionsUrl(config.baseUrl), {
       method: 'POST',
       headers: {
         authorization: `Bearer ${apiKey}`,
@@ -37,7 +45,7 @@ export default defineAi<Config>({
         ...opts.extra,
       }),
     });
-    if (!res.ok) throw new Error(`Mistral ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    if (!res.ok) throw new Error(`Mistral ${res.status}: ${redact((await res.text()).slice(0, 200), apiKey)}`);
     const data = (await res.json()) as {
       choices: Array<{ message?: { content?: string } }>;
       model: string;

--- a/packages/ai/mistral/src/index.ts
+++ b/packages/ai/mistral/src/index.ts
@@ -45,7 +45,7 @@ export default defineAi<Config>({
         ...opts.extra,
       }),
     });
-    if (!res.ok) throw new Error(`Mistral ${res.status}: ${redact((await res.text()).slice(0, 200), apiKey)}`);
+    if (!res.ok) throw new Error(`Mistral ${res.status}: ${redact(await res.text(), apiKey).slice(0, 200)}`);
     const data = (await res.json()) as {
       choices: Array<{ message?: { content?: string } }>;
       model: string;

--- a/packages/ai/xai/src/index.test.ts
+++ b/packages/ai/xai/src/index.test.ts
@@ -68,13 +68,36 @@ describe('xAI OpenAI-compatible generation', () => {
     });
   });
 
-  it('includes status and response body excerpt on errors', async () => {
+  it('normalizes configured base URLs with trailing slashes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'ok' } }], model: 'grok-3' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://proxy.example.com/' });
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://proxy.example.com/v1/chat/completions');
+  });
+
+  it('includes status and redacted response body excerpt on errors', async () => {
+    const apiKey = 'test-key';
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: false,
       status: 403,
-      text: async () => 'forbidden'.repeat(30),
+      text: async () => `forbidden ${apiKey}`.repeat(30),
     }));
 
-    await expect(adapter.generate(ctx(), 'hello', {}, {})).rejects.toThrow(/xAI 403: forbidden/);
+    let error: unknown;
+    try {
+      await adapter.generate(ctx({ XAI_API_KEY: apiKey }), 'hello', {}, {});
+    } catch (exc) {
+      error = exc;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('xAI 403: forbidden');
+    expect((error as Error).message).toContain('[redacted]');
+    expect((error as Error).message).not.toContain(apiKey);
   });
 });

--- a/packages/ai/xai/src/index.test.ts
+++ b/packages/ai/xai/src/index.test.ts
@@ -82,11 +82,12 @@ describe('xAI OpenAI-compatible generation', () => {
   });
 
   it('includes status and redacted response body excerpt on errors', async () => {
-    const apiKey = 'test-key';
+    const apiKey = 'test-key-crossing-truncation-boundary';
+    const prefix = 'x'.repeat(190);
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: false,
       status: 403,
-      text: async () => `forbidden ${apiKey}`.repeat(30),
+      text: async () => `${prefix}${apiKey} forbidden`,
     }));
 
     let error: unknown;
@@ -96,8 +97,9 @@ describe('xAI OpenAI-compatible generation', () => {
       error = exc;
     }
     expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain('xAI 403: forbidden');
+    expect((error as Error).message).toContain('xAI 403:');
     expect((error as Error).message).toContain('[redacted]');
     expect((error as Error).message).not.toContain(apiKey);
+    expect((error as Error).message).not.toContain(apiKey.slice(0, 10));
   });
 });

--- a/packages/ai/xai/src/index.ts
+++ b/packages/ai/xai/src/index.ts
@@ -45,7 +45,7 @@ export default defineAi<Config>({
         ...opts.extra,
       }),
     });
-    if (!res.ok) throw new Error(`xAI ${res.status}: ${redact((await res.text()).slice(0, 200), apiKey)}`);
+    if (!res.ok) throw new Error(`xAI ${res.status}: ${redact(await res.text(), apiKey).slice(0, 200)}`);
     const data = (await res.json()) as {
       choices: Array<{ message?: { content?: string } }>;
       model: string;

--- a/packages/ai/xai/src/index.ts
+++ b/packages/ai/xai/src/index.ts
@@ -6,6 +6,14 @@ interface Config {
 
 const DEFAULT_BASE = 'https://api.x.ai';
 
+function chatCompletionsUrl(baseUrl?: string): string {
+  return `${(baseUrl ?? DEFAULT_BASE).replace(/\/+$/, '')}/v1/chat/completions`;
+}
+
+function redact(value: string, apiKey: string): string {
+  return apiKey ? value.split(apiKey).join('[redacted]') : value;
+}
+
 export default defineAi<Config>({
   id: 'ai-xai',
   label: 'xAI',
@@ -23,7 +31,7 @@ export default defineAi<Config>({
     if (opts.system) messages.push({ role: 'system', content: opts.system });
     messages.push({ role: 'user', content: prompt });
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/chat/completions`, {
+    const res = await fetch(chatCompletionsUrl(config.baseUrl), {
       method: 'POST',
       headers: {
         authorization: `Bearer ${apiKey}`,
@@ -37,7 +45,7 @@ export default defineAi<Config>({
         ...opts.extra,
       }),
     });
-    if (!res.ok) throw new Error(`xAI ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    if (!res.ok) throw new Error(`xAI ${res.status}: ${redact((await res.text()).slice(0, 200), apiKey)}`);
     const data = (await res.json()) as {
       choices: Array<{ message?: { content?: string } }>;
       model: string;


### PR DESCRIPTION
## Summary
- normalize configured base URLs for Groq, DeepSeek, Mistral, xAI, and Cerebras before appending /v1/chat/completions
- redact provider API keys from non-2xx response excerpts before surfacing adapter errors
- add regression coverage for trailing-slash base URLs and redacted error bodies across all five adapters

## Tests
- pnpm vitest run packages/ai/groq/src/index.test.ts packages/ai/deepseek/src/index.test.ts packages/ai/mistral/src/index.test.ts packages/ai/xai/src/index.test.ts packages/ai/cerebras/src/index.test.ts
- pnpm --filter './packages/ai/{groq,deepseek,mistral,xai,cerebras}' typecheck
