### PR TITLE
Fix Go module v2 project names

### DIFF
--- a/packages/cli/src/commands/build.test.ts
+++ b/packages/cli/src/commands/build.test.ts
@@ -107,6 +107,16 @@ describe('detectStack', () => {
     expect(result!.packageManager).toBe('go');
   });
 
+  it('keeps v1 when it is the Go repository name', () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, 'go.mod'), `module github.com/user/v1\n\ngo 1.21\n`);
+    const result = detectStack(dir);
+    expect(result).toBeDefined();
+    expect(result!.runtime).toBe('go');
+    expect(result!.projectName).toBe('v1');
+    expect(result!.packageManager).toBe('go');
+  });
+
   it('returns undefined for an empty directory', () => {
     const dir = makeTempDir();
     const result = detectStack(dir);

--- a/packages/cli/src/commands/build.test.ts
+++ b/packages/cli/src/commands/build.test.ts
@@ -107,6 +107,16 @@ describe('detectStack', () => {
     expect(result!.packageManager).toBe('go');
   });
 
+  it('uses the repository segment for double-digit Go module versions', () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, 'go.mod'), `module github.com/user/my-go-app/v10\n\ngo 1.21\n`);
+    const result = detectStack(dir);
+    expect(result).toBeDefined();
+    expect(result!.runtime).toBe('go');
+    expect(result!.projectName).toBe('my-go-app');
+    expect(result!.packageManager).toBe('go');
+  });
+
   it('keeps v1 when it is the Go repository name', () => {
     const dir = makeTempDir();
     writeFileSync(join(dir, 'go.mod'), `module github.com/user/v1\n\ngo 1.21\n`);

--- a/packages/cli/src/commands/build.test.ts
+++ b/packages/cli/src/commands/build.test.ts
@@ -97,6 +97,16 @@ describe('detectStack', () => {
     expect(result!.packageManager).toBe('go');
   });
 
+  it('uses the repository segment for versioned Go modules', () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, 'go.mod'), `module github.com/user/my-go-app/v2\n\ngo 1.21\n`);
+    const result = detectStack(dir);
+    expect(result).toBeDefined();
+    expect(result!.runtime).toBe('go');
+    expect(result!.projectName).toBe('my-go-app');
+    expect(result!.packageManager).toBe('go');
+  });
+
   it('returns undefined for an empty directory', () => {
     const dir = makeTempDir();
     const result = detectStack(dir);

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -93,12 +93,21 @@ export function detectStack(dir: string): DetectedStack | undefined {
       return {
         runtime: 'go',
         packageManager: 'go',
-        projectName: modName ? modName.split('/').pop() : undefined,
+        projectName: modName ? projectNameFromGoModule(modName) : undefined,
       };
     } catch { /* skip */ }
   }
 
   return undefined;
+}
+
+function projectNameFromGoModule(moduleName: string): string | undefined {
+  const segments = moduleName.split('/').filter(Boolean);
+  const last = segments.at(-1);
+  if (last && /^v\d+$/.test(last) && segments.length > 1) {
+    return segments.at(-2);
+  }
+  return last;
 }
 
 // --- Git clone ---------------------------------------------------------------

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -104,7 +104,7 @@ export function detectStack(dir: string): DetectedStack | undefined {
 function projectNameFromGoModule(moduleName: string): string | undefined {
   const segments = moduleName.split('/').filter(Boolean);
   const last = segments.at(-1);
-  if (last && /^v\d+$/.test(last) && segments.length > 1) {
+  if (last && /^v[2-9]\d*$/.test(last) && segments.length > 1) {
     return segments.at(-2);
   }
   return last;

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -104,7 +104,7 @@ export function detectStack(dir: string): DetectedStack | undefined {
 function projectNameFromGoModule(moduleName: string): string | undefined {
   const segments = moduleName.split('/').filter(Boolean);
   const last = segments.at(-1);
-  if (last && /^v[2-9]\d*$/.test(last) && segments.length > 1) {
+  if (last && /^v(?:[2-9]|[1-9]\d+)$/.test(last) && segments.length > 1) {
     return segments.at(-2);
   }
   return last;


### PR DESCRIPTION
## Summary

- Detect versioned Go module paths like `github.com/user/my-go-app/v2` as `my-go-app` instead of `v2`
- Add focused build stack detection coverage for Go major-version module suffixes

Closes #495.

## Verification

- `npx --yes pnpm@9.12.0 exec vitest run packages/cli/src/commands/build.test.ts`
- `npx --yes pnpm@9.12.0 --filter @profullstack/sh1pt typecheck`

## Bounty trail

This is a focused bug fix for the ugig bounty asking for sh1pt bugs plus PRs: https://ugig.net/bounties/c3137a9d-de39-4c1e-b48a-3df804c32bdf