### PR TITLE
Validate snap package names

### DIFF
--- a/packages/targets/pkg-snap/src/index.test.ts
+++ b/packages/targets/pkg-snap/src/index.test.ts
@@ -60,4 +60,27 @@ describe('snapcraft manifest generation', () => {
       snapName: 'myapp',
     })).resolves.toEqual({ id: 'dry-run' });
   });
+
+  it('rejects invalid snap names before generating manifests', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-snap-'));
+    tempDirs.push(outDir);
+
+    await expect(adapter.build(fakeBuildContext({
+      outDir,
+      projectDir: '/repo/myapp',
+      version: '1.2.3',
+      channel: 'stable',
+    }) as any, {
+      snapName: 'Bad: Name',
+    })).rejects.toThrow('snapName');
+
+    await expect(adapter.build(fakeBuildContext({
+      outDir,
+      projectDir: '/repo/myapp',
+      version: '1.2.3',
+      channel: 'stable',
+    }) as any, {
+      snapName: '-myapp',
+    })).rejects.toThrow('snapName');
+  });
 });

--- a/packages/targets/pkg-snap/src/index.ts
+++ b/packages/targets/pkg-snap/src/index.ts
@@ -33,7 +33,18 @@ function renderDescription(description: string): string[] {
   ];
 }
 
+function assertSnapName(snapName: string): void {
+  if (
+    snapName.length > 40
+    || !/[a-z]/.test(snapName)
+    || !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(snapName)
+  ) {
+    throw new Error(`snapName must be a valid Snap Store name, got "${snapName}"`);
+  }
+}
+
 function renderSnapcraftYaml(ctx: { projectDir: string; version: string; channel: string }, config: Config): string {
+  assertSnapName(config.snapName);
   const grade = config.grade ?? (ctx.channel === 'stable' ? 'stable' : 'devel');
   const confinement = config.confinement ?? 'strict';
   const base = config.base ?? 'core22';
@@ -84,6 +95,7 @@ export default defineTarget<Config>({
   kind: 'package-manager',
   label: 'Snapcraft',
   async build(ctx, config) {
+    assertSnapName(config.snapName);
     const grade = config.grade ?? (ctx.channel === 'stable' ? 'stable' : 'devel');
     const confinement = config.confinement ?? 'strict';
     const base = config.base ?? 'core22';
@@ -97,6 +109,7 @@ export default defineTarget<Config>({
     return { artifact: manifestPath };
   },
   async ship(ctx, config) {
+    assertSnapName(config.snapName);
     const trackChannel = config.channel ?? (ctx.channel === 'stable' ? 'stable' : 'edge');
     ctx.log(`snapcraft upload + release ${config.snapName} → ${trackChannel}`);
     if (ctx.dryRun) return { id: 'dry-run' };


### PR DESCRIPTION
Fixes #517

## Summary
- validate pkg-snap `snapName` before manifest generation and shipping
- prevent invalid names from becoming unquoted `apps` / `parts` YAML keys
- cover uppercase/colon names and leading-hyphen names with regression tests

## Verification
- `npx --yes pnpm@9.12.0 exec vitest run packages/targets/pkg-snap/src/index.test.ts`
- `npx --yes pnpm@9.12.0 --filter @profullstack/sh1pt-target-pkg-snap typecheck`