### PR TITLE
Validate Firefox publish channels

### DIFF
--- a/packages/targets/browser-firefox/src/index.test.ts
+++ b/packages/targets/browser-firefox/src/index.test.ts
@@ -1,4 +1,4 @@
-import { fakeBuildContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -105,5 +105,32 @@ describe('browser-firefox target adapter', () => {
       throwOnNonZero: true,
     });
     expect(result).toEqual({ artifact });
+  });
+
+  it('rejects unsupported channels while planning dry-run builds', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-firefox-out-'));
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-firefox-project-'));
+    tempDirs.push(outDir, projectDir);
+
+    await expect(adapter.build(fakeBuildContext({
+      outDir,
+      projectDir,
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      extensionId: 'myext@example.com',
+      channel: 'preview',
+    } as any)).rejects.toThrow('browser-firefox channel must be one of: listed, unlisted');
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported channels while shipping', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      extensionId: 'myext@example.com',
+      channel: 'preview',
+    } as any)).rejects.toThrow('browser-firefox channel must be one of: listed, unlisted');
   });
 });

--- a/packages/targets/browser-firefox/src/index.ts
+++ b/packages/targets/browser-firefox/src/index.ts
@@ -8,6 +8,8 @@ interface Config {
   channel?: 'listed' | 'unlisted';
 }
 
+const CHANNELS = ['listed', 'unlisted'] as const;
+
 interface FirefoxPackagePlan {
   provider: 'mozilla-addons';
   extensionId: string;
@@ -39,19 +41,28 @@ function artifactPath(ctx: { outDir: string; version: string }, config: Config):
   return join(ctx.outDir, artifactName(ctx, config));
 }
 
+function channel(config: Config): NonNullable<Config['channel']> {
+  const selectedChannel = config.channel ?? 'listed';
+  if (CHANNELS.includes(selectedChannel as (typeof CHANNELS)[number])) {
+    return selectedChannel as NonNullable<Config['channel']>;
+  }
+  throw new Error(`browser-firefox channel must be one of: ${CHANNELS.join(', ')}`);
+}
+
 function packagePlan(
   ctx: { projectDir: string; outDir: string; version: string },
   config: Config,
 ): FirefoxPackagePlan {
   const src = sourceDir(ctx, config);
   const filename = artifactName(ctx, config);
+  const selectedChannel = channel(config);
   return {
     provider: 'mozilla-addons',
     extensionId: config.extensionId,
     version: ctx.version,
     sourceDir: src,
     artifact: join(ctx.outDir, filename),
-    channel: config.channel ?? 'listed',
+    channel: selectedChannel,
     build: {
       command: 'web-ext',
       args: ['build', '--source-dir', src, '--artifacts-dir', ctx.outDir, '--filename', filename],
@@ -101,11 +112,11 @@ export default defineTarget<Config>({
     return { artifact: artifactPath(ctx, config) };
   },
   async ship(ctx, config) {
-    const channel = config.channel ?? 'listed';
-    ctx.log(`sign + submit ${config.extensionId} to AMO (channel: ${channel})`);
+    const selectedChannel = channel(config);
+    ctx.log(`sign + submit ${config.extensionId} to AMO (channel: ${selectedChannel})`);
     if (ctx.dryRun) return { id: 'dry-run' };
     // TODO: web-ext sign --api-key=${AMO_JWT_ISSUER} --api-secret=${AMO_JWT_SECRET}
-    //       --channel=${channel} --source-dir ${config.sourceDir ?? 'dist/'}
+    //       --channel=${selectedChannel} --source-dir ${config.sourceDir ?? 'dist/'}
     // Or: POST https://addons.mozilla.org/api/v5/addons/<id>/versions/ with JWT auth
     return {
       id: `${config.extensionId}@${ctx.version}`,


### PR DESCRIPTION
Fixes #606.

Changes:
- validate browser-firefox channel at runtime before package planning or shipping
- keep package plans and ship logging constrained to listed/unlisted AMO channels
- add regression tests for invalid channel in dry-run build and ship flows

Validation:
- vitest run packages/targets/browser-firefox/src/index.test.ts
- tsc -p packages/targets/browser-firefox/tsconfig.json --noEmit