### PR TITLE
Validate Android TV package names

### DIFF
--- a/packages/targets/tv-androidtv/src/index.test.ts
+++ b/packages/targets/tv-androidtv/src/index.test.ts
@@ -181,4 +181,29 @@ describe('Android TV package planning', () => {
       },
     });
   });
+
+  it('rejects package names with path separators before writing the plan', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-androidtv-'));
+    tempDirs.push(outDir);
+
+    await expect(adapter.build(fakeBuildContext({
+      outDir,
+      version: '2.4.0',
+    }) as any, {
+      packageName: '../com.acme.tv',
+      track: 'internal',
+    })).rejects.toThrow('packageName');
+  });
+
+  it('rejects package names without multiple Java identifier segments', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      artifact: 'dist/tv-release.aab',
+      channel: 'stable',
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      packageName: 'androidtv',
+      track: 'beta',
+    })).rejects.toThrow('packageName');
+  });
 });

--- a/packages/targets/tv-androidtv/src/index.ts
+++ b/packages/targets/tv-androidtv/src/index.ts
@@ -11,10 +11,14 @@ interface Config {
 }
 
 const PLAN_FILE = 'androidtv-package-plan.json';
+const ANDROID_PACKAGE_NAME_RE = /^[a-zA-Z][a-zA-Z0-9_]*(?:\.[a-zA-Z][a-zA-Z0-9_]*)+$/;
 
 function requirePackageName(config: Config): string {
   const packageName = config.packageName?.trim();
   if (!packageName) throw new Error('tv-androidtv requires packageName');
+  if (!ANDROID_PACKAGE_NAME_RE.test(packageName)) {
+    throw new Error(`tv-androidtv packageName must be a valid Android application ID, got "${config.packageName}"`);
+  }
   return packageName;
 }
 


### PR DESCRIPTION
Fixes #586.

Changes:
- validate tv-androidtv packageName as an Android application ID before planning build/ship
- reject path separators and single-segment package names
- add regression tests for invalid packageName values

Validation:
- vitest run packages/targets/tv-androidtv/src/index.test.ts
- tsc -p packages/targets/tv-androidtv/tsconfig.json --noEmit