### PR TITLE
Fix forge subpath input classification

### DIFF
--- a/packages/cli/src/input.test.ts
+++ b/packages/cli/src/input.test.ts
@@ -14,6 +14,18 @@ describe('resolveInput', () => {
     expect(r.inferredName).toBe('sh1pt');
   });
 
+  it('classifies github issue urls as live urls, not git repos', () => {
+    const r = resolveInput('https://github.com/profullstack/sh1pt/issues/403');
+    expect(r.kind).toBe('url');
+    expect(r.inferredName).toBe('github.com');
+  });
+
+  it('classifies github tree urls as live urls, not git repos', () => {
+    const r = resolveInput('https://github.com/profullstack/sh1pt/tree/master/packages');
+    expect(r.kind).toBe('url');
+    expect(r.inferredName).toBe('github.com');
+  });
+
   it('detects gitlab repo urls', () => {
     const r = resolveInput('https://gitlab.com/some-org/some-repo');
     expect(r.kind).toBe('git');

--- a/packages/cli/src/input.ts
+++ b/packages/cli/src/input.ts
@@ -65,9 +65,16 @@ export function resolveInput(raw: string): ResolvedInput {
 }
 
 function isForgeRepoUrl(u: string): boolean {
-  // https://github.com/<org>/<repo>[...] — two path segments after the host.
-  const m = u.match(/^https?:\/\/(www\.)?(github\.com|gitlab\.com|bitbucket\.org|codeberg\.org)\/([^/\s]+)\/([^/\s?#]+)/i);
-  return Boolean(m);
+  try {
+    const url = new URL(u);
+    if (!/^(github\.com|gitlab\.com|bitbucket\.org|codeberg\.org)$/i.test(url.hostname.replace(/^www\./i, ''))) {
+      return false;
+    }
+    const segments = url.pathname.replace(/\/+$/, '').split('/').filter(Boolean);
+    return segments.length === 2;
+  } catch {
+    return false;
+  }
 }
 
 function normalizeUrl(u: string): string {


### PR DESCRIPTION
## Summary

- Restrict known forge repo detection to repo-root URLs only
- Keep GitHub issue/tree subpath URLs classified as live URLs instead of broken git clone inputs
- Add focused resolver regressions for issue and tree URLs

Closes #497.

## Verification

- `npx --yes pnpm@9.12.0 exec vitest run packages/cli/src/input.test.ts`
- `npx --yes pnpm@9.12.0 --filter @profullstack/sh1pt typecheck`

## Bounty trail

This is a focused bug fix for the ugig bounty asking for sh1pt bugs plus PRs: https://ugig.net/bounties/c3137a9d-de39-4c1e-b48a-3df804c32bdf