### PR TITLE
Validate winget package identifiers

### DIFF
--- a/packages/targets/pkg-winget/src/index.test.ts
+++ b/packages/targets/pkg-winget/src/index.test.ts
@@ -67,6 +67,36 @@ describe('winget manifest generation', () => {
     expect(localeManifest).toContain('License: "MIT"');
   });
 
+  it('rejects malformed package identifiers before writing manifests', async () => {
+    await expect(adapter.build(fakeBuildContext({
+      outDir: await mkdtemp(join(tmpdir(), 'sh1pt-winget-')),
+      version: '1.2.3',
+    }) as any, {
+      packageId: '.MyTool',
+      installers: [
+        {
+          architecture: 'x64',
+          url: 'https://downloads.example.com/my-tool-1.2.3-x64.exe',
+          sha256: 'a'.repeat(64),
+        },
+      ],
+    })).rejects.toThrow('packageId');
+
+    await expect(adapter.build(fakeBuildContext({
+      outDir: await mkdtemp(join(tmpdir(), 'sh1pt-winget-')),
+      version: '1.2.3',
+    }) as any, {
+      packageId: 'Acme',
+      installers: [
+        {
+          architecture: 'x64',
+          url: 'https://downloads.example.com/my-tool-1.2.3-x64.exe',
+          sha256: 'a'.repeat(64),
+        },
+      ],
+    })).rejects.toThrow('packageId');
+  });
+
   it('keeps dry-run shipping side-effect free', async () => {
     await expect(adapter.ship(fakeShipContext({
       version: '1.2.3',

--- a/packages/targets/pkg-winget/src/index.ts
+++ b/packages/targets/pkg-winget/src/index.ts
@@ -24,8 +24,23 @@ function yamlString(value: string): string {
   return JSON.stringify(value);
 }
 
+function packageIdParts(packageId: string): { publisher: string; name: string } {
+  const parts = packageId.split('.');
+  const publisher = parts[0];
+  const name = parts.at(-1);
+  if (
+    parts.length < 2
+    || !publisher
+    || !name
+    || parts.some((part) => part.length === 0)
+  ) {
+    throw new Error(`packageId must use winget Publisher.Package format, got "${packageId}"`);
+  }
+  return { publisher, name };
+}
+
 function manifestDir(outDir: string, packageId: string, version: string): string {
-  const [publisher = packageId, name = packageId] = packageId.split('.');
+  const { publisher, name } = packageIdParts(packageId);
   return join(outDir, 'manifests', publisher[0]!.toLowerCase(), publisher, name, version);
 }
 
@@ -74,8 +89,9 @@ function renderInstallerManifest(config: Config, version: string): string {
 function renderLocaleManifest(config: Config, version: string): string {
   const locale = config.defaultLocale ?? 'en-US';
   const manifestVersion = config.manifestVersion ?? '1.6.0';
-  const packageName = config.packageName ?? config.packageId.split('.').at(-1) ?? config.packageId;
-  const publisher = config.publisher ?? config.packageId.split('.')[0] ?? 'Unknown';
+  const idParts = packageIdParts(config.packageId);
+  const packageName = config.packageName ?? idParts.name;
+  const publisher = config.publisher ?? idParts.publisher;
   const lines = [
     `PackageIdentifier: ${yamlString(config.packageId)}`,
     `PackageVersion: ${yamlString(version)}`,


### PR DESCRIPTION
Fixes #513.

## Summary
- validate winget `packageId` before using it for manifest paths or locale metadata
- reject empty segments and single-segment identifiers with a clear packageId error
- reuse parsed publisher/name segments for both manifest directory generation and default locale fields
- add regression coverage for malformed identifiers that previously crashed or silently generated invalid manifests

## Verification
- `npx --yes pnpm@9.12.0 exec vitest run packages/targets/pkg-winget/src/index.test.ts` -> 6 passed
- `npx --yes pnpm@9.12.0 --filter @profullstack/sh1pt-target-pkg-winget typecheck` -> passed

Bounty trail: opened matching bug report #513 for the ugig bug-fix bounty.