### PR TITLE
Validate iOS bundle identifiers

### DIFF
--- a/packages/targets/mobile-ios/src/index.test.ts
+++ b/packages/targets/mobile-ios/src/index.test.ts
@@ -1,4 +1,28 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'mobile', requireKind: true });
+
+describe('iOS target', () => {
+  it('rejects invalid bundle identifiers while building', async () => {
+    await expect(adapter.build(fakeBuildContext({
+      outDir: '/repo/.sh1pt/out',
+      projectDir: '/repo',
+    }) as any, {
+      bundleId: '../Acme',
+      teamId: 'TEAM123456',
+    })).rejects.toThrow('mobile-ios bundleId must be a valid reverse-DNS identifier');
+  });
+
+  it('rejects invalid bundle identifiers while shipping', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      channel: 'stable',
+      dryRun: false,
+      version: '1.2.3',
+    }) as any, {
+      bundleId: 'com.acme/ios',
+      teamId: 'TEAM123456',
+    })).rejects.toThrow('mobile-ios bundleId must be a valid reverse-DNS identifier');
+  });
+});

--- a/packages/targets/mobile-ios/src/index.ts
+++ b/packages/targets/mobile-ios/src/index.ts
@@ -8,36 +8,49 @@ interface Config {
   testflightGroups?: string[];
 }
 
+const BUNDLE_ID_PATTERN = /^[A-Za-z][A-Za-z0-9-]*(\.[A-Za-z][A-Za-z0-9-]*)+$/;
+
+function requireBundleId(config: Config): string {
+  const bundleId = config.bundleId?.trim();
+  if (!bundleId) throw new Error('mobile-ios requires bundleId');
+  if (!BUNDLE_ID_PATTERN.test(bundleId)) {
+    throw new Error('mobile-ios bundleId must be a valid reverse-DNS identifier');
+  }
+  return bundleId;
+}
+
 export default defineTarget<Config>({
   id: 'mobile-ios',
   kind: 'mobile',
   label: 'App Store (iOS)',
   async build(ctx, config) {
-    ctx.log(`xcodebuild archive · scheme=${config.scheme ?? ctx.projectDir}`);
-    // TODO: xcodebuild archive → exportArchive → .ipa in ctx.outDir
-    // requires macOS runner; cloud builds will route to a mac worker
+    const bundleId = requireBundleId(config);
+    ctx.log(`xcodebuild archive - bundle=${bundleId} scheme=${config.scheme ?? ctx.projectDir}`);
+    // TODO: xcodebuild archive -> exportArchive -> .ipa in ctx.outDir.
+    // Requires a macOS runner; cloud builds will route to a Mac worker.
     return { artifact: `${ctx.outDir}/app.ipa` };
   },
   async ship(ctx, config) {
+    const bundleId = requireBundleId(config);
     const destination = ctx.channel === 'stable' ? 'App Store' : `TestFlight:${config.testflightGroups?.join(',') ?? 'internal'}`;
     ctx.log(`upload to ${destination} via App Store Connect API`);
     if (ctx.dryRun) return { id: 'dry-run' };
-    // TODO: altool / notarytool upload using APP_STORE_CONNECT_KEY from secrets
-    return { id: `${config.bundleId}@${ctx.version}` };
+    // TODO: altool / notarytool upload using APP_STORE_CONNECT_KEY from secrets.
+    return { id: `${bundleId}@${ctx.version}` };
   },
   async status(id) {
     return { state: 'in-review', version: id };
   },
 
   setup: manualSetup({
-    label: "iOS App Store",
-    vendorDocUrl: "https://developer.apple.com/",
+    label: 'iOS App Store',
+    vendorDocUrl: 'https://developer.apple.com/',
     steps: [
-      "Enroll in Apple Developer Program ($99/yr) + D-U-N-S (free, 1-2 days)",
-      "Accept all Paid Apps agreements in App Store Connect",
-      "Generate an App Store Connect API key (.p8 file) with Developer role",
-      "Run: sh1pt secret set APP_STORE_CONNECT_KEY_ID <id>",
-      "Run: sh1pt secret set APP_STORE_CONNECT_ISSUER_ID <uuid>",
+      'Enroll in Apple Developer Program ($99/yr) + D-U-N-S (free, 1-2 days)',
+      'Accept all Paid Apps agreements in App Store Connect',
+      'Generate an App Store Connect API key (.p8 file) with Developer role',
+      'Run: sh1pt secret set APP_STORE_CONNECT_KEY_ID <id>',
+      'Run: sh1pt secret set APP_STORE_CONNECT_ISSUER_ID <uuid>',
     ],
   }),
 });


### PR DESCRIPTION
Fixes #592.

Changes:
- validate mobile-ios bundleId as a reverse-DNS identifier before build or ship
- use the normalized bundleId for real ship IDs
- add regression tests for invalid bundleId values in build and ship flows

Validation:
- vitest run packages/targets/mobile-ios/src/index.test.ts
- tsc -p packages/targets/mobile-ios/tsconfig.json --noEmit