### PR TITLE
fix(coinpay): accept any matching webhook v1 signature

### DIFF
--- a/packages/payments/coinpay/src/index.test.ts
+++ b/packages/payments/coinpay/src/index.test.ts
@@ -169,6 +169,24 @@ describe('payment-coinpay', () => {
     });
   });
 
+  it('accepts any matching CoinPay v1 signature when multiple are present', async () => {
+    const raw = JSON.stringify({ type: 'payment.confirmed' });
+    const secret = 'whsec_test';
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const signature = createHmac('sha256', secret)
+      .update(`${timestamp}.${raw}`)
+      .digest('hex');
+
+    const webhook = await payment.verifyWebhook(
+      ctx({ COINPAY_WEBHOOK_SECRET: secret }),
+      raw,
+      `t=${timestamp},v1=${signature},v1=${'0'.repeat(64)}`,
+      {},
+    );
+
+    expect(webhook.type).toBe('payment.confirmed');
+  });
+
   it('rejects invalid CoinPay webhook signatures', async () => {
     const timestamp = Math.floor(Date.now() / 1000).toString();
     await expect(payment.verifyWebhook(

--- a/packages/payments/coinpay/src/index.test.ts
+++ b/packages/payments/coinpay/src/index.test.ts
@@ -185,6 +185,15 @@ describe('payment-coinpay', () => {
     );
 
     expect(webhook.type).toBe('payment.confirmed');
+
+    const webhookWithMatchingSignatureLast = await payment.verifyWebhook(
+      ctx({ COINPAY_WEBHOOK_SECRET: secret }),
+      raw,
+      `t=${timestamp},v1=${'0'.repeat(64)},v1=${signature}`,
+      {},
+    );
+
+    expect(webhookWithMatchingSignatureLast.type).toBe('payment.confirmed');
   });
 
   it('rejects invalid CoinPay webhook signatures', async () => {

--- a/packages/payments/coinpay/src/index.ts
+++ b/packages/payments/coinpay/src/index.ts
@@ -183,13 +183,17 @@ function verifyCoinPaySignature(
   secret: string,
   toleranceSeconds = 300,
 ): void {
-  const parts = Object.fromEntries(signatureHeader.split(',').map((part) => {
+  let timestamp: string | undefined;
+  const signatures: string[] = [];
+
+  for (const part of signatureHeader.split(',')) {
     const [key, ...value] = part.trim().split('=');
-    return [key, value.join('=')];
-  }));
-  const timestamp = parts.t;
-  const signature = parts.v1;
-  if (!timestamp || !signature) throw new Error('CoinPay signature missing t or v1');
+    const joinedValue = value.join('=');
+    if (key === 't') timestamp = joinedValue;
+    if (key === 'v1' && joinedValue) signatures.push(joinedValue);
+  }
+
+  if (!timestamp || signatures.length === 0) throw new Error('CoinPay signature missing t or v1');
 
   const timestampSeconds = Number(timestamp);
   if (!Number.isFinite(timestampSeconds)) throw new Error('CoinPay signature timestamp is invalid');
@@ -201,11 +205,15 @@ function verifyCoinPaySignature(
   const expected = createHmac('sha256', secret)
     .update(`${timestamp}.${rawBody}`)
     .digest('hex');
-  const actualBuffer = Buffer.from(signature, 'hex');
   const expectedBuffer = Buffer.from(expected, 'hex');
-  if (actualBuffer.length !== expectedBuffer.length || !timingSafeEqual(actualBuffer, expectedBuffer)) {
-    throw new Error('Invalid CoinPay webhook signature');
+  for (const signature of signatures) {
+    const actualBuffer = Buffer.from(signature, 'hex');
+    if (actualBuffer.length === expectedBuffer.length && timingSafeEqual(actualBuffer, expectedBuffer)) {
+      return;
+    }
   }
+
+  throw new Error('Invalid CoinPay webhook signature');
 }
 
 function normalizeWebhook(event: CoinPayWebhookEvent): Webhook {


### PR DESCRIPTION
## Summary
- preserve every CoinPay `v1` webhook signature instead of collapsing duplicate keys
- accept webhook verification when any provided `v1` signature matches the expected HMAC
- add a regression test for multiple CoinPay signatures during rotation

## Why
CoinPay webhook headers can carry repeated signature keys during signing-secret rotation. The previous `Object.fromEntries` parser kept only one `v1` value, which could reject a valid webhook if a non-matching signature overwrote the matching one.

## Testing
- Ran a standalone Node verification of the parser/HMAC loop for a header with two `v1` signatures.
- Full package tests not run locally: this Codex environment does not have npm/corepack/pnpm installed.

uGig follow-up candidate for bugfix bounty.
