### PR TITLE
Skip VSCE token for dry-run publish

### DIFF
--- a/packages/targets/plugin-vscode/src/index.test.ts
+++ b/packages/targets/plugin-vscode/src/index.test.ts
@@ -1,4 +1,4 @@
-import { fakeBuildContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -93,10 +93,20 @@ describe('plugin-vscode target adapter', () => {
       '--target',
       'linux-x64',
     ], {
-      cwd: '/repo/extensions/sample-extension',
+      cwd: join('/repo', 'extensions/sample-extension'),
       log: ctx.log,
       throwOnNonZero: true,
     });
-    expect(result).toEqual({ artifact: '/repo/.sh1pt/out/sample-extension-1.2.3.vsix' });
+    expect(result).toEqual({ artifact: join('/repo/.sh1pt/out', 'sample-extension-1.2.3.vsix') });
+  });
+
+  it('keeps dry-run publishing side-effect free without requiring a token', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      version: '1.2.3',
+      dryRun: true,
+      secret: () => undefined,
+    }) as any, sampleConfig)).resolves.toEqual({ id: 'dry-run' });
+
+    expect(execMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/targets/plugin-vscode/src/index.ts
+++ b/packages/targets/plugin-vscode/src/index.ts
@@ -77,14 +77,14 @@ export default defineTarget<Config>({
   async ship(ctx, config) {
     ctx.log(`vsce: publishing ${config.publisher}.${config.extensionName}@${ctx.version} to VS Code Marketplace`);
 
-    const token = ctx.secret('VSCE_TOKEN');
-    if (!token) {
-      throw new Error('VSCE_TOKEN not set. Run: sh1pt secret set VSCE_TOKEN <pat>');
-    }
-
     if (ctx.dryRun) {
       ctx.log('vsce: dry-run — would publish extension');
       return { id: 'dry-run' };
+    }
+
+    const token = ctx.secret('VSCE_TOKEN');
+    if (!token) {
+      throw new Error('VSCE_TOKEN not set. Run: sh1pt secret set VSCE_TOKEN <pat>');
     }
 
     await exec('npx', ['--yes', 'vsce', 'publish', '--pat', token, '--packagePath', ctx.artifact], {


### PR DESCRIPTION
Fixes #528

## Summary
- return the VS Code Marketplace dry-run publish result before requiring `VSCE_TOKEN`
- add regression coverage proving dry-run publish does not call vsce or require credentials
- make existing path assertions platform-neutral while covering the same build behavior

## Verification
- `npx --yes pnpm@9.12.0 exec vitest run packages/targets/plugin-vscode/src/index.test.ts`
- `npx --yes pnpm@9.12.0 --filter @profullstack/sh1pt-target-plugin-vscode typecheck`