### PR TITLE
Fix init default name on Windows paths

### DIFF
--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { defaultProjectName, initCmd } from './init.js';
+
+describe('initCmd', () => {
+  it('is registered as a top-level command named "init"', () => {
+    expect(initCmd.name()).toBe('init');
+  });
+
+  it('derives a default project name from POSIX paths', () => {
+    expect(defaultProjectName('/Users/alice/projects/my-app')).toBe('my-app');
+  });
+
+  it('derives a default project name from Windows paths', () => {
+    expect(defaultProjectName('C:\\Users\\alice\\projects\\my-app')).toBe('my-app');
+  });
+});

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { writeFile, access } from 'node:fs/promises';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import kleur from 'kleur';
 import prompts from 'prompts';
 
@@ -14,6 +14,10 @@ export default defineConfig({
   },
 });
 `;
+
+export function defaultProjectName(cwd = process.cwd()): string {
+  return basename(cwd.replace(/\\/g, '/')) || 'my-app';
+}
 
 /**
  * Shared init action — scaffolds sh1pt.config.ts in the current project.
@@ -32,7 +36,7 @@ export async function initAction(): Promise<void> {
     type: 'text',
     name: 'name',
     message: 'Project name',
-    initial: process.cwd().split('/').pop() ?? 'my-app',
+    initial: defaultProjectName(),
   });
   if (!name) return;
   await writeFile(cfgPath, CONFIG_TEMPLATE(name), 'utf8');


### PR DESCRIPTION
## Summary

- Fix `sh1pt init` default project-name derivation for Windows paths
- Add a focused init command regression test for POSIX and Windows-style cwd strings

Closes #491.

## Verification

- `npx --yes pnpm@9.12.0 exec vitest run packages/cli/src/commands/init.test.ts`
- `npx --yes pnpm@9.12.0 --filter @profullstack/sh1pt typecheck`

## Bounty trail

This is a focused bug fix for the ugig bounty asking for sh1pt bugs plus PRs: https://ugig.net/bounties/c3137a9d-de39-4c1e-b48a-3df804c32bdf