### PR TITLE
Validate Scoop app names

### DIFF
--- a/packages/targets/pkg-scoop/src/index.test.ts
+++ b/packages/targets/pkg-scoop/src/index.test.ts
@@ -73,4 +73,23 @@ describe('Scoop manifest generation', () => {
       appName: 'myapp',
     })).resolves.toEqual({ id: 'dry-run' });
   });
+
+  it('rejects invalid app names before writing manifests', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-scoop-'));
+    tempDirs.push(outDir);
+
+    await expect(adapter.build(fakeBuildContext({
+      outDir,
+      version: '1.2.3',
+    }) as any, {
+      appName: '../escape',
+    })).rejects.toThrow('appName');
+
+    await expect(adapter.build(fakeBuildContext({
+      outDir,
+      version: '1.2.3',
+    }) as any, {
+      appName: 'Bad Name',
+    })).rejects.toThrow('appName');
+  });
 });

--- a/packages/targets/pkg-scoop/src/index.ts
+++ b/packages/targets/pkg-scoop/src/index.ts
@@ -37,6 +37,12 @@ function scoopVersion(version: string): string {
   return version.replace(/^v/, '');
 }
 
+function assertAppName(appName: string): void {
+  if (!/^[a-z0-9][a-z0-9._-]*$/.test(appName)) {
+    throw new Error(`appName must be a valid Scoop manifest name, got "${appName}"`);
+  }
+}
+
 function templateValue(value: string, config: Config, version: string, arch: ScoopArch): string {
   return value
     .replaceAll('{{version}}', version)
@@ -57,6 +63,7 @@ function architectureUrl(ctx: { version: string }, config: Config, arch: Archite
 }
 
 function renderManifest(ctx: { version: string }, config: Config): string {
+  assertAppName(config.appName);
   const version = scoopVersion(ctx.version);
   const architectures = config.architecture ?? [{ name: '64bit' as const }];
   const manifest: Record<string, unknown> = {
@@ -94,6 +101,7 @@ export default defineTarget<Config>({
   kind: 'package-manager',
   label: 'Scoop bucket',
   async build(ctx, config) {
+    assertAppName(config.appName);
     const manifestPath = join(ctx.outDir, `${config.appName}.json`);
     ctx.log(`generate scoop manifest ${config.appName}.json for v${ctx.version}`);
     await mkdir(ctx.outDir, { recursive: true });
@@ -101,6 +109,7 @@ export default defineTarget<Config>({
     return { artifact: manifestPath };
   },
   async ship(ctx, config) {
+    assertAppName(config.appName);
     const bucket = config.bucketRepo ?? 'profullstack/scoop-bucket';
     ctx.log(`push ${config.appName}.json to ${bucket} bucket`);
     if (ctx.dryRun) return { id: 'dry-run' };


### PR DESCRIPTION
Fixes #526

## Summary
- validate pkg-scoop `appName` before rendering manifests or ship metadata
- prevent path traversal such as `../escape` from writing outside the configured output directory
- add regression coverage for path traversal and names with spaces

## Verification
- `npx --yes pnpm@9.12.0 exec vitest run packages/targets/pkg-scoop/src/index.test.ts`
- `npx --yes pnpm@9.12.0 --filter @profullstack/sh1pt-target-pkg-scoop typecheck`