### PR TITLE
Implement Chrome extension package plan

### DIFF
--- a/packages/targets/browser-chrome/src/index.test.ts
+++ b/packages/targets/browser-chrome/src/index.test.ts
@@ -1,4 +1,109 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { execMock } = vi.hoisted(() => ({
+  execMock: vi.fn(),
+}));
+
+vi.mock('@profullstack/sh1pt-core', async () => ({
+  ...await vi.importActual<typeof import('@profullstack/sh1pt-core')>('@profullstack/sh1pt-core'),
+  exec: execMock,
+}));
+
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'browser', requireKind: true });
+
+const tempDirs: string[] = [];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('browser-chrome target adapter', () => {
+  it('writes a package plan without touching the source directory in dry-run builds', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-chrome-out-'));
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-chrome-project-'));
+    tempDirs.push(outDir, projectDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      projectDir,
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      extensionId: 'chrome-extension',
+      sourceDir: 'extension-dist',
+    });
+
+    expect(execMock).not.toHaveBeenCalled();
+    expect(result.artifact).toBe(join(outDir, 'chrome-package.json'));
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan).toEqual({
+      provider: 'chrome-web-store',
+      extensionId: 'chrome-extension',
+      version: '1.2.3',
+      sourceDir: join(projectDir, 'extension-dist'),
+      artifact: join(outDir, 'chrome-extension-1.2.3.zip'),
+      command: ['zip', '-r', join(outDir, 'chrome-extension-1.2.3.zip'), '.'],
+      cwd: join(projectDir, 'extension-dist'),
+    });
+  });
+
+  it('packages the project-relative source directory with zip for real builds', async () => {
+    execMock.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-chrome-out-'));
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-chrome-project-'));
+    const sourceDir = join(projectDir, 'dist');
+    tempDirs.push(outDir, projectDir);
+    await mkdir(sourceDir, { recursive: true });
+    await writeFile(join(sourceDir, 'manifest.json'), JSON.stringify({ manifest_version: 3 }), 'utf-8');
+
+    const ctx = fakeBuildContext({
+      outDir,
+      projectDir,
+      version: '1.2.3',
+      dryRun: false,
+    });
+    const result = await adapter.build(ctx as any, {
+      extensionId: 'chrome-extension',
+    });
+
+    const artifact = join(outDir, 'chrome-extension-1.2.3.zip');
+    expect(execMock).toHaveBeenCalledWith('zip', ['-r', artifact, '.'], {
+      cwd: sourceDir,
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+    expect(result).toEqual({ artifact });
+  });
+
+  it('keeps extension IDs with path separators inside the output directory', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-chrome-out-'));
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-chrome-project-'));
+    tempDirs.push(outDir, projectDir);
+
+    const result = await adapter.build(fakeBuildContext({
+      outDir,
+      projectDir,
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      extensionId: '../chrome-extension',
+      sourceDir: 'extension-dist',
+    });
+
+    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
+    expect(plan.extensionId).toBe('../chrome-extension');
+    expect(plan.artifact).toBe(join(outDir, 'chrome-extension-1.2.3.zip'));
+    expect(plan.command).toEqual(['zip', '-r', join(outDir, 'chrome-extension-1.2.3.zip'), '.']);
+  });
+});

--- a/packages/targets/browser-chrome/src/index.ts
+++ b/packages/targets/browser-chrome/src/index.ts
@@ -1,4 +1,6 @@
-import { defineTarget, manualSetup } from '@profullstack/sh1pt-core';
+import { defineTarget, exec, manualSetup } from '@profullstack/sh1pt-core';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { isAbsolute, join } from 'node:path';
 
 interface Config {
   extensionId: string;
@@ -6,14 +8,74 @@ interface Config {
   deployPercent?: number;
 }
 
+function sourceDir(ctx: { projectDir: string }, config: Config): string {
+  const dir = config.sourceDir ?? 'dist';
+  return isAbsolute(dir) ? dir : join(ctx.projectDir, dir);
+}
+
+function safeFileStem(value: string): string {
+  return value
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/^\.+|\.+$/g, '')
+    .replace(/^-+|-+$/g, '') || 'chrome-extension';
+}
+
+function packageArtifact(ctx: { outDir: string; version: string }, config: Config): string {
+  return join(ctx.outDir, `${safeFileStem(config.extensionId)}-${safeFileStem(ctx.version)}.zip`);
+}
+
+function packagePlan(ctx: { projectDir: string; outDir: string; version: string }, config: Config) {
+  const src = sourceDir(ctx, config);
+  const artifact = packageArtifact(ctx, config);
+  return {
+    provider: 'chrome-web-store',
+    extensionId: config.extensionId,
+    version: ctx.version,
+    sourceDir: src,
+    artifact,
+    command: ['zip', '-r', artifact, '.'],
+    cwd: src,
+  };
+}
+
 export default defineTarget<Config>({
   id: 'browser-chrome',
   kind: 'browser-ext',
   label: 'Chrome Web Store',
   async build(ctx, config) {
-    ctx.log(`zip extension from ${config.sourceDir ?? 'dist/'}`);
-    // TODO: verify manifest.json, zip into ctx.outDir
-    return { artifact: `${ctx.outDir}/extension.zip` };
+    const src = sourceDir(ctx, config);
+    const zipPath = packageArtifact(ctx, config);
+
+    ctx.log(`pack Chrome extension from ${src} for v${ctx.version}`);
+
+    if (ctx.dryRun) {
+      const planPath = join(ctx.outDir, 'chrome-package.json');
+      await mkdir(ctx.outDir, { recursive: true });
+      await writeFile(planPath, `${JSON.stringify(packagePlan(ctx, config), null, 2)}\n`, 'utf-8');
+      return { artifact: planPath };
+    }
+
+    const manifestPath = join(src, 'manifest.json');
+    let manifestText: string;
+    try {
+      manifestText = await readFile(manifestPath, 'utf-8');
+    } catch {
+      throw new Error(`manifest.json not found at ${manifestPath} - run a build step first`);
+    }
+    const manifest = JSON.parse(manifestText) as { manifest_version?: number };
+    if (manifest.manifest_version !== 3) {
+      ctx.log(`manifest_version is ${manifest.manifest_version ?? 'missing'}, Chrome expects v3`, 'warn');
+    }
+
+    await mkdir(ctx.outDir, { recursive: true });
+    await exec('zip', ['-r', zipPath, '.'], {
+      cwd: src,
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+
+    ctx.log(`created ${zipPath}`);
+    return { artifact: zipPath };
   },
   async ship(ctx, config) {
     ctx.log(`upload + publish extension ${config.extensionId}`);


### PR DESCRIPTION
## Summary
- add a Chrome Web Store build plan for dry-run builds
- validate manifest.json and zip the extension source for real builds
- add Chrome target tests covering dry-run output, real zip invocation, and safe artifact names

## Tests
- Not run here: pnpm is not installed in this execution environment, and corepack could not prepare it because its cache directory was blocked.
