### PR TITLE
Validate flatpak app IDs

### DIFF
--- a/packages/targets/pkg-flatpak/src/index.test.ts
+++ b/packages/targets/pkg-flatpak/src/index.test.ts
@@ -54,6 +54,29 @@ describe('Flatpak manifest generation', () => {
     expect(manifest).toContain(`sha256: "${'a'.repeat(64)}"`);
   });
 
+  it('rejects malformed app IDs before writing manifest files', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-flatpak-'));
+    tempDirs.push(outDir);
+
+    await expect(adapter.build(fakeBuildContext({
+      outDir,
+      projectDir: '/repo/myapp',
+      version: '1.2.3',
+      channel: 'stable',
+    }) as any, {
+      appId: '../escape',
+    })).rejects.toThrow('appId');
+
+    await expect(adapter.build(fakeBuildContext({
+      outDir,
+      projectDir: '/repo/myapp',
+      version: '1.2.3',
+      channel: 'stable',
+    }) as any, {
+      appId: 'com.example',
+    })).rejects.toThrow('appId');
+  });
+
   it('keeps dry-run shipping side-effect free', async () => {
     await expect(adapter.ship(fakeShipContext({
       version: '1.2.3',

--- a/packages/targets/pkg-flatpak/src/index.ts
+++ b/packages/targets/pkg-flatpak/src/index.ts
@@ -27,7 +27,18 @@ function renderList(values: string[], indent: string): string[] {
   return values.map((value) => `${indent}- ${yamlString(value)}`);
 }
 
+function assertAppId(appId: string): void {
+  const parts = appId.split('.');
+  if (
+    parts.length < 3
+    || parts.some((part) => !/^[A-Za-z][A-Za-z0-9_-]*$/.test(part))
+  ) {
+    throw new Error(`appId must be a reverse-DNS Flatpak ID, got "${appId}"`);
+  }
+}
+
 function renderFlatpakManifest(ctx: { projectDir: string; version: string; channel: string }, config: Config): string {
+  assertAppId(config.appId);
   const branch = config.branch ?? (ctx.channel === 'stable' ? 'stable' : 'beta');
   const runtime = config.runtime ?? 'org.freedesktop.Platform';
   const runtimeVersion = config.runtimeVersion ?? '23.08';
@@ -84,6 +95,7 @@ export default defineTarget<Config>({
   kind: 'package-manager',
   label: 'Flathub',
   async build(ctx, config) {
+    assertAppId(config.appId);
     const branch = config.branch ?? (ctx.channel === 'stable' ? 'stable' : 'beta');
     const runtime = config.runtime ?? 'org.freedesktop.Platform';
     const runtimeVersion = config.runtimeVersion ?? '23.08';
@@ -96,6 +108,7 @@ export default defineTarget<Config>({
     return { artifact: manifestPath };
   },
   async ship(ctx, config) {
+    assertAppId(config.appId);
     const branch = config.branch ?? (ctx.channel === 'stable' ? 'stable' : 'beta');
     ctx.log(`submit ${config.appId} to Flathub (branch: ${branch})`);
     if (ctx.dryRun) return { id: 'dry-run' };


### PR DESCRIPTION
Fixes #515

## Summary
- validate pkg-flatpak `appId` values as reverse-DNS IDs before using them
- reject malformed IDs before writing manifest files or running ship logic
- add regression coverage for path traversal and too-short app IDs

## Verification
- `npx --yes pnpm@9.12.0 exec vitest run packages/targets/pkg-flatpak/src/index.test.ts`
- `npx --yes pnpm@9.12.0 --filter @profullstack/sh1pt-target-pkg-flatpak typecheck`