### PR TITLE
Validate Windows distribution mode

### DIFF
--- a/packages/targets/desktop-win/src/index.test.ts
+++ b/packages/targets/desktop-win/src/index.test.ts
@@ -1,4 +1,4 @@
-import { fakeBuildContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -83,5 +83,31 @@ describe('Windows desktop package planning', () => {
     const signCommand = plan.commands.find((command) => command.tool === 'signtool');
     expect(signCommand?.needsSigningCert).toBe(true);
     expect(signCommand?.args).toContain('<certificate-thumbprint>');
+  });
+
+  it('rejects unsupported distributions while building', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-desktop-win-'));
+    tempDirs.push(outDir);
+
+    await expect(adapter.build(fakeBuildContext({
+      outDir,
+      version: '1.0.0',
+      dryRun: true,
+    }) as any, {
+      appId: 'Acme.Tool',
+      publisherId: 'CN=publisher',
+      distribution: 'preview',
+    } as any)).rejects.toThrow('desktop-win distribution must be one of: msstore, msi, both');
+  });
+
+  it('rejects unsupported distributions while shipping', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      version: '1.0.0',
+      dryRun: true,
+    }) as any, {
+      appId: 'Acme.Tool',
+      publisherId: 'CN=publisher',
+      distribution: 'preview',
+    } as any)).rejects.toThrow('desktop-win distribution must be one of: msstore, msi, both');
   });
 });

--- a/packages/targets/desktop-win/src/index.ts
+++ b/packages/targets/desktop-win/src/index.ts
@@ -12,6 +12,7 @@ interface Config {
 }
 
 type WindowsArtifactKind = 'msixbundle' | 'msi';
+const DISTRIBUTIONS = ['msstore', 'msi', 'both'] as const;
 
 interface WindowsPackagePlan {
   appId: string;
@@ -34,15 +35,23 @@ function safeFileStem(value: string): string {
   return value.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-|-$/g, '') || 'windows-app';
 }
 
+function requireDistribution(config: Config): Config['distribution'] {
+  if (DISTRIBUTIONS.includes(config.distribution as Config['distribution'])) {
+    return config.distribution as Config['distribution'];
+  }
+  throw new Error(`desktop-win distribution must be one of: ${DISTRIBUTIONS.join(', ')}`);
+}
+
 function artifactKinds(distribution: Config['distribution']): WindowsArtifactKind[] {
   if (distribution === 'both') return ['msixbundle', 'msi'];
   return [distribution === 'msi' ? 'msi' : 'msixbundle'];
 }
 
 function buildPlan(ctx: { outDir: string; version: string }, config: Config): WindowsPackagePlan {
+  const distribution = requireDistribution(config);
   const architectures = config.architectures ?? ['x64', 'arm64'];
   const baseName = `${safeFileStem(config.appId)}-${safeFileStem(ctx.version)}`;
-  const artifacts = artifactKinds(config.distribution).map((kind) => ({
+  const artifacts = artifactKinds(distribution).map((kind) => ({
     kind,
     path: join(ctx.outDir, 'windows', `${baseName}.${kind}`),
   }));
@@ -92,7 +101,7 @@ function buildPlan(ctx: { outDir: string; version: string }, config: Config): Wi
     appId: config.appId,
     publisherId: config.publisherId,
     version: ctx.version,
-    distribution: config.distribution,
+    distribution,
     architectures,
     artifacts,
     commands,
@@ -121,10 +130,11 @@ export default defineTarget<Config>({
     //  - MSIX: makeappx pack + signtool sign using signingCertThumbprint
     //  - MSI: WiX toolset → .msi → signtool sign
     // Requires Windows runner; cloud builds route to a windows worker.
-    const ext = config.distribution === 'msi' ? 'msi' : 'msixbundle';
+    const ext = plan.distribution === 'msi' ? 'msi' : 'msixbundle';
     return { artifact: `${ctx.outDir}/app.${ext}` };
   },
   async ship(ctx, config) {
+    const distribution = requireDistribution(config);
     ctx.log(`publish ${config.appId}@${ctx.version} · distribution=${config.distribution}`);
     if (ctx.dryRun) return { id: 'dry-run' };
     // TODO:
@@ -132,7 +142,7 @@ export default defineTarget<Config>({
     //  - msi: upload to configured CDN/GitHub release + update winget manifest via pkg-winget
     return {
       id: `${config.appId}@${ctx.version}`,
-      url: config.distribution !== 'msi' ? `https://apps.microsoft.com/detail/${config.appId}` : undefined,
+      url: distribution !== 'msi' ? `https://apps.microsoft.com/detail/${config.appId}` : undefined,
     };
   },
   async status(id) {


### PR DESCRIPTION
Fixes #598.

Changes:
- validate desktop-win distribution at runtime before package planning or shipping
- keep generated artifact selection and store URL logic based on the validated distribution
- add regression tests for invalid distribution in build and dry-run ship flows

Validation:
- vitest run packages/targets/desktop-win/src/index.test.ts
- tsc -p packages/targets/desktop-win/tsconfig.json --noEmit