### PR TITLE
Validate Slack manifest runtime config

### DIFF
--- a/packages/targets/chat-slack/src/index.test.ts
+++ b/packages/targets/chat-slack/src/index.test.ts
@@ -70,4 +70,46 @@ describe('Slack app manifest generation', () => {
       scopes: { bot: ['chat:write'] },
     })).resolves.toEqual({ id: 'dry-run' });
   });
+
+  it('rejects invalid request URLs before writing manifests', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-slack-'));
+    tempDirs.push(outDir);
+
+    await expect(adapter.build(fakeBuildContext({ outDir }) as any, {
+      appId: 'A123456',
+      clientId: '123.456',
+      distribution: 'workspace',
+      requestUrl: 'http://example.com/slack/events',
+      scopes: { bot: ['chat:write'] },
+    })).rejects.toThrow('requestUrl must be a valid HTTPS URL');
+  });
+
+  it('rejects unsupported distributions in dry-run shipping', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      appId: 'A123456',
+      clientId: '123.456',
+      distribution: 'public-directory',
+      requestUrl: 'https://example.com/slack/events',
+      scopes: { bot: ['chat:write'] },
+    } as any)).rejects.toThrow('distribution must be one of');
+  });
+
+  it('rejects invalid slash command config in dry-run shipping', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      appId: 'A123456',
+      clientId: '123.456',
+      distribution: 'workspace',
+      requestUrl: 'https://example.com/slack/events',
+      slashCommands: [
+        { command: 'ship now', url: 'https://example.com/slack/commands', description: 'Ship' },
+      ],
+      scopes: { bot: ['commands'] },
+    } as any)).rejects.toThrow('slash command must start with /');
+  });
 });

--- a/packages/targets/chat-slack/src/index.ts
+++ b/packages/targets/chat-slack/src/index.ts
@@ -19,12 +19,51 @@ interface Config {
   scopes: { bot?: string[]; user?: string[] };
 }
 
+const DISTRIBUTIONS = ['workspace', 'directory'] as const;
+
 function yamlString(value: string): string {
   return JSON.stringify(value);
 }
 
+function requireDistribution(config: Config): Config['distribution'] {
+  const distribution = String(config.distribution ?? '').trim();
+  if (!DISTRIBUTIONS.includes(distribution as Config['distribution'])) {
+    throw new Error(`chat-slack distribution must be one of: ${DISTRIBUTIONS.join(', ')}`);
+  }
+  return distribution as Config['distribution'];
+}
+
+function requireHttpsUrl(value: string | undefined, field: string): string {
+  let url: URL;
+  try {
+    url = new URL(value ?? '');
+  } catch {
+    throw new Error(`chat-slack ${field} must be a valid HTTPS URL`);
+  }
+  if (url.protocol !== 'https:' || !url.hostname) {
+    throw new Error(`chat-slack ${field} must be a valid HTTPS URL`);
+  }
+  return url.toString();
+}
+
 function renderList(values: string[], indent: string): string[] {
   return values.map((value) => `${indent}- ${yamlString(value)}`);
+}
+
+function normalizeSlashCommands(commands: Config['slashCommands']): NonNullable<Config['slashCommands']> {
+  return (commands ?? []).map((command) => {
+    const name = command.command.trim();
+    if (!/^\/[a-z0-9_-]+$/.test(name)) {
+      throw new Error('chat-slack slash command must start with / and contain only lowercase letters, digits, underscores, or hyphens');
+    }
+    const description = command.description.trim();
+    if (!description) throw new Error(`chat-slack slash command "${name}" requires description`);
+    return {
+      command: name,
+      url: requireHttpsUrl(command.url, `slash command ${name} url`),
+      description,
+    };
+  });
 }
 
 function renderSlashCommands(commands: NonNullable<Config['slashCommands']>): string[] {
@@ -36,6 +75,9 @@ function renderSlashCommands(commands: NonNullable<Config['slashCommands']>): st
 }
 
 function renderSlackManifest(config: Config): string {
+  const distribution = requireDistribution(config);
+  const requestUrl = requireHttpsUrl(config.requestUrl, 'requestUrl');
+  const slashCommands = normalizeSlashCommands(config.slashCommands);
   const appName = config.name ?? config.appId;
   const botDisplayName = config.botDisplayName ?? appName;
   const botScopes = config.scopes.bot ?? [];
@@ -55,9 +97,9 @@ function renderSlackManifest(config: Config): string {
   lines.push(`    display_name: ${yamlString(botDisplayName)}`);
   lines.push('    always_online: false');
 
-  if (config.slashCommands?.length) {
+  if (slashCommands.length) {
     lines.push('  slash_commands:');
-    lines.push(...renderSlashCommands(config.slashCommands));
+    lines.push(...renderSlashCommands(slashCommands));
   }
 
   lines.push('oauth_config:');
@@ -76,7 +118,7 @@ function renderSlackManifest(config: Config): string {
 
   lines.push('settings:');
   lines.push('  event_subscriptions:');
-  lines.push(`    request_url: ${yamlString(config.requestUrl)}`);
+  lines.push(`    request_url: ${yamlString(requestUrl)}`);
 
   if (botEvents.length) {
     lines.push('    bot_events:');
@@ -85,8 +127,8 @@ function renderSlackManifest(config: Config): string {
 
   lines.push('  interactivity:');
   lines.push('    is_enabled: true');
-  lines.push(`    request_url: ${yamlString(config.requestUrl)}`);
-  lines.push(`  org_deploy_enabled: ${config.distribution === 'directory' ? 'true' : 'false'}`);
+  lines.push(`    request_url: ${yamlString(requestUrl)}`);
+  lines.push(`  org_deploy_enabled: ${distribution === 'directory' ? 'true' : 'false'}`);
   lines.push('  socket_mode_enabled: false');
   lines.push('  token_rotation_enabled: false');
   lines.push('');
@@ -105,7 +147,10 @@ export default defineTarget<Config>({
     return { artifact: manifestPath };
   },
   async ship(ctx, config) {
-    const dest = config.distribution === 'directory' ? 'App Directory (review queue)' : 'workspace (no review)';
+    const distribution = requireDistribution(config);
+    requireHttpsUrl(config.requestUrl, 'requestUrl');
+    normalizeSlashCommands(config.slashCommands);
+    const dest = distribution === 'directory' ? 'App Directory (review queue)' : 'workspace (no review)';
     ctx.log(`slack · push app manifest → ${dest}`);
     if (ctx.dryRun) return { id: 'dry-run' };
     // TODO: apps.manifest.update via app-level token, then apps.submit for directory


### PR DESCRIPTION
Fixes #614.

Changes:
- validate Slack distribution at runtime before manifest generation or shipping
- validate requestUrl and slash command URLs as HTTPS URLs
- validate slash command names/descriptions before dry-run or real shipping
- add regression tests for invalid request URL, distribution, and slash command config

Validation:
- vitest run packages/targets/chat-slack/src/index.test.ts
- tsc -p packages/targets/chat-slack/tsconfig.json --noEmit