### PR TITLE
Validate Telegram webhook and command config

### DIFF
--- a/packages/targets/chat-telegram/src/index.test.ts
+++ b/packages/targets/chat-telegram/src/index.test.ts
@@ -72,11 +72,40 @@ describe('chat-telegram API calls', () => {
     })).rejects.toThrow('TELEGRAM_BOT_TOKEN not in vault');
   });
 
+  it('rejects invalid webhook URLs before writing dry-run artifacts', async () => {
+    const ctx = fakeBuildContext({ outDir: '/tmp/sh1pt-out' });
+
+    await expect(adapter.build(ctx as any, {
+      botUsername: 'demo_bot',
+      webhookUrl: 'http://example.com/telegram',
+    })).rejects.toThrow('webhookUrl must be a valid HTTPS URL');
+  });
+
+  it('rejects invalid commands before dry-run shipping', async () => {
+    const ctx = fakeShipContext({ dryRun: true });
+
+    await expect(adapter.ship(ctx as any, {
+      botUsername: 'demo_bot',
+      webhookUrl: 'https://example.com/telegram',
+      commands: [{ command: '/bad command', description: 'Bad command' }],
+    })).rejects.toThrow('command must be 1-32 lowercase letters');
+  });
+
+  it('rejects empty command descriptions before dry-run shipping', async () => {
+    const ctx = fakeShipContext({ dryRun: true });
+
+    await expect(adapter.ship(ctx as any, {
+      botUsername: 'demo_bot',
+      webhookUrl: 'https://example.com/telegram',
+      commands: [{ command: '/start', description: ' ' }],
+    })).rejects.toThrow('requires description');
+  });
+
   it('surfaces Telegram API errors', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: false,
       status: 400,
-      json: async () => ({ ok: false, description: 'Bad Request: invalid webhook url' }),
+      json: async () => ({ ok: false, description: 'Bad Request: webhook host not reachable' }),
     } as any);
 
     const ctx = fakeShipContext({
@@ -86,7 +115,7 @@ describe('chat-telegram API calls', () => {
 
     await expect(adapter.ship(ctx as any, {
       botUsername: 'demo_bot',
-      webhookUrl: 'not-a-url',
-    })).rejects.toThrow('Bad Request: invalid webhook url');
+      webhookUrl: 'https://example.com/telegram',
+    })).rejects.toThrow('Bad Request: webhook host not reachable');
   });
 });

--- a/packages/targets/chat-telegram/src/index.ts
+++ b/packages/targets/chat-telegram/src/index.ts
@@ -32,11 +32,14 @@ export default defineTarget<Config>({
   label: 'Telegram Bot',
   async build(ctx, config) {
     const username = normalizeUsername(config.botUsername);
+    requireWebhookUrl(config.webhookUrl);
     ctx.log(`telegram prepare bot manifest for @${username}`);
     return { artifact: join(ctx.outDir, `telegram-${safeFilename(username)}.json`) };
   },
   async ship(ctx, config) {
     const username = normalizeUsername(config.botUsername);
+    const webhookUrl = requireWebhookUrl(config.webhookUrl);
+    const commands = config.commands?.map(normalizeCommand) ?? [];
     ctx.log(`telegram setWebhook + setMyCommands for @${username}`);
     if (ctx.dryRun) return { id: 'dry-run' };
 
@@ -45,13 +48,13 @@ export default defineTarget<Config>({
     if (!token) throw new Error(`${tokenKey} not in vault - run: sh1pt secret set ${tokenKey} <bot-token>`);
 
     await callTelegram(ctx.log, token, 'setWebhook', {
-      url: config.webhookUrl,
+      url: webhookUrl,
       ...(config.webhookSecretKey ? { secret_token: requireSecret(ctx, config.webhookSecretKey) } : {}),
     });
 
-    if (config.commands?.length) {
+    if (commands.length) {
       await callTelegram(ctx.log, token, 'setMyCommands', {
-        commands: config.commands.map(normalizeCommand),
+        commands,
       });
     }
 
@@ -106,14 +109,33 @@ function normalizeUsername(username: string): string {
   return clean;
 }
 
+function requireWebhookUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('chat-telegram webhookUrl must be a valid HTTPS URL');
+  }
+  if (url.protocol !== 'https:' || !url.hostname) {
+    throw new Error('chat-telegram webhookUrl must be a valid HTTPS URL');
+  }
+  return url.toString();
+}
+
 function safeFilename(value: string): string {
   return value.replace(/[^a-zA-Z0-9_-]/g, '_');
 }
 
 function normalizeCommand(command: TelegramCommand): TelegramCommand {
+  const name = command.command.replace(/^\//, '').trim().toLowerCase();
+  if (!/^[a-z0-9_]{1,32}$/.test(name)) {
+    throw new Error('chat-telegram command must be 1-32 lowercase letters, digits, or underscores');
+  }
+  const description = command.description.trim();
+  if (!description) throw new Error(`chat-telegram command "${name}" requires description`);
   return {
-    command: command.command.replace(/^\//, ''),
-    description: command.description,
+    command: name,
+    description,
   };
 }
 


### PR DESCRIPTION
Fixes #612.

Changes:
- validate webhookUrl as an HTTPS URL before build or ship
- validate Telegram command names and non-empty descriptions before dry-run or real shipping
- reuse normalized command payloads for API calls
- add regression tests for invalid webhook URLs, commands, and remote API errors

Validation:
- vitest run packages/targets/chat-telegram/src/index.test.ts
- tsc -p packages/targets/chat-telegram/tsconfig.json --noEmit