### PR TITLE
fix(version): make cmp() SemVer-prerelease-aware in release tooling

### DIFF
--- a/scripts/semver-cmp.mjs
+++ b/scripts/semver-cmp.mjs
@@ -1,0 +1,23 @@
+// SemVer precedence over the three numeric release segments only.
+// A prerelease (e.g. 0.3.4-beta.1) ranks BELOW its own release (0.3.4) but
+// ABOVE the previous release (0.3.3).
+//
+// The previous inline implementation did `a.split('.').map(Number)`, so the
+// patch segment of "0.3.4-beta.1" parsed to NaN. Since NaN !== NaN and any
+// comparison with NaN is false, the max-version reduce() in version.mjs
+// silently kept a stale lower base and mis-versioned all three lockstep
+// packages on the next release.
+export function cmp(a, b) {
+  const core = (v) => v.split('-')[0].split('.').map(Number);
+  const hasPre = (v) => v.includes('-');
+  const pa = core(a);
+  const pb = core(b);
+  for (let i = 0; i < 3; i++) {
+    const da = pa[i] ?? 0;
+    const db = pb[i] ?? 0;
+    if (da !== db) return da - db;
+  }
+  // Equal release segments: a release outranks a prerelease of the same release.
+  if (hasPre(a) === hasPre(b)) return 0;
+  return hasPre(a) ? -1 : 1;
+}

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -15,19 +15,12 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { cmp } from './semver-cmp.mjs';
 
 const ROOT = resolve(fileURLToPath(import.meta.url), '..', '..');
 const PACKAGES = ['packages/core', 'packages/policy', 'packages/cli'];
-const arg = process.argv[2] ?? 'patch';
 
-function cmp(a, b) {
-  const pa = a.split('.').map(Number);
-  const pb = b.split('.').map(Number);
-  for (let i = 0; i < 3; i++) {
-    if (pa[i] !== pb[i]) return pa[i] - pb[i];
-  }
-  return 0;
-}
+const arg = process.argv[2] ?? 'patch';
 
 const entries = PACKAGES.map((rel) => {
   const path = resolve(ROOT, rel, 'package.json');

--- a/scripts/version.test.mjs
+++ b/scripts/version.test.mjs
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { cmp } from './semver-cmp.mjs';
+
+describe('version cmp() SemVer precedence', () => {
+  it('orders plain release versions', () => {
+    expect(cmp('0.3.4', '0.3.3')).toBeGreaterThan(0);
+    expect(cmp('0.3.3', '0.3.4')).toBeLessThan(0);
+    expect(cmp('1.0.0', '0.9.9')).toBeGreaterThan(0);
+    expect(cmp('0.3.3', '0.3.3')).toBe(0);
+  });
+
+  it('ranks a prerelease BELOW its own release but ABOVE the previous release', () => {
+    // This is the regression: with the old map(Number) the patch of
+    // "0.3.4-beta.1" was NaN, so every comparison returned NaN and the
+    // max-version reduce silently kept a stale lower base.
+    expect(cmp('0.3.4-beta.1', '0.3.3')).toBeGreaterThan(0);
+    expect(cmp('0.3.4-beta.1', '0.3.4')).toBeLessThan(0);
+    expect(cmp('0.3.4', '0.3.4-beta.1')).toBeGreaterThan(0);
+  });
+
+  it('never returns NaN for a prerelease tag', () => {
+    expect(Number.isNaN(cmp('0.3.4-beta.1', '0.3.3'))).toBe(false);
+  });
+
+  it('picks the correct max base across lockstep package versions', () => {
+    const versions = ['0.3.3', '0.3.4-beta.1', '0.3.3'];
+    const base = versions.reduce((max, v) => (cmp(v, max) > 0 ? v : max), '0.0.0');
+    // Old behaviour wrongly selected '0.3.3' as the base.
+    expect(base).toBe('0.3.4-beta.1');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['packages/**/src/**/*.test.ts', 'services/**/src/**/*.test.ts'],
+    include: ['packages/**/src/**/*.test.ts', 'services/**/src/**/*.test.ts', 'scripts/**/*.test.mjs'],
     exclude: ['**/node_modules/**', '**/dist/**', 'boilerplates/**', 'sites/**'],
     passWithNoTests: true,
     // Contract tests never touch the network; nothing should take > 5s.


### PR DESCRIPTION
## Problem
`scripts/version.mjs` picks the max current version across the three lockstep packages (core/policy/cli) as the base for the next bump. Its `cmp()` did `version.split('.').map(Number)`, so a prerelease tag such as `0.3.4-beta.1` parsed its patch segment to `NaN`. Because every comparison with `NaN` is false, the max-version `reduce()` silently kept a stale lower base (e.g. `0.3.3` over `0.3.4-beta.1`) and the next patch/minor/major was computed off the wrong number — mis-versioning all three packages.

The explicit-version path already accepts prerelease tags via `/^\d+\.\d+\.\d+(?:-[\w.-]+)?$/`, so prereleases are a supported input; only the comparator was wrong.

## Fix
- Extract `cmp()` into `scripts/semver-cmp.mjs`, SemVer-precedence-correct: compare the three numeric release segments, then rank a prerelease below its own release.
- Add `scripts/version.test.mjs` (vitest) covering the regression.
- Extend `vitest.config.ts` `include` to scan `scripts/**/*.test.mjs` (touches shared config — flagged here for review).

## Tests
`pnpm exec vitest run scripts/version.test.mjs` → 4 passed.
