### PR TITLE
Validate webOS package identifiers

### DIFF
--- a/packages/targets/tv-webos/src/index.test.ts
+++ b/packages/targets/tv-webos/src/index.test.ts
@@ -121,4 +121,50 @@ describe('webOS TV target', () => {
       submission: 'developer-mode',
     })).rejects.toThrow('webOS appinfo.json id must match appId');
   });
+
+  it('rejects app ids with path separators before writing the plan', async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-webos-project-'));
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-webos-out-'));
+    tempDirs.push(projectDir, outDir);
+    await mkdir(join(projectDir, 'webos'), { recursive: true });
+    await writeFile(join(projectDir, 'webos', 'index.html'), '<main></main>\n', 'utf-8');
+    await writeFile(join(projectDir, 'webos', 'appinfo.json'), JSON.stringify({
+      id: '../com.acme.tv',
+      version: '1.2.3',
+      title: 'Acme TV',
+      main: 'index.html',
+    }), 'utf-8');
+
+    await expect(adapter.build(fakeBuildContext({
+      projectDir,
+      outDir,
+    }) as any, {
+      appId: '../com.acme.tv',
+      sourceDir: 'webos',
+      submission: 'developer-mode',
+    })).rejects.toThrow('appId');
+  });
+
+  it('rejects package versions with path separators', async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-webos-project-'));
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-webos-out-'));
+    tempDirs.push(projectDir, outDir);
+    await mkdir(join(projectDir, 'webos'), { recursive: true });
+    await writeFile(join(projectDir, 'webos', 'index.html'), '<main></main>\n', 'utf-8');
+    await writeFile(join(projectDir, 'webos', 'appinfo.json'), JSON.stringify({
+      id: 'com.acme.tv',
+      version: '../1.2.3',
+      title: 'Acme TV',
+      main: 'index.html',
+    }), 'utf-8');
+
+    await expect(adapter.build(fakeBuildContext({
+      projectDir,
+      outDir,
+    }) as any, {
+      appId: 'com.acme.tv',
+      sourceDir: 'webos',
+      submission: 'developer-mode',
+    })).rejects.toThrow('appinfo.version');
+  });
 });

--- a/packages/targets/tv-webos/src/index.ts
+++ b/packages/targets/tv-webos/src/index.ts
@@ -23,10 +23,29 @@ interface WebOsAppInfo {
   type?: string;
 }
 
+const WEBOS_APP_ID_RE = /^[a-zA-Z][a-zA-Z0-9]*(?:\.[a-zA-Z][a-zA-Z0-9]*)+$/;
+const WEBOS_VERSION_RE = /^[0-9A-Za-z][0-9A-Za-z._-]*$/;
+
 function requireValue(value: string | undefined, field: string): string {
   const trimmed = value?.trim();
   if (!trimmed) throw new Error(`tv-webos requires ${field}`);
   return trimmed;
+}
+
+function requireAppId(value: string | undefined): string {
+  const appId = requireValue(value, 'appId');
+  if (!WEBOS_APP_ID_RE.test(appId)) {
+    throw new Error(`tv-webos appId must be a valid reverse-DNS app id, got "${value}"`);
+  }
+  return appId;
+}
+
+function requirePackageVersion(value: string | undefined): string {
+  const version = requireValue(value, 'appinfo.version');
+  if (!WEBOS_VERSION_RE.test(version)) {
+    throw new Error(`tv-webos appinfo.version contains invalid package filename characters, got "${value}"`);
+  }
+  return version;
 }
 
 async function readAppInfo(sourceDir: string, appId: string): Promise<WebOsAppInfo> {
@@ -35,7 +54,7 @@ async function readAppInfo(sourceDir: string, appId: string): Promise<WebOsAppIn
   if (appInfo.id !== appId) {
     throw new Error(`webOS appinfo.json id must match appId (${appId})`);
   }
-  requireValue(appInfo.version, 'appinfo.version');
+  requirePackageVersion(appInfo.version);
   requireValue(appInfo.title, 'appinfo.title');
   requireValue(appInfo.main, 'appinfo.main');
   await access(join(sourceDir, appInfo.main!));
@@ -44,7 +63,7 @@ async function readAppInfo(sourceDir: string, appId: string): Promise<WebOsAppIn
 }
 
 async function packagePlan(ctx: { projectDir: string; outDir: string; version: string }, config: Config) {
-  const appId = requireValue(config.appId, 'appId');
+  const appId = requireAppId(config.appId);
   const sourceDir = resolve(ctx.projectDir, requireValue(config.sourceDir, 'sourceDir'));
   const info = await stat(sourceDir);
   if (!info.isDirectory()) throw new Error(`tv-webos sourceDir is not a directory: ${sourceDir}`);
@@ -82,11 +101,12 @@ export default defineTarget<Config>({
     return { artifact, meta: { expectedPackage: plan.expectedPackage, command: plan.command } };
   },
   async ship(ctx, config) {
+    const appId = requireAppId(config.appId);
     const dest = config.submission === 'developer-mode' ? 'devkit sideload' : 'LG Content Store review';
     ctx.log(`webOS package ready for ${dest}`);
     if (ctx.dryRun) return { id: 'dry-run', meta: { submission: config.submission } };
     return {
-      id: `${config.appId}@${ctx.version}`,
+      id: `${appId}@${ctx.version}`,
       meta: {
         artifact: ctx.artifact,
         submission: config.submission,


### PR DESCRIPTION
Fixes #584.

Changes:
- validate tv-webos appId as a reverse-DNS app id before build/ship
- validate appinfo.version before using it in the generated .ipk filename
- add regression tests for path separators in appId and version

Validation:
- vitest run packages/targets/tv-webos/src/index.test.ts
- tsc -p packages/targets/tv-webos/tsconfig.json --noEmit