### PR TITLE
Strip browser suffixes from git clone URLs

### DIFF
--- a/packages/cli/src/input.test.ts
+++ b/packages/cli/src/input.test.ts
@@ -21,6 +21,13 @@ describe('resolveInput', () => {
     expect(r.inferredName).toBe('sh1pt');
   });
 
+  it('strips query strings from .git clone urls', () => {
+    const r = resolveInput('https://example.com/repo.git?tab=readme-ov-file#usage');
+    expect(r.kind).toBe('git');
+    expect(r.value).toBe('https://example.com/repo.git');
+    expect(r.inferredName).toBe('repo');
+  });
+
   it('keeps query strings and fragments on live site urls', () => {
     const r = resolveInput('https://example.com/pricing?plan=pro#faq');
     expect(r.kind).toBe('url');

--- a/packages/cli/src/input.test.ts
+++ b/packages/cli/src/input.test.ts
@@ -14,6 +14,19 @@ describe('resolveInput', () => {
     expect(r.inferredName).toBe('sh1pt');
   });
 
+  it('strips query strings and fragments from git clone urls', () => {
+    const r = resolveInput('https://github.com/profullstack/sh1pt?tab=readme-ov-file#usage');
+    expect(r.kind).toBe('git');
+    expect(r.value).toBe('https://github.com/profullstack/sh1pt');
+    expect(r.inferredName).toBe('sh1pt');
+  });
+
+  it('keeps query strings and fragments on live site urls', () => {
+    const r = resolveInput('https://example.com/pricing?plan=pro#faq');
+    expect(r.kind).toBe('url');
+    expect(r.value).toBe('https://example.com/pricing?plan=pro#faq');
+  });
+
   it('detects gitlab repo urls', () => {
     const r = resolveInput('https://gitlab.com/some-org/some-repo');
     expect(r.kind).toBe('git');

--- a/packages/cli/src/input.ts
+++ b/packages/cli/src/input.ts
@@ -77,7 +77,7 @@ function normalizeUrl(u: string): string {
 
 function normalizeGitUrl(u: string): string {
   if (!/^https?:\/\//i.test(u)) {
-    return normalizeUrl(u);
+    return normalizeUrl(u).replace(/[?#].*$/, '');
   }
 
   try {

--- a/packages/cli/src/input.ts
+++ b/packages/cli/src/input.ts
@@ -39,8 +39,8 @@ export function resolveInput(raw: string): ResolvedInput {
   // 2) Http(s) git urls: *.git, github.com/foo/bar, gitlab.com/foo/bar,
   //    bitbucket.org/foo/bar. A plain https to a known forge with org/repo
   //    is treated as git, not a live site.
-  if (/\.git$/i.test(input) || isForgeRepoUrl(input)) {
-    return { kind: 'git', raw, value: normalizeUrl(input), inferredName: repoNameFromGit(input) };
+  if (/\.git(?:[?#]|$)/i.test(input) || isForgeRepoUrl(input)) {
+    return { kind: 'git', raw, value: normalizeGitUrl(input), inferredName: repoNameFromGit(input) };
   }
 
   // 3) Generic http(s) — a live site.
@@ -73,6 +73,22 @@ function isForgeRepoUrl(u: string): boolean {
 function normalizeUrl(u: string): string {
   // Trim trailing slashes and default fragments; keep the path intact.
   return u.replace(/\/+$/, '').replace(/\.git$/i, '.git');
+}
+
+function normalizeGitUrl(u: string): string {
+  if (!/^https?:\/\//i.test(u)) {
+    return normalizeUrl(u);
+  }
+
+  try {
+    const parsed = new URL(u);
+    parsed.search = '';
+    parsed.hash = '';
+    parsed.pathname = parsed.pathname.replace(/\/+$/, '');
+    return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
+  } catch {
+    return normalizeUrl(u).replace(/[?#].*$/, '');
+  }
 }
 
 function repoNameFromGit(u: string): string | undefined {


### PR DESCRIPTION
Fixes #499.

## Summary
- normalize HTTP(S) git clone URLs separately from live-site URLs
- strip browser-only query strings and fragments from git clone targets before clone flows receive them
- keep query strings and fragments intact for ordinary live-site URL inputs
- recognize `.git?query` / `.git#fragment` forms as git URLs

## Verification
- `npx --yes pnpm@9.12.0 exec vitest run packages/cli/src/input.test.ts` -> 15 passed
- `npx --yes pnpm@9.12.0 --filter @profullstack/sh1pt typecheck` -> passed

Bounty trail: opened matching bug report #499 for the ugig bug-fix bounty.