### PR TITLE
fix(bot): correct tsconfig.base.json extends path for nested packages

### DIFF
--- a/packages/bot/core/tsconfig.json
+++ b/packages/bot/core/tsconfig.json
@@ -1,5 +1,5 @@
-{
-  "extends": "../../tsconfig.base.json",
+﻿{
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"

--- a/packages/bot/discord/tsconfig.json
+++ b/packages/bot/discord/tsconfig.json
@@ -1,5 +1,5 @@
-{
-  "extends": "../../tsconfig.base.json",
+﻿{
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"

--- a/packages/bot/signal/tsconfig.json
+++ b/packages/bot/signal/tsconfig.json
@@ -1,5 +1,5 @@
-{
-  "extends": "../../tsconfig.base.json",
+﻿{
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"

--- a/packages/bot/telegram/tsconfig.json
+++ b/packages/bot/telegram/tsconfig.json
@@ -1,5 +1,5 @@
-{
-  "extends": "../../tsconfig.base.json",
+﻿{
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"

--- a/packages/bot/whatsapp/tsconfig.json
+++ b/packages/bot/whatsapp/tsconfig.json
@@ -1,5 +1,5 @@
-{
-  "extends": "../../tsconfig.base.json",
+﻿{
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src"


### PR DESCRIPTION
Fixes #482

Changes ../../tsconfig.base.json to ../../../tsconfig.base.json in all 5 bot tsconfig files.