### PR TITLE
Secure npm publish metadata

### DIFF
--- a/packages/targets/pkg-npm/src/index.test.ts
+++ b/packages/targets/pkg-npm/src/index.test.ts
@@ -1,6 +1,91 @@
-import { contractTestTarget } from '@profullstack/sh1pt-core/testing';
+import { fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { execMock } = vi.hoisted(() => ({
+  execMock: vi.fn(),
+}));
+
+vi.mock('@profullstack/sh1pt-core', async () => ({
+  ...await vi.importActual<typeof import('@profullstack/sh1pt-core')>('@profullstack/sh1pt-core'),
+  exec: execMock,
+}));
+
 import target from './index.js';
 
-contractTestTarget(target, {
-  sampleConfig: { packageDir: './fake', access: 'public' },
+smokeTest(target, { idPrefix: 'pkg', requireKind: true });
+
+const tempDirs: string[] = [];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('npm package publishing', () => {
+  it('keeps dry-run shipping side-effect free', async () => {
+    const result = await target.ship(fakeShipContext({ dryRun: true }) as any, {
+      packageDir: 'packages/my-lib',
+      access: 'public',
+    });
+
+    expect(result).toEqual({ id: 'dry-run' });
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  it('publishes with a temporary npmrc and returns the package URL', async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-npm-project-'));
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-npm-out-'));
+    const pkgDir = join(projectDir, 'packages', 'my-lib');
+    tempDirs.push(projectDir, outDir);
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(join(pkgDir, 'package.json'), `${JSON.stringify({ name: '@acme/my-lib' })}\n`, 'utf-8');
+
+    execMock.mockImplementationOnce(async (_bin, _args, opts) => {
+      const npmrc = await readFile(opts.env.NPM_CONFIG_USERCONFIG, 'utf-8');
+      expect(npmrc).toContain('//registry.npmjs.org/:_authToken=test-token');
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+
+    const ctx = fakeShipContext({
+      projectDir,
+      outDir,
+      version: '1.2.3',
+      channel: 'stable',
+      dryRun: false,
+      env: { CI: 'true' },
+      secret: (key: string) => key === 'NPM_TOKEN' ? 'test-token' : undefined,
+    });
+
+    const result = await target.ship(ctx as any, {
+      packageDir: 'packages/my-lib',
+      access: 'restricted',
+    });
+
+    expect(execMock).toHaveBeenCalledWith('npm', [
+      'publish',
+      '--registry=https://registry.npmjs.org',
+      '--tag=latest',
+      '--access=restricted',
+    ], {
+      cwd: pkgDir,
+      log: ctx.log,
+      env: {
+        CI: 'true',
+        NPM_CONFIG_USERCONFIG: join(outDir, 'npm-publish.npmrc'),
+      },
+      throwOnNonZero: true,
+    });
+    await expect(readFile(join(outDir, 'npm-publish.npmrc'), 'utf-8')).rejects.toThrow();
+    await expect(readFile(join(pkgDir, '.npmrc'), 'utf-8')).rejects.toThrow();
+    expect(result).toEqual({
+      id: '@acme/my-lib@1.2.3',
+      url: 'https://www.npmjs.com/package/@acme/my-lib',
+    });
+  });
 });

--- a/packages/targets/pkg-npm/src/index.ts
+++ b/packages/targets/pkg-npm/src/index.ts
@@ -1,5 +1,5 @@
 import { defineTarget, manualSetup, exec } from '@profullstack/sh1pt-core';
-import { writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 interface Config {
@@ -9,12 +9,24 @@ interface Config {
   registry?: string;
 }
 
+function packageDir(ctx: { projectDir: string }, config: Config): string {
+  return config.packageDir ? join(ctx.projectDir, config.packageDir) : ctx.projectDir;
+}
+
+async function packageName(pkgDir: string): Promise<string> {
+  const manifest = JSON.parse(await readFile(join(pkgDir, 'package.json'), 'utf-8')) as { name?: unknown };
+  if (typeof manifest.name !== 'string' || !manifest.name.trim()) {
+    throw new Error('package.json must contain a package name before npm publish');
+  }
+  return manifest.name;
+}
+
 export default defineTarget<Config>({
   id: 'pkg-npm',
   kind: 'package-manager',
   label: 'npm',
   async build(ctx, config) {
-    const pkgDir = config.packageDir ? join(ctx.projectDir, config.packageDir) : ctx.projectDir;
+    const pkgDir = packageDir(ctx, config);
     if (ctx.dryRun) return { artifact: `${ctx.outDir}/package.tgz` };
     ctx.log(`npm pack in ${pkgDir}`);
     await exec('npm', ['pack', '--pack-destination', ctx.outDir], {
@@ -33,23 +45,31 @@ export default defineTarget<Config>({
     const token = ctx.secret('NPM_TOKEN');
     if (!token) throw new Error('NPM_TOKEN secret not set. Run: sh1pt secret set NPM_TOKEN <token>');
 
-    const pkgDir = config.packageDir
-      ? join(ctx.projectDir, config.packageDir)
-      : ctx.projectDir;
+    const pkgDir = packageDir(ctx, config);
+    const name = await packageName(pkgDir);
 
-    // Write temporary .npmrc with auth for the target registry
     const registryHost = new URL(registry).host;
+    await mkdir(ctx.outDir, { recursive: true });
+    const npmrcPath = join(ctx.outDir, 'npm-publish.npmrc');
     const npmrc = `//${registryHost}/:_authToken=${token}\n`;
-    await writeFile(join(pkgDir, '.npmrc'), npmrc, 'utf-8');
+    await writeFile(npmrcPath, npmrc, 'utf-8');
 
     const access = config.access ?? 'public';
-    await exec('npm', ['publish', `--registry=${registry}`, `--tag=${tag}`, `--access=${access}`], {
-      cwd: pkgDir,
-      log: ctx.log,
-      throwOnNonZero: true,
-    });
+    try {
+      await exec('npm', ['publish', `--registry=${registry}`, `--tag=${tag}`, `--access=${access}`], {
+        cwd: pkgDir,
+        log: ctx.log,
+        env: {
+          ...ctx.env,
+          NPM_CONFIG_USERCONFIG: npmrcPath,
+        },
+        throwOnNonZero: true,
+      });
+    } finally {
+      await rm(npmrcPath, { force: true });
+    }
 
-    return { id: `${ctx.version}@${tag}`, url: `https://www.npmjs.com/package/${ctx.version}` };
+    return { id: `${name}@${ctx.version}`, url: `https://www.npmjs.com/package/${name}` };
   },
   async status(id) {
     return { state: 'live', version: id };


### PR DESCRIPTION
Fixes #524

## Summary
- use a temporary npm userconfig in `ctx.outDir` instead of writing `.npmrc` into the package directory
- remove the temporary npmrc after publish, including failure paths
- read `package.json` so publish metadata returns the actual package id and npm package URL
- replace the contract-only test with focused publish regression coverage

## Verification
- `npx --yes pnpm@9.12.0 exec vitest run packages/targets/pkg-npm/src/index.test.ts`
- `npx --yes pnpm@9.12.0 --filter @profullstack/sh1pt-target-pkg-npm typecheck`