### PR TITLE
feat(cli): implement agents list with real binary detection

### DIFF
--- a/packages/cli/src/commands/agents.ts
+++ b/packages/cli/src/commands/agents.ts
@@ -1,5 +1,87 @@
 import { Command } from 'commander';
 import kleur from 'kleur';
+import { spawnSync } from 'node:child_process';
+
+// ---------------------------------------------------------------------------
+// Known agent CLI descriptors
+// ---------------------------------------------------------------------------
+
+interface AgentDescriptor {
+  id: string;
+  binary: string;
+  versionArgs: string[];
+  installHint: string;
+  package: string;
+}
+
+const KNOWN_AGENTS: AgentDescriptor[] = [
+  {
+    id: 'claude',
+    binary: 'claude',
+    versionArgs: ['--version'],
+    installHint: 'npm install -g @anthropic-ai/claude-code',
+    package: '@anthropic-ai/claude-code',
+  },
+  {
+    id: 'codex',
+    binary: 'codex',
+    versionArgs: ['--version'],
+    installHint: 'npm install -g @openai/codex',
+    package: '@openai/codex',
+  },
+  {
+    id: 'qwen',
+    binary: 'qwen',
+    versionArgs: ['--version'],
+    installHint: 'pip install qwen-agent',
+    package: 'qwen-agent',
+  },
+];
+
+interface AgentStatus {
+  id: string;
+  installed: boolean;
+  version?: string;
+  binary: string;
+  installHint: string;
+  package: string;
+  setupCommand: string;
+}
+
+/** Probe a single agent binary, returning install status and version string. */
+function probeAgent(desc: AgentDescriptor): AgentStatus {
+  const result = spawnSync(desc.binary, desc.versionArgs, {
+    timeout: 5000,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  if (result.error || result.status !== 0) {
+    return {
+      id: desc.id,
+      installed: false,
+      binary: desc.binary,
+      installHint: desc.installHint,
+      package: desc.package,
+      setupCommand: `sh1pt agents setup --agent ${desc.id}`,
+    };
+  }
+
+  const raw = (result.stdout ?? result.stderr ?? '').trim();
+  // Extract semver-ish version from output like "claude 1.2.3" or "v1.2.3"
+  const match = raw.match(/v?(\d+\.\d+(?:\.\d+)?(?:[-+][^\s]*)?)/);
+  const version = match ? match[1] : raw.split('\n')[0]?.trim();
+
+  return {
+    id: desc.id,
+    installed: true,
+    version,
+    binary: desc.binary,
+    installHint: desc.installHint,
+    package: desc.package,
+    setupCommand: `sh1pt agents setup --agent ${desc.id}`,
+  };
+}
 
 export const agentsCmd = new Command('agents')
   .description('Orchestrate AI coding CLIs (Claude Code, Codex, Qwen) — generate, edit, and talk')
@@ -12,19 +94,36 @@ agentsCmd
   .description('Which agent CLIs are installed on this machine')
   .option('--json', 'output as JSON')
   .action((opts: { json?: boolean }) => {
-    const agents = ['claude', 'codex', 'qwen'];
+    const statuses = KNOWN_AGENTS.map(probeAgent);
+
     if (opts.json) {
-      const output = agents.map((id) => ({
-        id,
-        package: `@profullstack/sh1pt-agent-${id}`,
-        setupCommand: `sh1pt agents setup --agent ${id}`,
-      }));
-      console.log(JSON.stringify(output, null, 2));
+      console.log(JSON.stringify(statuses, null, 2));
       return;
     }
-    for (const a of agents) {
-      // TODO: resolve adapter, call check(), render real status
-      console.log(`  ${kleur.gray('○')} ${kleur.bold(a)}  ${kleur.dim('run \`sh1pt agents setup --agent ' + a + '\`')}`);
+
+    for (const s of statuses) {
+      if (s.installed) {
+        console.log(
+          `  ${kleur.green('●')} ${kleur.bold(s.id).padEnd(8)} ${kleur.green(`v${s.version ?? 'unknown'}`)}`,
+        );
+      } else {
+        console.log(
+          `  ${kleur.gray('○')} ${kleur.bold(s.id).padEnd(8)} ${kleur.dim(`not installed — ${s.installHint}`)}`,
+        );
+      }
+    }
+
+    const installed = statuses.filter((s) => s.installed).length;
+    const total = statuses.length;
+    console.log();
+    if (installed === total) {
+      console.log(kleur.green(`${installed}/${total} agent(s) installed.`));
+    } else {
+      console.log(
+        kleur.dim(`${installed}/${total} agent(s) installed.`) +
+          ' ' +
+          kleur.cyan('Run `sh1pt agents setup` to install missing agents.'),
+      );
     }
   });
 


### PR DESCRIPTION
Closes #465

Replaces hardcoded stubs in sh1pt agents list with real binary probing via spawnSync.

- Add AgentDescriptor interface for claude, codex, qwen
- probeAgent() runs binary --version, parses semver from stdout
- Installed agents show version in green
- Missing agents show npm/pip install hint
- --json flag outputs real AgentStatus array with installed/version fields
- Summary line shows N/total installed