### PR TITLE
Validate Fly deploy strategies

### DIFF
--- a/packages/targets/deploy-fly/src/index.test.ts
+++ b/packages/targets/deploy-fly/src/index.test.ts
@@ -1,4 +1,17 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'deploy', requireKind: true });
+
+describe('Fly.io target adapter', () => {
+  it('rejects unsupported deployment strategies', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      channel: 'stable',
+      dryRun: true,
+    }) as any, {
+      app: 'acme-app',
+      strategy: 'preview',
+    } as any)).rejects.toThrow('deploy-fly strategy must be one of: rolling, canary, bluegreen, immediate');
+  });
+});

--- a/packages/targets/deploy-fly/src/index.ts
+++ b/packages/targets/deploy-fly/src/index.ts
@@ -7,6 +7,16 @@ interface Config {
   dockerfile?: string;
 }
 
+const STRATEGIES = ['rolling', 'canary', 'bluegreen', 'immediate'] as const;
+
+function deployStrategy(ctx: { channel: string }, config: Config): NonNullable<Config['strategy']> {
+  const selectedStrategy = config.strategy ?? (ctx.channel === 'stable' ? 'rolling' : 'canary');
+  if (STRATEGIES.includes(selectedStrategy as (typeof STRATEGIES)[number])) {
+    return selectedStrategy as NonNullable<Config['strategy']>;
+  }
+  throw new Error(`deploy-fly strategy must be one of: ${STRATEGIES.join(', ')}`);
+}
+
 export default defineTarget<Config>({
   id: 'deploy-fly',
   kind: 'web',
@@ -16,7 +26,7 @@ export default defineTarget<Config>({
     return { artifact: `${ctx.outDir}/fly-image` };
   },
   async ship(ctx, config) {
-    const strategy = config.strategy ?? (ctx.channel === 'stable' ? 'rolling' : 'canary');
+    const strategy = deployStrategy(ctx, config);
     ctx.log(`flyctl deploy · app=${config.app} · strategy=${strategy}`);
 
     if (ctx.dryRun) return { id: 'dry-run' };


### PR DESCRIPTION
Fixes #604.

Changes:
- validate deploy-fly strategy at runtime before dry-run or real deployments
- reject unsupported strategy values before flyctl command construction
- add a regression test for invalid strategy values

Validation:
- vitest run packages/targets/deploy-fly/src/index.test.ts
- tsc -p packages/targets/deploy-fly/tsconfig.json --noEmit