### PR TITLE
fix(cli): filter empty slug segments in titleFromSlug

### DIFF
--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -76,6 +76,19 @@ const SKILL_TARGETS = {
 function slugify(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 64) || 'my-skill';
 }
+
+/**
+ * Infer a human-readable title from a slug by splitting on hyphens,
+ * filtering empty segments (handles repeated separators like `alpha--beta`),
+ * and capitalizing each word.
+ */
+export function titleFromSlug(slug: string): string {
+  return slug
+    .split('-')
+    .filter((segment) => segment.length > 0)
+    .map((w) => w[0]!.toUpperCase() + w.slice(1))
+    .join(' ');
+}
 function q(s: string): string { return JSON.stringify(s); }
 async function exists(path: string): Promise<boolean> { try { await access(path); return true; } catch { return false; } }
 function frontmatterValue(text: string, key: string): string | undefined {
@@ -87,7 +100,7 @@ async function inferFromSkill(file: string): Promise<Partial<SkillManifest>> {
   const text = await readFile(file, 'utf8');
   const name = frontmatterValue(text, 'name');
   const description = frontmatterValue(text, 'description');
-  const title = name ? name.split('-').map(w => w[0]?.toUpperCase() + w.slice(1)).join(' ') : undefined;
+  const title = name ? titleFromSlug(name) : undefined;
   return { name, title, description };
 }
 async function loadManifest(path = 'sh1pt.skill.json'): Promise<SkillManifest> {


### PR DESCRIPTION
Fixes #502

Extracts titleFromSlug() helper that filters empty segments before capitalizing, fixing 'undefined' in inferred titles for slugs with repeated separators like 'alpha--beta'.

Before: 'alpha--beta' -> 'Alpha undefined Beta'
After:  'alpha--beta' -> 'Alpha Beta'