### PR TITLE
Validate Android package names

### DIFF
--- a/packages/targets/mobile-android/src/index.test.ts
+++ b/packages/targets/mobile-android/src/index.test.ts
@@ -14,7 +14,7 @@ afterEach(async () => {
 });
 
 describe('mobile-android target adapter', () => {
-  it('keeps package names with path separators inside the output directory', async () => {
+  it('writes the AAB artifact for a valid Android package name', async () => {
     const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-android-out-'));
     tempDirs.push(outDir);
 
@@ -23,9 +23,31 @@ describe('mobile-android target adapter', () => {
       version: '1.2.3',
       dryRun: true,
     }) as any, {
-      packageName: '../com.example.app',
+      packageName: 'com.example.app',
     });
 
     expect(result.artifact).toBe(join(outDir, 'com.example.app-1.2.3.aab'));
+  });
+
+  it('rejects package names with path separators', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-android-out-'));
+    tempDirs.push(outDir);
+
+    await expect(adapter.build(fakeBuildContext({
+      outDir,
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      packageName: '../com.example.app',
+    })).rejects.toThrow('packageName');
+  });
+
+  it('rejects package names without multiple Java identifier segments', async () => {
+    await expect(adapter.ship(fakeBuildContext({
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      packageName: 'example',
+    })).rejects.toThrow('packageName');
   });
 });

--- a/packages/targets/mobile-android/src/index.ts
+++ b/packages/targets/mobile-android/src/index.ts
@@ -6,6 +6,8 @@ interface Config {
   track?: 'internal' | 'alpha' | 'beta' | 'production';
 }
 
+const ANDROID_PACKAGE_NAME_RE = /^[a-zA-Z][a-zA-Z0-9_]*(?:\.[a-zA-Z][a-zA-Z0-9_]*)+$/;
+
 function safeFileStem(value: string): string {
   return value
     .replace(/[^a-zA-Z0-9._-]+/g, '-')
@@ -13,24 +15,34 @@ function safeFileStem(value: string): string {
     .replace(/^-+|-+$/g, '') || 'android-app';
 }
 
+function requirePackageName(config: Config): string {
+  const packageName = config.packageName?.trim();
+  if (!packageName || !ANDROID_PACKAGE_NAME_RE.test(packageName)) {
+    throw new Error(`mobile-android packageName must be a valid Android application ID, got "${config.packageName}"`);
+  }
+  return packageName;
+}
+
 export default defineTarget<Config>({
   id: 'mobile-android',
   kind: 'mobile',
   label: 'Google Play Store',
   async build(ctx, config) {
-    ctx.log(`build Android AAB for ${config.packageName} v${ctx.version}`);
+    const packageName = requirePackageName(config);
+    ctx.log(`build Android AAB for ${packageName} v${ctx.version}`);
     // TODO: run Gradle bundleRelease to produce signed .aab
-    return { artifact: join(ctx.outDir, `${safeFileStem(config.packageName)}-${safeFileStem(ctx.version)}.aab`) };
+    return { artifact: join(ctx.outDir, `${safeFileStem(packageName)}-${safeFileStem(ctx.version)}.aab`) };
   },
   async ship(ctx, config) {
+    const packageName = requirePackageName(config);
     const track = config.track ?? 'internal';
-    ctx.log(`upload ${config.packageName}@${ctx.version} to Google Play track: ${track}`);
+    ctx.log(`upload ${packageName}@${ctx.version} to Google Play track: ${track}`);
     if (ctx.dryRun) return { id: 'dry-run' };
     // TODO: use Google Play Developer API v3 to upload AAB
     // Uses GOOGLE_PLAY_JSON from ctx.secret('GOOGLE_PLAY_JSON') (service account key)
     return {
-      id: `${config.packageName}@${ctx.version}`,
-      url: `https://play.google.com/store/apps/details?id=${config.packageName}`,
+      id: `${packageName}@${ctx.version}`,
+      url: `https://play.google.com/store/apps/details?id=${packageName}`,
     };
   },
   async status(id) {


### PR DESCRIPTION
Fixes #580.

Changes:
- validate mobile-android packageName as an Android application ID before build/ship
- use the validated packageName for artifact names and Google Play IDs/URLs
- add regression tests for valid IDs, path separators, and single-segment names

Validation:
- vitest run packages/targets/mobile-android/src/index.test.ts
- tsc -p packages/targets/mobile-android/tsconfig.json --noEmit