### PR TITLE
Validate Roku channel types

### DIFF
--- a/packages/targets/tv-roku/src/index.test.ts
+++ b/packages/targets/tv-roku/src/index.test.ts
@@ -14,7 +14,7 @@ afterEach(async () => {
 });
 
 describe('Roku TV target', () => {
-  it('validates the Roku manifest and writes a package plan', async () => {
+  async function writeValidRokuProject() {
     const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-roku-project-'));
     const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-roku-out-'));
     tempDirs.push(projectDir, outDir);
@@ -30,6 +30,11 @@ describe('Roku TV target', () => {
       'mm_icon_focus_hd=images/icon.png',
       '',
     ].join('\n'), 'utf-8');
+    return { projectDir, outDir };
+  }
+
+  it('validates the Roku manifest and writes a package plan', async () => {
+    const { projectDir, outDir } = await writeValidRokuProject();
 
     const result = await adapter.build(fakeBuildContext({
       projectDir,
@@ -69,6 +74,19 @@ describe('Roku TV target', () => {
     ]);
   });
 
+  it('rejects unsupported channel types while building the package plan', async () => {
+    const { projectDir, outDir } = await writeValidRokuProject();
+
+    await expect(adapter.build(fakeBuildContext({
+      projectDir,
+      outDir,
+    }) as any, {
+      developerId: 'dev-123',
+      sourceDir: 'roku',
+      channelType: 'preview',
+    } as any)).rejects.toThrow('tv-roku channelType must be one of: public, beta, private');
+  });
+
   it('keeps dry-run shipping side-effect free', async () => {
     await expect(adapter.ship(fakeShipContext({
       dryRun: true,
@@ -83,6 +101,16 @@ describe('Roku TV target', () => {
         destination: 'Roku Channel Store review',
       },
     });
+  });
+
+  it('rejects unsupported channel types while shipping', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      dryRun: true,
+    }) as any, {
+      developerId: 'dev-123',
+      sourceDir: 'roku',
+      channelType: 'preview',
+    } as any)).rejects.toThrow('tv-roku channelType must be one of: public, beta, private');
   });
 
   it('returns package metadata in real ship mode', async () => {

--- a/packages/targets/tv-roku/src/index.ts
+++ b/packages/targets/tv-roku/src/index.ts
@@ -19,10 +19,20 @@ interface Config {
 
 type RokuManifest = Record<string, string>;
 
+const CHANNEL_TYPES = ['public', 'beta', 'private'] as const;
+
 function requireValue(value: string | undefined, field: string): string {
   const trimmed = value?.trim();
   if (!trimmed) throw new Error(`tv-roku requires ${field}`);
   return trimmed;
+}
+
+function requireChannelType(value: string | undefined): Config['channelType'] {
+  const channelType = requireValue(value, 'channelType');
+  if (!CHANNEL_TYPES.includes(channelType as Config['channelType'])) {
+    throw new Error(`tv-roku channelType must be one of: ${CHANNEL_TYPES.join(', ')}`);
+  }
+  return channelType as Config['channelType'];
 }
 
 function parseManifest(text: string): RokuManifest {
@@ -50,6 +60,7 @@ async function listFiles(root: string, dir = root): Promise<string[]> {
 
 async function packagePlan(ctx: { projectDir: string; outDir: string; version: string }, config: Config) {
   const developerId = requireValue(config.developerId, 'developerId');
+  const channelType = requireChannelType(config.channelType);
   const sourceDir = resolve(ctx.projectDir, requireValue(config.sourceDir, 'sourceDir'));
   const info = await stat(sourceDir);
   if (!info.isDirectory()) throw new Error(`tv-roku sourceDir is not a directory: ${sourceDir}`);
@@ -70,12 +81,12 @@ async function packagePlan(ctx: { projectDir: string; outDir: string; version: s
     version: `${major}.${minor}.${build}`,
     channelId: config.channelId,
     developerId,
-    channelType: config.channelType,
+    channelType,
     sourceDir,
     expectedPackage,
     files,
     command: ['zip', '-r', expectedPackage, '.'],
-    submission: config.channelType === 'public' ? 'Roku Channel Store review' : `${config.channelType} channel`,
+    submission: channelType === 'public' ? 'Roku Channel Store review' : `${channelType} channel`,
   };
 }
 
@@ -92,14 +103,15 @@ export default defineTarget<Config>({
     return { artifact, meta: { expectedPackage: plan.expectedPackage, files: plan.files.length, command: plan.command } };
   },
   async ship(ctx, config) {
-    const dest = config.channelType === 'public' ? 'Roku Channel Store review' : `${config.channelType} channel`;
+    const channelType = requireChannelType(config.channelType);
+    const dest = channelType === 'public' ? 'Roku Channel Store review' : `${channelType} channel`;
     ctx.log(`Roku package ready for ${dest}`);
-    if (ctx.dryRun) return { id: 'dry-run', meta: { channelType: config.channelType, destination: dest } };
+    if (ctx.dryRun) return { id: 'dry-run', meta: { channelType, destination: dest } };
     return {
       id: `${config.channelId ?? 'pending'}@${ctx.version}`,
       meta: {
         artifact: ctx.artifact,
-        channelType: config.channelType,
+        channelType,
         destination: dest,
         developerId: config.developerId,
       },


### PR DESCRIPTION
Fixes #588.

Changes:
- validate tv-roku channelType at runtime before package planning or shipping
- keep generated plan and ship metadata normalized to public, beta, or private
- add regression tests for invalid channelType in build and dry-run ship flows

Validation:
- vitest run packages/targets/tv-roku/src/index.test.ts
- tsc -p packages/targets/tv-roku/tsconfig.json --noEmit