### PR TITLE
Fix skill title inference for repeated separators

### DIFF
--- a/packages/cli/src/commands/skills.test.ts
+++ b/packages/cli/src/commands/skills.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -100,6 +100,51 @@ describe('skills install command', () => {
     expect(content).toContain('<!-- sh1pt-skill:modern-web start -->');
     expect(content).toContain('Modern Web Guidance');
     expect(content).toContain('Prefer least-privilege GitHub Actions permissions.');
+  });
+});
+
+describe('skills new command', () => {
+  let stdout: string[];
+  let tempDir: string;
+
+  beforeEach(() => {
+    stdout = [];
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      stdout.push(args.map(String).join(' '));
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = '';
+    }
+  });
+
+  it('infers titles without undefined words for repeated slug separators', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'sh1pt-skills-new-'));
+    const skillFile = join(tempDir, 'SKILL.md');
+    const manifestFile = join(tempDir, 'sh1pt.skill.json');
+    writeFileSync(skillFile, [
+      '---',
+      'name: alpha--beta',
+      'description: Handles alpha beta workflows.',
+      '---',
+      '',
+      '# Alpha Beta',
+      '',
+    ].join('\n'));
+
+    const newCmd = skillsCmd.commands.find((c) => c.name() === 'new');
+    expect(newCmd).toBeDefined();
+
+    await newCmd?.parseAsync(['--skill-file', skillFile, '--out', manifestFile], { from: 'user' });
+
+    const manifest = JSON.parse(readFileSync(manifestFile, 'utf8'));
+    expect(manifest.name).toBe('alpha-beta');
+    expect(manifest.title).toBe('Alpha Beta');
+    expect(manifest.title).not.toContain('undefined');
   });
 });
 

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -76,6 +76,9 @@ const SKILL_TARGETS = {
 function slugify(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 64) || 'my-skill';
 }
+function titleFromSlug(s: string): string {
+  return s.split('-').filter(Boolean).map(w => w[0]!.toUpperCase() + w.slice(1)).join(' ');
+}
 function q(s: string): string { return JSON.stringify(s); }
 async function exists(path: string): Promise<boolean> { try { await access(path); return true; } catch { return false; } }
 function frontmatterValue(text: string, key: string): string | undefined {
@@ -87,7 +90,7 @@ async function inferFromSkill(file: string): Promise<Partial<SkillManifest>> {
   const text = await readFile(file, 'utf8');
   const name = frontmatterValue(text, 'name');
   const description = frontmatterValue(text, 'description');
-  const title = name ? name.split('-').map(w => w[0]?.toUpperCase() + w.slice(1)).join(' ') : undefined;
+  const title = name ? titleFromSlug(slugify(name)) : undefined;
   return { name, title, description };
 }
 async function loadManifest(path = 'sh1pt.skill.json'): Promise<SkillManifest> {


### PR DESCRIPTION
Fixes #501.

## Summary
- add a small `titleFromSlug` helper that filters empty slug segments before capitalization
- infer skill listing titles from the same normalized slug used for manifest names
- add a regression test for `name: alpha--beta`, which previously generated `Alpha undefined Beta`

## Verification
- `npx --yes pnpm@9.12.0 exec vitest run packages/cli/src/commands/skills.test.ts` -> 10 passed
- `npx --yes pnpm@9.12.0 --filter @profullstack/sh1pt typecheck` -> passed

Bounty trail: opened matching bug report #501 for the ugig bug-fix bounty.