### PR TITLE
fix(cli): go module v2 names + forge subpath URL classification

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -36,6 +36,16 @@ export interface DetectedStack {
  * Inspect a directory root and return detected stack info based on manifest
  * files. Returns undefined if nothing recognizable is found.
  */
+/**
+ * Extract a human-readable project name from a Go module path.
+ * Strips major-version suffixes so `github.com/user/my-go-app/v2`
+ * returns `my-go-app` rather than `v2`.
+ */
+function goProjectName(module: string): string {
+  const stripped = module.replace(/\/v\d+$/, '');
+  return stripped.split('/').pop() ?? stripped;
+}
+
 export function detectStack(dir: string): DetectedStack | undefined {
   // Node (package.json)
   const pkgPath = join(dir, 'package.json');
@@ -93,7 +103,7 @@ export function detectStack(dir: string): DetectedStack | undefined {
       return {
         runtime: 'go',
         packageManager: 'go',
-        projectName: modName ? modName.split('/').pop() : undefined,
+        projectName: modName ? goProjectName(modName) : undefined,
       };
     } catch { /* skip */ }
   }

--- a/packages/cli/src/input.ts
+++ b/packages/cli/src/input.ts
@@ -65,9 +65,18 @@ export function resolveInput(raw: string): ResolvedInput {
 }
 
 function isForgeRepoUrl(u: string): boolean {
-  // https://github.com/<org>/<repo>[...] — two path segments after the host.
-  const m = u.match(/^https?:\/\/(www\.)?(github\.com|gitlab\.com|bitbucket\.org|codeberg\.org)\/([^/\s]+)\/([^/\s?#]+)/i);
-  return Boolean(m);
+  // Match repo-root URLs only: https://github.com/<org>/<repo>
+  // with no additional path segments (issues/123, tree/main, etc.).
+  // Subpath URLs like /issues/ or /tree/ are live-site pages, not clone targets.
+  const m = u.match(
+    /^https?:\/\/(www\.)?(github\.com|gitlab\.com|bitbucket\.org|codeberg\.org)\/([^/\s]+)\/([^/\s?#]+)([?#].*)?$/i,
+  );
+  if (!m) return false;
+  // Reject if the URL path continues beyond /<org>/<repo>
+  // (e.g. /org/repo/issues/1 or /org/repo/tree/main)
+  const afterHost = u.replace(/^https?:\/\/(www\.)?(github\.com|gitlab\.com|bitbucket\.org|codeberg\.org)\//i, '');
+  const segments = afterHost.split('/').filter(s => s && !s.startsWith('?') && !s.startsWith('#'));
+  return segments.length === 2;
 }
 
 function normalizeUrl(u: string): string {


### PR DESCRIPTION
Closes #496
Closes #498

Fixes Go module v2 path detection and forge subpath URL classification in one PR.