### PR TITLE
fix(coinpay): accept any matching v1 signature during key rotation

### DIFF
--- a/packages/payments/coinpay/src/index.ts
+++ b/packages/payments/coinpay/src/index.ts
@@ -183,13 +183,27 @@ function verifyCoinPaySignature(
   secret: string,
   toleranceSeconds = 300,
 ): void {
-  const parts = Object.fromEntries(signatureHeader.split(',').map((part) => {
-    const [key, ...value] = part.trim().split('=');
-    return [key, value.join('=')];
-  }));
-  const timestamp = parts.t;
-  const signature = parts.v1;
-  if (!timestamp || !signature) throw new Error('CoinPay signature missing t or v1');
+  // Parse all key=value pairs, preserving duplicate keys as arrays.
+  // CoinPay can send multiple v1 signatures during secret rotation;
+  // using Object.fromEntries() would silently drop all but one.
+  let timestamp: string | undefined;
+  const v1Signatures: string[] = [];
+
+  for (const part of signatureHeader.split(',')) {
+    const eqIdx = part.indexOf('=');
+    if (eqIdx === -1) continue;
+    const key = part.slice(0, eqIdx).trim();
+    const val = part.slice(eqIdx + 1).trim();
+    if (key === 't') {
+      timestamp = val;
+    } else if (key === 'v1' && val) {
+      v1Signatures.push(val);
+    }
+  }
+
+  if (!timestamp || v1Signatures.length === 0) {
+    throw new Error('CoinPay signature missing t or v1');
+  }
 
   const timestampSeconds = Number(timestamp);
   if (!Number.isFinite(timestampSeconds)) throw new Error('CoinPay signature timestamp is invalid');
@@ -201,9 +215,19 @@ function verifyCoinPaySignature(
   const expected = createHmac('sha256', secret)
     .update(`${timestamp}.${rawBody}`)
     .digest('hex');
-  const actualBuffer = Buffer.from(signature, 'hex');
   const expectedBuffer = Buffer.from(expected, 'hex');
-  if (actualBuffer.length !== expectedBuffer.length || !timingSafeEqual(actualBuffer, expectedBuffer)) {
+
+  // Accept the webhook if ANY provided v1 signature matches.
+  const valid = v1Signatures.some((sig) => {
+    try {
+      const actualBuffer = Buffer.from(sig, 'hex');
+      return actualBuffer.length === expectedBuffer.length && timingSafeEqual(actualBuffer, expectedBuffer);
+    } catch {
+      return false;
+    }
+  });
+
+  if (!valid) {
     throw new Error('Invalid CoinPay webhook signature');
   }
 }


### PR DESCRIPTION
Fixes #489

Replaces Object.fromEntries parser with explicit loop that collects all v1 values, accepting the webhook when any one matches the expected HMAC.