### PR TITLE
Parse pkg-nix source repo URLs

### DIFF
--- a/packages/targets/pkg-nix/src/index.test.ts
+++ b/packages/targets/pkg-nix/src/index.test.ts
@@ -62,6 +62,33 @@ describe('nix package expression generation', () => {
     expect(expression).toContain('maintainers = with maintainers; [ photon101 ];');
   });
 
+  it('accepts GitHub URLs for sourceRepo', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-nix-'));
+    tempDirs.push(outDir);
+
+    await adapter.build(fakeBuildContext({
+      outDir,
+      version: '1.2.3',
+    }) as any, {
+      pname: 'myapp',
+      sourceRepo: 'https://github.com/acme/myapp.git?tab=readme-ov-file#usage',
+    });
+
+    const expression = await readFile(join(outDir, 'default.nix'), 'utf-8');
+    expect(expression).toContain('owner = "acme";');
+    expect(expression).toContain('repo = "myapp";');
+  });
+
+  it('rejects malformed sourceRepo values', async () => {
+    await expect(adapter.build(fakeBuildContext({
+      outDir: await mkdtemp(join(tmpdir(), 'sh1pt-nix-')),
+      version: '1.2.3',
+    }) as any, {
+      pname: 'myapp',
+      sourceRepo: 'acme',
+    })).rejects.toThrow('sourceRepo');
+  });
+
   it('keeps dry-run shipping side-effect free', async () => {
     await expect(adapter.ship(fakeShipContext({
       version: '1.2.3',

--- a/packages/targets/pkg-nix/src/index.test.ts
+++ b/packages/targets/pkg-nix/src/index.test.ts
@@ -80,12 +80,28 @@ describe('nix package expression generation', () => {
   });
 
   it('rejects malformed sourceRepo values', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-nix-'));
+    tempDirs.push(outDir);
+
     await expect(adapter.build(fakeBuildContext({
-      outDir: await mkdtemp(join(tmpdir(), 'sh1pt-nix-')),
+      outDir,
       version: '1.2.3',
     }) as any, {
       pname: 'myapp',
       sourceRepo: 'acme',
+    })).rejects.toThrow('sourceRepo');
+  });
+
+  it('rejects non-GitHub sourceRepo URLs', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-nix-'));
+    tempDirs.push(outDir);
+
+    await expect(adapter.build(fakeBuildContext({
+      outDir,
+      version: '1.2.3',
+    }) as any, {
+      pname: 'myapp',
+      sourceRepo: 'https://gitlab.com/acme/myapp',
     })).rejects.toThrow('sourceRepo');
   });
 

--- a/packages/targets/pkg-nix/src/index.ts
+++ b/packages/targets/pkg-nix/src/index.ts
@@ -35,6 +35,9 @@ function parseRepo(sourceRepo: string | undefined, pname: string): { owner: stri
   if (/^https?:\/\//i.test(value)) {
     try {
       const parsed = new URL(value);
+      if (!['github.com', 'www.github.com'].includes(parsed.hostname.toLowerCase())) {
+        throw new Error(`sourceRepo URL must point to github.com, got "${parsed.hostname}"`);
+      }
       path = parsed.pathname;
     } catch {
       throw new Error(`invalid sourceRepo "${sourceRepo}"`);

--- a/packages/targets/pkg-nix/src/index.ts
+++ b/packages/targets/pkg-nix/src/index.ts
@@ -29,11 +29,29 @@ function nixString(value: string): string {
 }
 
 function parseRepo(sourceRepo: string | undefined, pname: string): { owner: string; repo: string } {
-  const [owner, repo] = (sourceRepo ?? `profullstack/${pname}`).split('/');
-  return {
-    owner: owner || 'profullstack',
-    repo: repo || pname,
-  };
+  const value = sourceRepo?.trim() || `profullstack/${pname}`;
+  let path = value;
+
+  if (/^https?:\/\//i.test(value)) {
+    try {
+      const parsed = new URL(value);
+      path = parsed.pathname;
+    } catch {
+      throw new Error(`invalid sourceRepo "${sourceRepo}"`);
+    }
+  }
+
+  const [owner, repo, ...rest] = path
+    .replace(/[?#].*$/, '')
+    .replace(/^\/+|\/+$/g, '')
+    .replace(/\.git$/i, '')
+    .split('/');
+
+  if (!owner || !repo || rest.length > 0) {
+    throw new Error(`sourceRepo must be "owner/repo" or a GitHub repository URL, got "${sourceRepo}"`);
+  }
+
+  return { owner, repo };
 }
 
 function nixList(values: string[] | undefined): string {


### PR DESCRIPTION
Fixes #511.

## Summary
- parse `pkg-nix` `sourceRepo` values from either `owner/repo` or a GitHub-style HTTP(S) repository URL
- strip `.git`, query strings, fragments, and leading/trailing slashes before rendering `fetchFromGitHub`
- reject malformed `sourceRepo` values instead of silently generating the wrong owner/repo
- add regression coverage for pasted GitHub URLs and malformed single-segment values

## Verification
- `npx --yes pnpm@9.12.0 exec vitest run packages/targets/pkg-nix/src/index.test.ts` -> 7 passed
- `npx --yes pnpm@9.12.0 --filter @profullstack/sh1pt-target-pkg-nix typecheck` -> passed

Bounty trail: opened matching bug report #511 for the ugig bug-fix bounty.