### PR TITLE
fix(dns): validate googledns delete record ids before splitting

### DIFF
--- a/packages/dns/googledns/src/index.ts
+++ b/packages/dns/googledns/src/index.ts
@@ -123,14 +123,29 @@ export default defineDns<Config>({
     const token = await getAccessToken();
     const project = config.projectId ?? _secret('GOOGLE_PROJECT_ID');
     if (!project) throw new Error('GOOGLE_PROJECT_ID not set');
-    const [type, name] = recordId.split('/');
+
+    // Validate that recordId contains the expected separator before splitting.
+    if (!recordId.includes('/')) {
+      throw new Error(`Google Cloud DNS deleteRecord: invalid recordId "${recordId}" — expected "<type>/<FQDN>" format`);
+    }
+    const slashIdx = recordId.indexOf('/');
+    const type = recordId.slice(0, slashIdx);
+    const name = recordId.slice(slashIdx + 1);
+    if (!type || !name) {
+      throw new Error(`Google Cloud DNS deleteRecord: invalid recordId "${recordId}" — type or name is empty`);
+    }
+
     // Need to fetch the rrset to get current rrdatas for the deletion entry.
     const existing = (await this.listRecords(zoneId, config)).filter(
       r => r.type === type && (r.name === name || r.name === name.replace(/\.$/, '')),
     );
     if (existing.length === 0) return;
+
+    // Narrow the first record explicitly to satisfy noUncheckedIndexedAccess.
+    const first = existing[0];
+    if (!first) return;
     const fqdn = name.endsWith('.') ? name : `${name}.`;
-    const ttl = existing[0].ttl;
+    const ttl = first.ttl;
     const res = await fetch(`${API}/projects/${project}/managedZones/${zoneId}/changes`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },


### PR DESCRIPTION
Fixes #481

Validates recordId contains '/' before splitting, uses slice() with explicit index, and narrows the first matched record before reading .ttl to satisfy noUncheckedIndexedAccess.