### PR TITLE
Validate apt package names

### DIFF
--- a/packages/targets/pkg-apt/src/index.test.ts
+++ b/packages/targets/pkg-apt/src/index.test.ts
@@ -65,4 +65,27 @@ describe('apt package metadata generation', () => {
       packageName: 'myapp',
     })).resolves.toEqual({ id: 'dry-run' });
   });
+
+  it('rejects invalid Debian package names before writing metadata artifacts', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-apt-'));
+    tempDirs.push(outDir);
+
+    for (const packageName of ['../escape', 'Bad Name', 'UpperCase', 'a']) {
+      await expect(adapter.build(fakeBuildContext({
+        outDir,
+        version: '1.2.3',
+      }) as any, {
+        packageName,
+      })).rejects.toThrow('packageName');
+    }
+  });
+
+  it('rejects invalid Debian package names before shipping', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      packageName: '../escape',
+    })).rejects.toThrow('packageName');
+  });
 });

--- a/packages/targets/pkg-apt/src/index.test.ts
+++ b/packages/targets/pkg-apt/src/index.test.ts
@@ -66,6 +66,20 @@ describe('apt package metadata generation', () => {
     })).resolves.toEqual({ id: 'dry-run' });
   });
 
+  it('accepts Debian package names with allowed special characters', async () => {
+    for (const packageName of ['libfoo-bar', 'g++', 'python3.10']) {
+      const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-apt-'));
+      tempDirs.push(outDir);
+
+      await expect(adapter.build(fakeBuildContext({
+        outDir,
+        version: '1.2.3',
+      }) as any, {
+        packageName,
+      })).resolves.toEqual({ artifact: join(outDir, 'debian', 'control') });
+    }
+  });
+
   it('rejects invalid Debian package names before writing metadata artifacts', async () => {
     const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-apt-'));
     tempDirs.push(outDir);

--- a/packages/targets/pkg-apt/src/index.ts
+++ b/packages/targets/pkg-apt/src/index.ts
@@ -23,6 +23,12 @@ function debVersion(version: string): string {
   return version.replace(/^v/, '');
 }
 
+function assertPackageName(packageName: string): void {
+  if (!/^[a-z0-9][a-z0-9+.-]+$/.test(packageName)) {
+    throw new Error(`packageName must be a valid Debian package name, got "${packageName}"`);
+  }
+}
+
 function packageFileName(config: Config, version: string, arch: string): string {
   return config.packageFilename
     ? config.packageFilename
@@ -84,6 +90,7 @@ export default defineTarget<Config>({
   kind: 'package-manager',
   label: 'apt repo / PPA',
   async build(ctx, config) {
+    assertPackageName(config.packageName);
     const arches = config.architecture ?? ['amd64', 'arm64'];
     const dist = config.distribution ?? 'jammy';
     const component = config.component ?? 'main';
@@ -102,6 +109,7 @@ export default defineTarget<Config>({
     return { artifact: controlPath };
   },
   async ship(ctx, config) {
+    assertPackageName(config.packageName);
     const dist = config.distribution ?? 'jammy';
     const component = config.component ?? 'main';
     ctx.log(`publish ${config.packageName}@${ctx.version} to apt repo (${dist}/${component})`);


### PR DESCRIPTION
Fixes the pkg-apt target accepting invalid Debian package names before rendering package metadata. Invalid names such as path traversal, spaces, uppercase letters, or one-character names are now rejected before build artifacts or ship IDs are produced.

Validation:
- vitest run packages/targets/pkg-apt/src/index.test.ts
- tsc -p packages/targets/pkg-apt/tsconfig.json --noEmit