### PR TITLE
Validate Expo platform mode

### DIFF
--- a/packages/targets/mobile-expo/src/index.test.ts
+++ b/packages/targets/mobile-expo/src/index.test.ts
@@ -65,6 +65,24 @@ describe('mobile-expo target adapter', () => {
     });
   });
 
+  it('rejects unsupported platforms while building', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-expo-out-'));
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-expo-project-'));
+    tempDirs.push(outDir, projectDir);
+
+    await expect(adapter.build(fakeBuildContext({
+      outDir,
+      projectDir,
+      version: '1.2.3',
+      channel: 'beta',
+      dryRun: true,
+    }) as any, {
+      appId: '@acme/mobile-app',
+      platform: 'web',
+    } as any)).rejects.toThrow('mobile-expo platform must be one of: ios, android, all');
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
   it('runs EAS with argv args and writes build metadata for real builds', async () => {
     execMock.mockResolvedValue({ exitCode: 0, stdout: '{"buildId":"abc"}\n', stderr: '' });
 
@@ -163,5 +181,19 @@ describe('mobile-expo target adapter', () => {
       id: 'acme-mobile@1.2.3',
       url: 'https://expo.dev/accounts/acme-mobile',
     });
+  });
+
+  it('rejects unsupported platforms while shipping', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      projectDir: '/tmp/expo-app',
+      version: '1.2.3',
+      channel: 'stable',
+      dryRun: true,
+    }) as any, {
+      appId: 'acme-mobile',
+      platform: 'web',
+      submit: true,
+    } as any)).rejects.toThrow('mobile-expo platform must be one of: ios, android, all');
+    expect(execMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/targets/mobile-expo/src/index.ts
+++ b/packages/targets/mobile-expo/src/index.ts
@@ -9,6 +9,8 @@ interface Config {
   submit?: boolean;
 }
 
+const PLATFORMS = ['ios', 'android', 'all'] as const;
+
 interface EasCommand {
   command: 'eas';
   args: string[];
@@ -40,7 +42,11 @@ interface ExpoShipPlan {
 }
 
 function platform(config: Config): 'ios' | 'android' | 'all' {
-  return config.platform ?? 'all';
+  const selectedPlatform = config.platform ?? 'all';
+  if (PLATFORMS.includes(selectedPlatform as (typeof PLATFORMS)[number])) {
+    return selectedPlatform as 'ios' | 'android' | 'all';
+  }
+  throw new Error(`mobile-expo platform must be one of: ${PLATFORMS.join(', ')}`);
 }
 
 function profile(ctx: { channel: string }, config: Config): string {


### PR DESCRIPTION
Fixes #602.

Changes:
- validate mobile-expo platform at runtime before planning build or ship commands
- reject unsupported platform values before invoking EAS or writing dry-run plans
- add regression tests for invalid platform in build and ship flows

Validation:
- vitest run packages/targets/mobile-expo/src/index.test.ts
- tsc -p packages/targets/mobile-expo/tsconfig.json --noEmit