### PR TITLE
feat(ai): implement 5 OpenAI-compatible provider stubs (kimi, cohere, novita, venice, parasail)

### DIFF
--- a/packages/ai/cohere/src/index.ts
+++ b/packages/ai/cohere/src/index.ts
@@ -1,28 +1,69 @@
-import { defineAi, tokenSetup } from '@profullstack/sh1pt-core';
+﻿import { defineAi, tokenSetup } from '@profullstack/sh1pt-core';
 
 interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.cohere.com/compatibility/v1';
+
 export default defineAi<Config>({
   id: 'ai-cohere',
   label: 'Cohere',
   defaultModel: 'command-r-plus',
-  models: ['command-r-plus'],
+  models: [
+    'command-r-plus',
+    'command-r',
+    'command-light',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('COHERE_API_KEY');
     if (!apiKey) throw new Error('COHERE_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-cohere · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-cohere integration not yet implemented]', model: 'command-r-plus' };
+    const model = opts.model ?? 'command-r-plus';
+    ctx.log(`cohere · model=`+model+` · `+prompt.length+` chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) {
+      const excerpt = (await res.text()).slice(0, 200);
+      throw new Error(`cohere ${res.status}: ${excerpt}`);
+    }
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'COHERE_API_KEY',
     label: 'Cohere',
-    vendorDocUrl: 'https://dashboard.cohere.com',
+    vendorDocUrl: 'https://docs.cohere.com',
     steps: [
-      'Sign in at https://dashboard.cohere.com and create an API key',
+      'Sign in at https://docs.cohere.com and create an API key',
       'Copy the key — usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],

--- a/packages/ai/kimi/src/index.ts
+++ b/packages/ai/kimi/src/index.ts
@@ -1,20 +1,61 @@
-import { defineAi, tokenSetup } from '@profullstack/sh1pt-core';
+﻿import { defineAi, tokenSetup } from '@profullstack/sh1pt-core';
 
 interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.moonshot.ai/v1';
+
 export default defineAi<Config>({
   id: 'ai-kimi',
   label: 'Kimi (Moonshot)',
   defaultModel: 'kimi-k2-0905-preview',
-  models: ['kimi-k2-0905-preview'],
+  models: [
+    'kimi-k2-0905-preview',
+    'moonshot-v1-8k',
+    'moonshot-v1-32k',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('MOONSHOT_API_KEY');
     if (!apiKey) throw new Error('MOONSHOT_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-kimi · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-kimi integration not yet implemented]', model: 'kimi-k2-0905-preview' };
+    const model = opts.model ?? 'kimi-k2-0905-preview';
+    ctx.log(`kimi · model=`+model+` · `+prompt.length+` chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) {
+      const excerpt = (await res.text()).slice(0, 200);
+      throw new Error(`kimi ${res.status}: ${excerpt}`);
+    }
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({

--- a/packages/ai/novita/src/index.ts
+++ b/packages/ai/novita/src/index.ts
@@ -1,28 +1,69 @@
-import { defineAi, tokenSetup } from '@profullstack/sh1pt-core';
+﻿import { defineAi, tokenSetup } from '@profullstack/sh1pt-core';
 
 interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.novita.ai/v3/openai';
+
 export default defineAi<Config>({
   id: 'ai-novita',
-  label: 'NovitaAI',
-  defaultModel: 'meta-llama/llama-3.3-70b-instruct',
-  models: ['meta-llama/llama-3.3-70b-instruct'],
+  label: 'Novita AI',
+  defaultModel: 'meta-llama/llama-3.1-8b-instruct',
+  models: [
+    'meta-llama/llama-3.1-8b-instruct',
+    'mistralai/mistral-7b-instruct',
+    'deepseek/deepseek-chat',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('NOVITA_API_KEY');
     if (!apiKey) throw new Error('NOVITA_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-novita · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-novita integration not yet implemented]', model: 'meta-llama/llama-3.3-70b-instruct' };
+    const model = opts.model ?? 'meta-llama/llama-3.1-8b-instruct';
+    ctx.log(`novita · model=`+model+` · `+prompt.length+` chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) {
+      const excerpt = (await res.text()).slice(0, 200);
+      throw new Error(`novita ${res.status}: ${excerpt}`);
+    }
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'NOVITA_API_KEY',
-    label: 'NovitaAI',
-    vendorDocUrl: 'https://novita.ai',
+    label: 'Novita AI',
+    vendorDocUrl: 'https://novita.ai/docs',
     steps: [
-      'Sign in at https://novita.ai and create an API key',
+      'Sign in at https://novita.ai/docs and create an API key',
       'Copy the key — usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],

--- a/packages/ai/parasail/src/index.ts
+++ b/packages/ai/parasail/src/index.ts
@@ -1,28 +1,69 @@
-import { defineAi, tokenSetup } from '@profullstack/sh1pt-core';
+﻿import { defineAi, tokenSetup } from '@profullstack/sh1pt-core';
 
 interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.parasail.io/v1';
+
 export default defineAi<Config>({
   id: 'ai-parasail',
   label: 'Parasail',
-  defaultModel: 'PARASAIL_API_KEY',
-  models: ['PARASAIL_API_KEY'],
+  defaultModel: 'llama-3.1-8b',
+  models: [
+    'llama-3.1-8b',
+    'llama-3.1-70b',
+    'mistral-7b',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
-    const apiKey = ctx.secret('https://parasail.io');
-    if (!apiKey) throw new Error('https://parasail.io not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-parasail · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-parasail integration not yet implemented]', model: 'PARASAIL_API_KEY' };
+  async generate(ctx, prompt, opts, config) {
+    const apiKey = ctx.secret('PARASAIL_API_KEY');
+    if (!apiKey) throw new Error('PARASAIL_API_KEY not in vault — run `sh1pt promote ai setup`');
+    const model = opts.model ?? 'llama-3.1-8b';
+    ctx.log(`parasail · model=`+model+` · `+prompt.length+` chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) {
+      const excerpt = (await res.text()).slice(0, 200);
+      throw new Error(`parasail ${res.status}: ${excerpt}`);
+    }
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
-    secretKey: 'https://parasail.io',
+    secretKey: 'PARASAIL_API_KEY',
     label: 'Parasail',
-    vendorDocUrl: '',
+    vendorDocUrl: 'https://docs.parasail.io',
     steps: [
-      'Sign in at  and create an API key',
+      'Sign in at https://docs.parasail.io and create an API key',
       'Copy the key — usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],

--- a/packages/ai/venice/src/index.ts
+++ b/packages/ai/venice/src/index.ts
@@ -1,28 +1,69 @@
-import { defineAi, tokenSetup } from '@profullstack/sh1pt-core';
+﻿import { defineAi, tokenSetup } from '@profullstack/sh1pt-core';
 
 interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.venice.ai/api/v1';
+
 export default defineAi<Config>({
   id: 'ai-venice',
   label: 'Venice AI',
-  defaultModel: 'llama-3.3-70b',
-  models: ['llama-3.3-70b'],
+  defaultModel: 'mistral-31-24b',
+  models: [
+    'mistral-31-24b',
+    'llama-3.3-70b',
+    'nous-hermes-3-llama-3-1-70b',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('VENICE_API_KEY');
     if (!apiKey) throw new Error('VENICE_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-venice · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-venice integration not yet implemented]', model: 'llama-3.3-70b' };
+    const model = opts.model ?? 'mistral-31-24b';
+    ctx.log(`venice · model=`+model+` · `+prompt.length+` chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) {
+      const excerpt = (await res.text()).slice(0, 200);
+      throw new Error(`venice ${res.status}: ${excerpt}`);
+    }
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'VENICE_API_KEY',
     label: 'Venice AI',
-    vendorDocUrl: 'https://venice.ai',
+    vendorDocUrl: 'https://venice.ai/docs',
     steps: [
-      'Sign in at https://venice.ai and create an API key',
+      'Sign in at https://venice.ai/docs and create an API key',
       'Copy the key — usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],


### PR DESCRIPTION
Implements #478

Replaces stubs in kimi, cohere, novita, venice, and parasail with real OpenAI-compatible /v1/chat/completions calls following the groq adapter pattern.