### PR TITLE
Validate Homebrew formula names

### DIFF
--- a/packages/targets/pkg-homebrew/src/index.test.ts
+++ b/packages/targets/pkg-homebrew/src/index.test.ts
@@ -73,4 +73,39 @@ describe('Homebrew formula generation', () => {
       ],
     })).resolves.toEqual({ id: 'dry-run' });
   });
+
+  it('rejects invalid formula names before writing formula files', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-homebrew-'));
+    tempDirs.push(outDir);
+
+    await expect(adapter.build(fakeBuildContext({
+      outDir,
+      version: '1.2.3',
+    }) as any, {
+      tap: 'acme/homebrew-tools',
+      formulaName: '../escape',
+      binaries: [
+        {
+          platform: 'darwin-x64',
+          url: 'https://downloads.example.com/tool-1.2.3-darwin-x64.tar.gz',
+          sha256: 'c'.repeat(64),
+        },
+      ],
+    })).rejects.toThrow('formulaName');
+
+    await expect(adapter.build(fakeBuildContext({
+      outDir,
+      version: '1.2.3',
+    }) as any, {
+      tap: 'acme/homebrew-tools',
+      formulaName: 'BadName',
+      binaries: [
+        {
+          platform: 'darwin-x64',
+          url: 'https://downloads.example.com/tool-1.2.3-darwin-x64.tar.gz',
+          sha256: 'c'.repeat(64),
+        },
+      ],
+    })).rejects.toThrow('formulaName');
+  });
 });

--- a/packages/targets/pkg-homebrew/src/index.ts
+++ b/packages/targets/pkg-homebrew/src/index.ts
@@ -31,6 +31,12 @@ function formulaClassName(formulaName: string): string {
   return name || 'Sh1ptFormula';
 }
 
+function assertFormulaName(formulaName: string): void {
+  if (!/^[a-z0-9][a-z0-9@._+-]*$/.test(formulaName)) {
+    throw new Error(`formulaName must be a lowercase Homebrew formula name, got "${formulaName}"`);
+  }
+}
+
 function osFor(platform: Binary['platform']): Os {
   return platform.startsWith('darwin') ? 'darwin' : 'linux';
 }
@@ -61,6 +67,7 @@ function renderPlatformBlocks(binaries: Binary[]): string {
 }
 
 function renderFormula(config: Config, version: string): string {
+  assertFormulaName(config.formulaName);
   if (!config.binaries?.length) {
     throw new Error('Homebrew formula requires at least one binary download');
   }
@@ -99,6 +106,7 @@ export default defineTarget<Config>({
   kind: 'package-manager',
   label: 'Homebrew',
   async build(ctx, config) {
+    assertFormulaName(config.formulaName);
     const formula = renderFormula(config, ctx.version);
     const formulaPath = join(ctx.outDir, `${config.formulaName}.rb`);
     ctx.log(`render Formula/${config.formulaName}.rb`);
@@ -107,6 +115,7 @@ export default defineTarget<Config>({
     return { artifact: formulaPath };
   },
   async ship(ctx, config) {
+    assertFormulaName(config.formulaName);
     ctx.log(`open PR against ${config.tap} bumping ${config.formulaName} → ${ctx.version}`);
     if (ctx.dryRun) return { id: 'dry-run' };
     // TODO: git clone tap, commit formula, push branch, open PR via GH_TOKEN


### PR DESCRIPTION
Fixes #521

## Summary
- validate pkg-homebrew `formulaName` before rendering, writing formula files, or shipping
- prevent path traversal such as `../escape` from writing outside the configured output directory
- reject uppercase formula names that would violate Homebrew lowercase filename conventions

## Verification
- `npx --yes pnpm@9.12.0 exec vitest run packages/targets/pkg-homebrew/src/index.test.ts`
- `npx --yes pnpm@9.12.0 --filter @profullstack/sh1pt-target-pkg-homebrew typecheck`