### PR TITLE
fix(policy): reject bundle ids with a trailing/edge hyphen

### DIFF
--- a/packages/policy/src/rules/bundle-id.test.ts
+++ b/packages/policy/src/rules/bundle-id.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { bundleId } from './bundle-id.js';
+import type { Finding, LintContext } from '../rule.js';
+
+function lint(bid: string): Finding[] {
+  const ctx = {
+    projectDir: '/tmp/project',
+    manifest: {
+      targets: {
+        ios: { use: 'ios', enabled: true, config: { bundleId: bid } },
+      },
+    },
+  } as unknown as LintContext;
+  return bundleId.run(ctx) as Finding[];
+}
+
+describe('bundle-id rule', () => {
+  it('accepts a valid reverse-DNS id', () => {
+    expect(lint('com.yourcompany.appname')).toHaveLength(0);
+  });
+
+  it('accepts an internal hyphen inside a label', () => {
+    expect(lint('com.your-company.app-name')).toHaveLength(0);
+  });
+
+  it('rejects a trailing hyphen (Apple/Google reject it)', () => {
+    const findings = lint('com.foo.bar-');
+    expect(findings.some((f) => /not valid reverse-DNS/.test(f.message))).toBe(true);
+  });
+
+  it('rejects a label that starts with a hyphen', () => {
+    const findings = lint('com.-foo.bar');
+    expect(findings.some((f) => /not valid reverse-DNS/.test(f.message))).toBe(true);
+  });
+
+  it('rejects a single-segment id (not reverse-DNS)', () => {
+    const findings = lint('com');
+    expect(findings.some((f) => /not valid reverse-DNS/.test(f.message))).toBe(true);
+  });
+});

--- a/packages/policy/src/rules/bundle-id.ts
+++ b/packages/policy/src/rules/bundle-id.ts
@@ -1,6 +1,11 @@
 import type { Rule, Finding } from '../rule.js';
 
-const BUNDLE_RE = /^[a-zA-Z][a-zA-Z0-9-]*(\.[a-zA-Z][a-zA-Z0-9-]*)+$/;
+// Each reverse-DNS label must start with a letter and end with an
+// alphanumeric; hyphens are only allowed between alphanumerics. The previous
+// pattern (`[a-zA-Z][a-zA-Z0-9-]*`) let a label end with a hyphen, so
+// "com.foo.bar-" passed even though Apple App Store Connect and Google Play
+// both reject a bundle/application id with a trailing (or doubled) hyphen.
+const BUNDLE_RE = /^[a-zA-Z][a-zA-Z0-9]*(-[a-zA-Z0-9]+)*(\.[a-zA-Z][a-zA-Z0-9]*(-[a-zA-Z0-9]+)*)+$/;
 
 export const bundleId: Rule = {
   id: 'mobile/bundle-id',


### PR DESCRIPTION
## Problem
The bundle-id rule's `BUNDLE_RE` used `[a-zA-Z][a-zA-Z0-9-]*` per label, which let a label end with a hyphen — so `com.foo.bar-` passed validation. Apple App Store Connect and Google Play both reject a bundle/application id whose label ends with (or doubles) a hyphen, so the linter gave a false pass the stores would later bounce.

## Fix
Tighten the pattern so hyphens are only allowed between alphanumerics within a label: `[a-zA-Z][a-zA-Z0-9]*(-[a-zA-Z0-9]+)*`. All previously valid ids still pass; only genuinely store-invalid hyphen placements now fail. Adds a vitest spec (valid ids, internal hyphens, trailing/leading-hyphen and single-segment rejections).

## Tests
`pnpm exec vitest run packages/policy/src/rules/bundle-id.test.ts` → 5 passed.
