### PR TITLE
fix(targets): package name validations + vscode dry-run order

### DIFF
--- a/packages/targets/pkg-aur/src/index.ts
+++ b/packages/targets/pkg-aur/src/index.ts
@@ -1,4 +1,4 @@
-import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+﻿import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { isAbsolute, join } from 'node:path';
 
@@ -122,11 +122,19 @@ async function renderFromTemplate(ctx: { projectDir: string; version: string }, 
     .replaceAll('{{sha256sums}}', bashArray([sourceSha256(config)]));
 }
 
+
+/** Validate AUR package name: lowercase alphanumeric, hyphens, underscores, dots. */
+function validatePkgName(name: string): void {
+  if (!name || !/^[a-z0-9][a-z0-9_.-]*$/.test(name) || /[;$<>&|\\\\]/.test(name)) {
+    throw new Error(pkg-aur: invalid pkgName "${name}");
+  }
+}
 export default defineTarget<Config>({
   id: 'pkg-aur',
   kind: 'package-manager',
   label: 'Arch User Repository (AUR)',
   async build(ctx, config) {
+    validatePkgName(config.pkgName);
     const arches = config.arch ?? ['x86_64', 'aarch64'];
     const pkgbuildPath = join(ctx.outDir, 'PKGBUILD');
     const srcinfoPath = join(ctx.outDir, '.SRCINFO');
@@ -165,3 +173,5 @@ export default defineTarget<Config>({
     ],
   }),
 });
+
+

--- a/packages/targets/pkg-homebrew/src/index.ts
+++ b/packages/targets/pkg-homebrew/src/index.ts
@@ -1,4 +1,4 @@
-import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+﻿import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
@@ -94,11 +94,19 @@ function renderFormula(config: Config, version: string): string {
   return lines.join('\n');
 }
 
+
+/** Validate Homebrew formula name: lowercase, alphanumeric, hyphens only. */
+function validateFormulaName(name: string): void {
+  if (!name || !/^[a-z0-9][a-z0-9-]*$/.test(name)) {
+    throw new Error(pkg-homebrew: invalid formulaName "${name}". Must be lowercase with hyphens only.);
+  }
+}
 export default defineTarget<Config>({
   id: 'pkg-homebrew',
   kind: 'package-manager',
   label: 'Homebrew',
   async build(ctx, config) {
+    validateFormulaName(config.formulaName);
     const formula = renderFormula(config, ctx.version);
     const formulaPath = join(ctx.outDir, `${config.formulaName}.rb`);
     ctx.log(`render Formula/${config.formulaName}.rb`);
@@ -107,7 +115,7 @@ export default defineTarget<Config>({
     return { artifact: formulaPath };
   },
   async ship(ctx, config) {
-    ctx.log(`open PR against ${config.tap} bumping ${config.formulaName} → ${ctx.version}`);
+    ctx.log(`open PR against ${config.tap} bumping ${config.formulaName} â†’ ${ctx.version}`);
     if (ctx.dryRun) return { id: 'dry-run' };
     // TODO: git clone tap, commit formula, push branch, open PR via GH_TOKEN
     return { id: `${config.formulaName}@${ctx.version}`, url: `https://github.com/${config.tap}` };
@@ -123,3 +131,5 @@ export default defineTarget<Config>({
     ],
   }),
 });
+
+

--- a/packages/targets/pkg-scoop/src/index.ts
+++ b/packages/targets/pkg-scoop/src/index.ts
@@ -89,11 +89,22 @@ function renderManifest(ctx: { version: string }, config: Config): string {
   return `${JSON.stringify(manifest, null, 2)}\n`;
 }
 
+/** Validate a Scoop app name — alphanumeric, hyphens, underscores only. No path traversal. */
+function validateAppName(name: string): void {
+  if (!name || !/^[a-zA-Z0-9][a-zA-Z0-9_\-]*$/.test(name)) {
+    throw new Error(`pkg-scoop: invalid appName "${name}". Must start with alphanumeric and contain only letters, digits, hyphens, or underscores.`);
+  }
+  if (name.includes('..') || name.includes('/') || name.includes('\\')) {
+    throw new Error(`pkg-scoop: appName "${name}" contains path traversal characters.`);
+  }
+}
+
 export default defineTarget<Config>({
   id: 'pkg-scoop',
   kind: 'package-manager',
   label: 'Scoop bucket',
   async build(ctx, config) {
+    validateAppName(config.appName);
     const manifestPath = join(ctx.outDir, `${config.appName}.json`);
     ctx.log(`generate scoop manifest ${config.appName}.json for v${ctx.version}`);
     await mkdir(ctx.outDir, { recursive: true });
@@ -101,6 +112,7 @@ export default defineTarget<Config>({
     return { artifact: manifestPath };
   },
   async ship(ctx, config) {
+    validateAppName(config.appName);
     const bucket = config.bucketRepo ?? 'profullstack/scoop-bucket';
     ctx.log(`push ${config.appName}.json to ${bucket} bucket`);
     if (ctx.dryRun) return { id: 'dry-run' };

--- a/packages/targets/plugin-vscode/src/index.ts
+++ b/packages/targets/plugin-vscode/src/index.ts
@@ -77,14 +77,15 @@ export default defineTarget<Config>({
   async ship(ctx, config) {
     ctx.log(`vsce: publishing ${config.publisher}.${config.extensionName}@${ctx.version} to VS Code Marketplace`);
 
-    const token = ctx.secret('VSCE_TOKEN');
-    if (!token) {
-      throw new Error('VSCE_TOKEN not set. Run: sh1pt secret set VSCE_TOKEN <pat>');
-    }
-
+    // Check dry-run before requiring credentials — dry-run should never need a token.
     if (ctx.dryRun) {
       ctx.log('vsce: dry-run — would publish extension');
       return { id: 'dry-run' };
+    }
+
+    const token = ctx.secret('VSCE_TOKEN');
+    if (!token) {
+      throw new Error('VSCE_TOKEN not set. Run: sh1pt secret set VSCE_TOKEN <pat>');
     }
 
     await exec('npx', ['--yes', 'vsce', 'publish', '--pat', token, '--packagePath', ctx.artifact], {


### PR DESCRIPTION
Fixes #527
Fixes #522
Fixes #520
Fixes #529

Adds input validation to pkg-scoop, pkg-homebrew, pkg-aur and fixes vscode dry-run credential ordering.