### PR TITLE
Validate Adyen payment arguments

### DIFF
--- a/packages/targets/payment-adyen/src/index.test.ts
+++ b/packages/targets/payment-adyen/src/index.test.ts
@@ -1,7 +1,158 @@
-import { describe, it, expect } from 'vitest';
-describe('payment-adyen', () => {
-  it('should have correct metadata', () => {
+import { fakeBuildContext, makeVault } from '@profullstack/sh1pt-core/testing';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import target from './index.js';
+
+describe('payment-adyen target adapter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('has correct package metadata', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const pkg = require('../package.json');
     expect(pkg.name).toBe('@profullstack/sh1pt-target-payment-adyen');
+  });
+
+  it('creates payments with validated amount and currency', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ resultCode: 'RedirectShopper' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await target.build(fakeBuildContext({
+      secret: makeVault({
+        ADYEN_API_KEY: 'adyen-key',
+        ADYEN_MERCHANT_ACCOUNT: 'merchant-account',
+      }),
+    }) as any, {
+      command: 'payment',
+      args: { amount: 1500, currency: 'usd' },
+    });
+
+    expect(result).toEqual({
+      artifact: 'adyen-payment-create',
+      meta: { raw: JSON.stringify({ resultCode: 'RedirectShopper' }) },
+    });
+    expect(fetchMock).toHaveBeenCalledWith('https://checkout-test.adyen.com/v71/payments', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({
+        'X-API-Key': 'adyen-key',
+        'Content-Type': 'application/json',
+      }),
+    }));
+    const body = JSON.parse(String(fetchMock.mock.calls[0]![1].body));
+    expect(body).toMatchObject({
+      amount: { value: 1500, currency: 'USD' },
+      merchantAccount: 'merchant-account',
+      channel: 'web',
+    });
+  });
+
+  it('rejects invalid payment amounts before calling Adyen', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(target.build(fakeBuildContext({
+      secret: makeVault({
+        ADYEN_API_KEY: 'adyen-key',
+        ADYEN_MERCHANT_ACCOUNT: 'merchant-account',
+      }),
+    }) as any, {
+      command: 'payment',
+      args: { amount: 0, currency: 'USD' },
+    })).rejects.toThrow('amount must be a positive integer');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid currencies before calling Adyen', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(target.build(fakeBuildContext({
+      secret: makeVault({
+        ADYEN_API_KEY: 'adyen-key',
+        ADYEN_MERCHANT_ACCOUNT: 'merchant-account',
+      }),
+    }) as any, {
+      command: 'payment',
+      args: { amount: 1500, currency: 'US' },
+    })).rejects.toThrow('currency must be a three-letter ISO code');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('requires pspReference for capture, refund, and cancel commands', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const ctx = fakeBuildContext({
+      secret: makeVault({
+        ADYEN_API_KEY: 'adyen-key',
+        ADYEN_MERCHANT_ACCOUNT: 'merchant-account',
+      }),
+    }) as any;
+
+    await expect(target.build(ctx, {
+      command: 'capture',
+      args: { pspReference: '  ' },
+    })).rejects.toThrow('pspReference required');
+
+    await expect(target.build(ctx, {
+      command: 'refund',
+      args: {},
+    })).rejects.toThrow('pspReference required');
+
+    await expect(target.build(ctx, {
+      command: 'cancel',
+      args: {},
+    })).rejects.toThrow('pspReference required');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('validates optional capture amount before calling Adyen', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(target.build(fakeBuildContext({
+      secret: makeVault({
+        ADYEN_API_KEY: 'adyen-key',
+        ADYEN_MERCHANT_ACCOUNT: 'merchant-account',
+      }),
+    }) as any, {
+      command: 'capture',
+      args: { pspReference: 'psp_123', amount: 1.5, currency: 'USD' },
+    })).rejects.toThrow('amount must be a positive integer');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('checks all payment status when no pspReference is supplied', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ payments: [] }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await target.build(fakeBuildContext({
+      secret: makeVault({
+        ADYEN_API_KEY: 'adyen-key',
+        ADYEN_MERCHANT_ACCOUNT: 'merchant-account',
+      }),
+    }) as any, {
+      command: 'status',
+      args: {},
+    });
+
+    expect(result).toEqual({
+      artifact: 'adyen-payment-status',
+      meta: { raw: JSON.stringify({ payments: [] }) },
+    });
+    expect(fetchMock).toHaveBeenCalledWith('https://checkout-test.adyen.com/v71/payments', expect.any(Object));
   });
 });

--- a/packages/targets/payment-adyen/src/index.ts
+++ b/packages/targets/payment-adyen/src/index.ts
@@ -10,6 +10,34 @@ interface AdyenError {
   message?: string;
 }
 
