### PR TITLE
fix fdroid package name validation

### DIFF
--- a/packages/targets/pkg-fdroid/src/index.test.ts
+++ b/packages/targets/pkg-fdroid/src/index.test.ts
@@ -79,6 +79,25 @@ describe('F-Droid target', () => {
     });
   });
 
+  it('rejects invalid package names before writing metadata artifacts', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-fdroid-'));
+    tempDirs.push(outDir);
+    const ctx = fakeBuildContext({ outDir }) as any;
+    const metadata = {
+      categories: ['Development'],
+      license: 'MIT',
+      sourceRepo: 'https://github.com/acme/app',
+    };
+
+    for (const packageName of ['../escape', 'com.acme/app', 'com..acme', '1com.acme.app']) {
+      await expect(adapter.build(ctx, {
+        packageName,
+        mode: 'main-repo',
+        metadata,
+      })).rejects.toThrow('packageName');
+    }
+  });
+
   it('keeps dry-run shipping side-effect free for main repo submissions', async () => {
     await expect(adapter.ship(fakeShipContext({ dryRun: true }) as any, {
       packageName: 'com.acme.app',
@@ -95,5 +114,17 @@ describe('F-Droid target', () => {
         metadataFile: 'metadata/com.acme.app.yml',
       },
     });
+  });
+
+  it('rejects invalid package names before shipping', async () => {
+    await expect(adapter.ship(fakeShipContext({ dryRun: true }) as any, {
+      packageName: '../escape',
+      mode: 'main-repo',
+      metadata: {
+        categories: ['Development'],
+        license: 'Apache-2.0',
+        sourceRepo: 'https://github.com/acme/app',
+      },
+    })).rejects.toThrow('packageName');
   });
 });

--- a/packages/targets/pkg-fdroid/src/index.test.ts
+++ b/packages/targets/pkg-fdroid/src/index.test.ts
@@ -8,6 +8,7 @@ import adapter from './index.js';
 smokeTest(adapter, { idPrefix: 'pkg', requireKind: true });
 
 const tempDirs: string[] = [];
+const invalidPackageNames = ['../escape', 'com.acme/app', 'com..acme', '1com.acme.app', 'com.int.app'];
 
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
@@ -89,7 +90,7 @@ describe('F-Droid target', () => {
       sourceRepo: 'https://github.com/acme/app',
     };
 
-    for (const packageName of ['../escape', 'com.acme/app', 'com..acme', '1com.acme.app']) {
+    for (const packageName of invalidPackageNames) {
       await expect(adapter.build(ctx, {
         packageName,
         mode: 'main-repo',
@@ -117,14 +118,16 @@ describe('F-Droid target', () => {
   });
 
   it('rejects invalid package names before shipping', async () => {
-    await expect(adapter.ship(fakeShipContext({ dryRun: true }) as any, {
-      packageName: '../escape',
-      mode: 'main-repo',
-      metadata: {
-        categories: ['Development'],
-        license: 'Apache-2.0',
-        sourceRepo: 'https://github.com/acme/app',
-      },
-    })).rejects.toThrow('packageName');
+    for (const packageName of invalidPackageNames) {
+      await expect(adapter.ship(fakeShipContext({ dryRun: true }) as any, {
+        packageName,
+        mode: 'main-repo',
+        metadata: {
+          categories: ['Development'],
+          license: 'Apache-2.0',
+          sourceRepo: 'https://github.com/acme/app',
+        },
+      })).rejects.toThrow('packageName');
+    }
   });
 });

--- a/packages/targets/pkg-fdroid/src/index.ts
+++ b/packages/targets/pkg-fdroid/src/index.ts
@@ -42,7 +42,6 @@ function renderBlock(key: string, value: string): string[] {
 }
 
 function renderMetadata(config: Config): string {
-  assertPackageName(config.packageName);
   if (!config.metadata) {
     throw new Error('pkg-fdroid main-repo mode requires metadata');
   }
@@ -78,10 +77,21 @@ function resolveRepoDir(ctx: { projectDir: string }, config: Config): string {
   return isAbsolute(dir) ? dir : join(ctx.projectDir, dir);
 }
 
+const JAVA_RESERVED_WORDS = new Set([
+  'abstract', 'assert', 'boolean', 'break', 'byte', 'case', 'catch', 'char',
+  'class', 'const', 'continue', 'default', 'do', 'double', 'else', 'enum',
+  'extends', 'final', 'finally', 'float', 'for', 'goto', 'if', 'implements',
+  'import', 'instanceof', 'int', 'interface', 'long', 'native', 'new',
+  'package', 'private', 'protected', 'public', 'return', 'short', 'static',
+  'strictfp', 'super', 'switch', 'synchronized', 'this', 'throw', 'throws',
+  'transient', 'try', 'void', 'volatile', 'while', 'true', 'false', 'null',
+]);
+
 function assertPackageName(packageName: string): void {
   const segment = '[A-Za-z][A-Za-z0-9_]*';
   const pattern = new RegExp(`^${segment}(\\.${segment})+$`);
-  if (!pattern.test(packageName)) {
+  const segments = packageName.split('.');
+  if (!pattern.test(packageName) || segments.some((part) => JAVA_RESERVED_WORDS.has(part))) {
     throw new Error(`packageName must be a valid Android package name, got "${packageName}"`);
   }
 }

--- a/packages/targets/pkg-fdroid/src/index.ts
+++ b/packages/targets/pkg-fdroid/src/index.ts
@@ -42,6 +42,7 @@ function renderBlock(key: string, value: string): string[] {
 }
 
 function renderMetadata(config: Config): string {
+  assertPackageName(config.packageName);
   if (!config.metadata) {
     throw new Error('pkg-fdroid main-repo mode requires metadata');
   }
@@ -77,11 +78,20 @@ function resolveRepoDir(ctx: { projectDir: string }, config: Config): string {
   return isAbsolute(dir) ? dir : join(ctx.projectDir, dir);
 }
 
+function assertPackageName(packageName: string): void {
+  const segment = '[A-Za-z][A-Za-z0-9_]*';
+  const pattern = new RegExp(`^${segment}(\\.${segment})+$`);
+  if (!pattern.test(packageName)) {
+    throw new Error(`packageName must be a valid Android package name, got "${packageName}"`);
+  }
+}
+
 export default defineTarget<Config>({
   id: 'pkg-fdroid',
   kind: 'package-manager',
   label: 'F-Droid (Android FOSS repo)',
   async build(ctx, config) {
+    assertPackageName(config.packageName);
     if (config.mode === 'main-repo') {
       ctx.log(`render fdroiddata metadata for ${config.packageName}`);
       const metadataPath = join(ctx.outDir, `${config.packageName}.yml`);
@@ -109,6 +119,7 @@ export default defineTarget<Config>({
     return { artifact: cwd };
   },
   async ship(ctx, config) {
+    assertPackageName(config.packageName);
     if (config.mode === 'main-repo') {
       ctx.log(`open PR against fdroiddata for ${config.packageName}`);
       if (ctx.dryRun) {


### PR DESCRIPTION
## Summary
- validate pkg-fdroid Android package names before build and ship work
- reject malformed names before they can be used in metadata artifact filenames
- add regression coverage for path separators and malformed package segments

## Why
pkg-fdroid used config.packageName directly in the generated metadata filename. Invalid values such as ../escape or com.acme/app should be rejected instead of influencing the artifact path.

## Tests
- vitest run packages/targets/pkg-fdroid/src/index.test.ts passed
- tsc -p packages/targets/pkg-fdroid/tsconfig.json --noEmit passed