### PR TITLE
Validate SteamOS app identifiers

### DIFF
--- a/packages/targets/desktop-steamos/src/index.test.ts
+++ b/packages/targets/desktop-steamos/src/index.test.ts
@@ -1,4 +1,4 @@
-import { contractTestTarget, fakeBuildContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { contractTestTarget, fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -49,5 +49,28 @@ describe('SteamOS target planning', () => {
       selfHosted: { uploadTo: 'github-pages' },
       outputArtifact: 'com.acme.deckapp.flatpak',
     });
+  });
+
+  it('rejects invalid app identifiers while building', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-steamos-'));
+    tempDirs.push(outDir);
+
+    await expect(adapter.build(fakeBuildContext({
+      outDir,
+      version: '2.0.0',
+    }) as any, {
+      ...sampleConfig,
+      appId: '../deckapp',
+    })).rejects.toThrow('desktop-steamos appId must be a valid reverse-DNS identifier');
+  });
+
+  it('rejects invalid app identifiers while shipping', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      version: '2.0.0',
+      dryRun: false,
+    }) as any, {
+      ...sampleConfig,
+      appId: 'com.acme/deckapp',
+    })).rejects.toThrow('desktop-steamos appId must be a valid reverse-DNS identifier');
   });
 });

--- a/packages/targets/desktop-steamos/src/index.ts
+++ b/packages/targets/desktop-steamos/src/index.ts
@@ -25,28 +25,41 @@ interface Config {
   selfHosted?: { uploadTo: 'github-pages' | 'cdn' | 's3' };
 }
 
+const APP_ID_PATTERN = /^[A-Za-z][A-Za-z0-9-]*(\.[A-Za-z][A-Za-z0-9-]*)+$/;
+
+function requireAppId(config: Config): string {
+  const appId = config.appId?.trim();
+  if (!appId) throw new Error('desktop-steamos requires appId');
+  if (!APP_ID_PATTERN.test(appId)) {
+    throw new Error('desktop-steamos appId must be a valid reverse-DNS identifier');
+  }
+  return appId;
+}
+
 export default defineTarget<Config>({
   id: 'desktop-steamos',
   kind: 'desktop',
   label: 'SteamOS / Steam Deck (Desktop Mode / Flatpak)',
   async build(ctx, config) {
+    const appId = requireAppId(config);
     ctx.log(`flatpak-builder · appId=${config.appId}`);
     const artifactDir = join(ctx.outDir, 'steamos');
     const planPath = join(artifactDir, 'steamos-flatpak-plan.json');
     await mkdir(artifactDir, { recursive: true });
     await writeFile(planPath, `${JSON.stringify({
-      appId: config.appId,
+      appId,
       version: ctx.version,
       sourceDir: config.sourceDir,
       distribution: config.distribution,
       flatpakManifest: config.flatpakManifest,
       gamingModeLauncher: config.gamingModeLauncher,
       selfHosted: config.selfHosted,
-      outputArtifact: `${config.appId}.flatpak`,
+      outputArtifact: `${appId}.flatpak`,
     }, null, 2)}\n`, 'utf-8');
     return { artifact: planPath };
   },
   async ship(ctx, config) {
+    const appId = requireAppId(config);
     const dest = config.distribution === 'flathub' ? 'Flathub PR' : `self-hosted (${config.selfHosted?.uploadTo})`;
     ctx.log(`publish ${config.appId}@${ctx.version} → ${dest}`);
     if (ctx.dryRun) return { id: 'dry-run' };
@@ -54,8 +67,8 @@ export default defineTarget<Config>({
     //  - flathub:     open PR against flathub/flathub (like pkg-homebrew pattern)
     //  - self-hosted: sync repo dir with signed index to github-pages / cdn / s3
     return {
-      id: `${config.appId}@${ctx.version}`,
-      url: config.distribution === 'flathub' ? `https://flathub.org/apps/${config.appId}` : undefined,
+      id: `${appId}@${ctx.version}`,
+      url: config.distribution === 'flathub' ? `https://flathub.org/apps/${appId}` : undefined,
     };
   },
   async status(id) {


### PR DESCRIPTION
Fixes #600.

Changes:
- validate desktop-steamos appId as a reverse-DNS identifier before build or ship
- use the normalized appId in generated Flatpak plans, artifact names, Flathub URLs, and real ship IDs
- add regression tests for invalid appId values in build and ship flows

Validation:
- vitest run packages/targets/desktop-steamos/src/index.test.ts
- tsc -p packages/targets/desktop-steamos/tsconfig.json --noEmit