+function requireText(value: unknown, name: string): string {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${name} required`);
+  return value.trim();
+}
+
+function requireSecret(value: string | undefined, name: string): string {
+  if (!value) throw new Error(`${name} not set`);
+  return value;
+}
+
+function requirePositiveInteger(value: unknown, name: string): number {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function requireCurrency(value: unknown): string {
+  const currency = typeof value === 'string' ? value.trim().toUpperCase() : 'USD';
+  if (!/^[A-Z]{3}$/.test(currency)) throw new Error('currency must be a three-letter ISO code');
+  return currency;
+}
+
+function optionalAmount(value: unknown, currency: unknown): { value: number; currency: string } | undefined {
+  if (value === undefined) return undefined;
+  return { value: requirePositiveInteger(value, 'amount'), currency: requireCurrency(currency) };
+}
+
 export default defineTarget<Config>({
   id: 'payment-adyen',
   kind: 'payment',
@@ -17,10 +45,8 @@ export default defineTarget<Config>({
 
   async build(ctx, config) {
     const cmd = config.command || 'status';
-    const key = ctx.secret('ADYEN_API_KEY');
-    const merchant = ctx.secret('ADYEN_MERCHANT_ACCOUNT');
-    if (!key) throw new Error('ADYEN_API_KEY not set');
-    if (!merchant) throw new Error('ADYEN_MERCHANT_ACCOUNT not set');
+    const key = requireSecret(ctx.secret('ADYEN_API_KEY'), 'ADYEN_API_KEY');
+    const merchant = requireSecret(ctx.secret('ADYEN_MERCHANT_ACCOUNT'), 'ADYEN_MERCHANT_ACCOUNT');
     const base = 'https://checkout-test.adyen.com/v71';
 
     async function adyen(path: string, init?: RequestInit) {
@@ -42,8 +68,8 @@ export default defineTarget<Config>({
 
     switch (cmd) {
       case 'payment': {
-        const amount = config.args?.amount as number || 0;
-        const currency = config.args?.currency as string || 'USD';
+        const amount = requirePositiveInteger(config.args?.amount, 'amount');
+        const currency = requireCurrency(config.args?.currency);
         const ref = `sh1pt-${Date.now()}`;
         ctx.log(`adyen: creating payment of ${amount} ${currency}`);
         const data = await adyen('/payments', {
@@ -56,44 +82,46 @@ export default defineTarget<Config>({
             returnUrl: 'https://sh1pt.com/adyen/redirect',
           }),
         });
-        return { output: JSON.stringify(data) };
+        return { artifact: 'adyen-payment-create', meta: { raw: JSON.stringify(data) } };
       }
       case 'capture': {
-        const psp = config.args?.pspReference as string || '';
+        const psp = requireText(config.args?.pspReference, 'pspReference');
+        const amount = optionalAmount(config.args?.amount, config.args?.currency);
         ctx.log(`adyen: capturing ${psp}`);
         const data = await adyen(`/payments/${psp}/captures`, {
           method: 'POST',
           body: JSON.stringify({
             merchantAccount: merchant,
-            amount: config.args?.amount ? { value: config.args.amount as number, currency: (config.args?.currency as string) || 'USD' } : undefined,
+            amount,
           }),
         });
-        return { output: JSON.stringify(data) };
+        return { artifact: 'adyen-payment-capture', meta: { raw: JSON.stringify(data) } };
       }
       case 'refund': {
-        const psp = config.args?.pspReference as string || '';
+        const psp = requireText(config.args?.pspReference, 'pspReference');
+        const amount = optionalAmount(config.args?.amount, config.args?.currency);
         ctx.log(`adyen: refunding ${psp}`);
         const data = await adyen(`/payments/${psp}/refunds`, {
           method: 'POST',
-          body: JSON.stringify({ merchantAccount: merchant, amount: config.args?.amount }),
+          body: JSON.stringify({ merchantAccount: merchant, amount }),
         });
-        return { output: JSON.stringify(data) };
+        return { artifact: 'adyen-payment-refund', meta: { raw: JSON.stringify(data) } };
       }
       case 'cancel': {
-        const psp = config.args?.pspReference as string || '';
+        const psp = requireText(config.args?.pspReference, 'pspReference');
         ctx.log(`adyen: canceling ${psp}`);
         const data = await adyen(`/payments/${psp}/cancels`, {
           method: 'POST',
           body: JSON.stringify({ merchantAccount: merchant }),
         });
-        return { output: JSON.stringify(data) };
+        return { artifact: 'adyen-payment-cancel', meta: { raw: JSON.stringify(data) } };
       }
       case 'status': {
-        const psp = config.args?.pspReference as string || '';
+        const psp = typeof config.args?.pspReference === 'string' ? config.args.pspReference.trim() : '';
         ctx.log(`adyen: checking status of ${psp || 'all'}`);
         const endpoint = psp ? `/payments/${psp}` : '/payments';
         const data = await adyen(endpoint);
-        return { output: JSON.stringify(data) };
+        return { artifact: 'adyen-payment-status', meta: { raw: JSON.stringify(data) } };
       }
       default:
         throw new Error(`Unknown command: ${cmd}`);
@@ -103,7 +131,7 @@ export default defineTarget<Config>({
   async ship(ctx, _config) {
     ctx.log('adyen: verifying setup');
     if (!ctx.secret('ADYEN_API_KEY') || !ctx.secret('ADYEN_MERCHANT_ACCOUNT')) {
-      return setupGuide({
+      const setup = setupGuide({
         title: 'Adyen API Key & Merchant Account',
         steps: [
           '1. Go to https://ca-test.adyen.com (test) or https://ca-live.adyen.com (live)',
@@ -112,7 +140,8 @@ export default defineTarget<Config>({
           '4. Run: sh1pt secret set ADYEN_MERCHANT_ACCOUNT <account>',
         ],
       });
+      return { id: 'setup-required', meta: { setup } };
     }
-    return { status: 'ready' };
+    return { id: 'ready', meta: { status: 'ready' } };
   },
 });


### PR DESCRIPTION
Fixes #626.

Changes:
- validate Adyen payment amount as a positive integer
- normalize and validate three-letter currency codes
- require pspReference for capture, refund, and cancel commands
- validate optional capture/refund amount objects before network calls
- return contract-compliant BuildResult and ShipResult shapes
- add unit tests proving invalid configs do not call Adyen

Validation:
- vitest run packages/targets/payment-adyen/src/index.test.ts
- tsc -p packages/targets/payment-adyen/tsconfig.json --noEmit