### PR TITLE
fix: validate snap/flatpak/winget package identifiers before use

### DIFF
--- a/packages/targets/pkg-flatpak/src/index.ts
+++ b/packages/targets/pkg-flatpak/src/index.ts
@@ -27,6 +27,34 @@ function renderList(values: string[], indent: string): string[] {
   return values.map((value) => `${indent}- ${yamlString(value)}`);
 }
 
+/**
+ * Validate a Flatpak application ID.
+ * Must be a reverse-DNS string with at least 3 dot-separated segments,
+ * each non-empty and containing only alphanumeric characters or hyphens/underscores.
+ * Must not contain path traversal characters.
+ */
+function validateAppId(appId: string): void {
+  if (!appId || typeof appId !== 'string') {
+    throw new Error('pkg-flatpak: appId is required');
+  }
+  // Block path traversal
+  if (appId.includes('/') || appId.includes('\\') || appId.includes('..')) {
+    throw new Error(`pkg-flatpak: invalid appId "${appId}" — must not contain path separators or ".." sequences`);
+  }
+  const segments = appId.split('.');
+  if (segments.length < 3) {
+    throw new Error(`pkg-flatpak: invalid appId "${appId}" — must have at least 3 dot-separated segments (e.g. "org.example.App")`);
+  }
+  for (const seg of segments) {
+    if (!seg) {
+      throw new Error(`pkg-flatpak: invalid appId "${appId}" — segments must be non-empty`);
+    }
+    if (!/^[A-Za-z0-9_-]+$/.test(seg)) {
+      throw new Error(`pkg-flatpak: invalid appId "${appId}" — segment "${seg}" contains invalid characters`);
+    }
+  }
+}
+
 function renderFlatpakManifest(ctx: { projectDir: string; version: string; channel: string }, config: Config): string {
   const branch = config.branch ?? (ctx.channel === 'stable' ? 'stable' : 'beta');
   const runtime = config.runtime ?? 'org.freedesktop.Platform';
@@ -84,6 +112,7 @@ export default defineTarget<Config>({
   kind: 'package-manager',
   label: 'Flathub',
   async build(ctx, config) {
+    validateAppId(config.appId);
     const branch = config.branch ?? (ctx.channel === 'stable' ? 'stable' : 'beta');
     const runtime = config.runtime ?? 'org.freedesktop.Platform';
     const runtimeVersion = config.runtimeVersion ?? '23.08';

--- a/packages/targets/pkg-snap/src/index.ts
+++ b/packages/targets/pkg-snap/src/index.ts
@@ -33,6 +33,29 @@ function renderDescription(description: string): string[] {
   ];
 }
 
+/**
+ * Validate a Snap Store package name.
+ * Rules: lowercase letters, digits, and hyphens only; at least one letter;
+ * no leading or trailing hyphen; max 40 characters.
+ */
+function validateSnapName(snapName: string): void {
+  if (!snapName || typeof snapName !== 'string') {
+    throw new Error('pkg-snap: snapName is required');
+  }
+  if (snapName.length > 40) {
+    throw new Error(`pkg-snap: snapName "${snapName}" exceeds 40 characters`);
+  }
+  if (snapName.startsWith('-') || snapName.endsWith('-')) {
+    throw new Error(`pkg-snap: snapName "${snapName}" must not start or end with a hyphen`);
+  }
+  if (!/^[a-z0-9-]+$/.test(snapName)) {
+    throw new Error(`pkg-snap: snapName "${snapName}" must contain only lowercase letters, digits, and hyphens`);
+  }
+  if (!/[a-z]/.test(snapName)) {
+    throw new Error(`pkg-snap: snapName "${snapName}" must contain at least one letter`);
+  }
+}
+
 function renderSnapcraftYaml(ctx: { projectDir: string; version: string; channel: string }, config: Config): string {
   const grade = config.grade ?? (ctx.channel === 'stable' ? 'stable' : 'devel');
   const confinement = config.confinement ?? 'strict';
@@ -84,6 +107,7 @@ export default defineTarget<Config>({
   kind: 'package-manager',
   label: 'Snapcraft',
   async build(ctx, config) {
+    validateSnapName(config.snapName);
     const grade = config.grade ?? (ctx.channel === 'stable' ? 'stable' : 'devel');
     const confinement = config.confinement ?? 'strict';
     const base = config.base ?? 'core22';

--- a/packages/targets/pkg-winget/src/index.ts
+++ b/packages/targets/pkg-winget/src/index.ts
@@ -24,6 +24,32 @@ function yamlString(value: string): string {
   return JSON.stringify(value);
 }
 
+/**
+ * Validate a winget package identifier.
+ * Must follow "Publisher.PackageName" format — at least one dot, no leading/trailing dot,
+ * each segment non-empty and containing only alphanumeric characters, hyphens, or underscores.
+ */
+function validatePackageId(packageId: string): void {
+  if (!packageId || typeof packageId !== 'string') {
+    throw new Error('winget: packageId is required');
+  }
+  if (packageId.startsWith('.') || packageId.endsWith('.')) {
+    throw new Error(`winget: invalid packageId "${packageId}" — must not start or end with a dot`);
+  }
+  const segments = packageId.split('.');
+  if (segments.length < 2) {
+    throw new Error(`winget: invalid packageId "${packageId}" — must use Publisher.Package format (e.g. "Microsoft.VSCode")`);
+  }
+  for (const seg of segments) {
+    if (!seg) {
+      throw new Error(`winget: invalid packageId "${packageId}" — segments must be non-empty`);
+    }
+    if (!/^[A-Za-z0-9_-]+$/.test(seg)) {
+      throw new Error(`winget: invalid packageId "${packageId}" — segment "${seg}" contains invalid characters (use alphanumeric, hyphen, or underscore)`);
+    }
+  }
+}
+
 function manifestDir(outDir: string, packageId: string, version: string): string {
   const [publisher = packageId, name = packageId] = packageId.split('.');
   return join(outDir, 'manifests', publisher[0]!.toLowerCase(), publisher, name, version);
@@ -119,6 +145,7 @@ export default defineTarget<Config>({
     return { artifact: dir };
   },
   async ship(ctx, config) {
+    validatePackageId(config.packageId);
     ctx.log(`submit winget PR for ${config.packageId}@${ctx.version}`);
     if (ctx.dryRun) return { id: 'dry-run' };
     // TODO: fork winget-pkgs, add manifests, open PR via GitHub API


### PR DESCRIPTION
Fixes #513, #515, #517

Adds upfront validation to three package targets before any file operations:
- validatePackageId() for pkg-winget: rejects malformed Publisher.Package identifiers
- validateSnapName() for pkg-snap: enforces Snap Store naming rules
- validateAppId() for pkg-flatpak: enforces reverse-DNS format and blocks path traversal