### PR TITLE
fix(cli): use path.basename for init default name on Windows

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { writeFile, access } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, basename } from 'node:path';
 import kleur from 'kleur';
 import prompts from 'prompts';
 
@@ -32,7 +32,7 @@ export async function initAction(): Promise<void> {
     type: 'text',
     name: 'name',
     message: 'Project name',
-    initial: process.cwd().split('/').pop() ?? 'my-app',
+    initial: basename(process.cwd()) || 'my-app',
   });
   if (!name) return;
   await writeFile(cfgPath, CONFIG_TEMPLATE(name), 'utf8');


### PR DESCRIPTION
Fixes #492

Replace process.cwd().split('/').pop() with path.basename(process.cwd()) so sh1pt init correctly infers the project name on Windows paths (backslash separators).