### PR TITLE
Validate Chrome extension config

### DIFF
--- a/packages/targets/browser-chrome/src/index.test.ts
+++ b/packages/targets/browser-chrome/src/index.test.ts
@@ -86,12 +86,12 @@ describe('browser-chrome target adapter', () => {
     expect(result).toEqual({ artifact });
   });
 
-  it('keeps extension IDs with path separators inside the output directory', async () => {
+  it('rejects Chrome extension IDs that are blank or not URL path segments', async () => {
     const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-chrome-out-'));
     const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-chrome-project-'));
     tempDirs.push(outDir, projectDir);
 
-    const result = await adapter.build(fakeBuildContext({
+    await expect(adapter.build(fakeBuildContext({
       outDir,
       projectDir,
       version: '1.2.3',
@@ -99,11 +99,34 @@ describe('browser-chrome target adapter', () => {
     }) as any, {
       extensionId: '../chrome-extension',
       sourceDir: 'extension-dist',
-    });
+    })).rejects.toThrow('extensionId must be a single URL path segment');
 
-    const plan = JSON.parse(await readFile(result.artifact, 'utf-8'));
-    expect(plan.extensionId).toBe('../chrome-extension');
-    expect(plan.artifact).toBe(join(outDir, 'chrome-extension-1.2.3.zip'));
-    expect(plan.command).toEqual(['zip', '-r', join(outDir, 'chrome-extension-1.2.3.zip'), '.']);
+    await expect(adapter.build(fakeBuildContext({
+      outDir,
+      projectDir,
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      extensionId: '   ',
+      sourceDir: 'extension-dist',
+    })).rejects.toThrow('browser-chrome requires extensionId');
+
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects blank source directories before packaging', async () => {
+    const outDir = await mkdtemp(join(tmpdir(), 'sh1pt-chrome-out-'));
+    const projectDir = await mkdtemp(join(tmpdir(), 'sh1pt-chrome-project-'));
+    tempDirs.push(outDir, projectDir);
+
+    await expect(adapter.build(fakeBuildContext({
+      outDir,
+      projectDir,
+      version: '1.2.3',
+      dryRun: true,
+    }) as any, {
+      extensionId: 'chrome-extension',
+      sourceDir: '   ',
+    })).rejects.toThrow('browser-chrome requires sourceDir');
   });
 });

--- a/packages/targets/browser-chrome/src/index.ts
+++ b/packages/targets/browser-chrome/src/index.ts
@@ -8,8 +8,28 @@ interface Config {
   deployPercent?: number;
 }
 
+function requireText(value: string | undefined, name: string): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`browser-chrome requires ${name}`);
+  }
+  return value.trim();
+}
+
+function optionalText(value: string | undefined, name: string): string | undefined {
+  if (value === undefined) return undefined;
+  return requireText(value, name);
+}
+
+function requireExtensionId(value: string | undefined): string {
+  const extensionId = requireText(value, 'extensionId');
+  if (/[\\/?#\x00-\x1F\x7F]/.test(extensionId)) {
+    throw new Error('browser-chrome extensionId must be a single URL path segment');
+  }
+  return extensionId;
+}
+
 function sourceDir(ctx: { projectDir: string }, config: Config): string {
-  const dir = config.sourceDir ?? 'dist';
+  const dir = optionalText(config.sourceDir, 'sourceDir') ?? 'dist';
   return isAbsolute(dir) ? dir : join(ctx.projectDir, dir);
 }
 
@@ -21,15 +41,16 @@ function safeFileStem(value: string): string {
 }
 
 function packageArtifact(ctx: { outDir: string; version: string }, config: Config): string {
-  return join(ctx.outDir, `${safeFileStem(config.extensionId)}-${safeFileStem(ctx.version)}.zip`);
+  return join(ctx.outDir, `${safeFileStem(requireExtensionId(config.extensionId))}-${safeFileStem(ctx.version)}.zip`);
 }
 
 function packagePlan(ctx: { projectDir: string; outDir: string; version: string }, config: Config) {
+  const extensionId = requireExtensionId(config.extensionId);
   const src = sourceDir(ctx, config);
   const artifact = packageArtifact(ctx, config);
   return {
     provider: 'chrome-web-store',
-    extensionId: config.extensionId,
+    extensionId,
     version: ctx.version,
     sourceDir: src,
     artifact,
@@ -43,10 +64,11 @@ export default defineTarget<Config>({
   kind: 'browser-ext',
   label: 'Chrome Web Store',
   async build(ctx, config) {
+    const extensionId = requireExtensionId(config.extensionId);
     const src = sourceDir(ctx, config);
     const zipPath = packageArtifact(ctx, config);
 
-    ctx.log(`pack Chrome extension from ${src} for v${ctx.version}`);
+    ctx.log(`pack Chrome extension ${extensionId} from ${src} for v${ctx.version}`);
 
     if (ctx.dryRun) {
       const planPath = join(ctx.outDir, 'chrome-package.json');
@@ -78,12 +100,13 @@ export default defineTarget<Config>({
     return { artifact: zipPath };
   },
   async ship(ctx, config) {
-    ctx.log(`upload + publish extension ${config.extensionId}`);
+    const extensionId = requireExtensionId(config.extensionId);
+    ctx.log(`upload + publish extension ${extensionId}`);
     if (ctx.dryRun) return { id: 'dry-run' };
     // TODO: Chrome Web Store Publish API w/ refresh token
     return {
-      id: `${config.extensionId}@${ctx.version}`,
-      url: `https://chrome.google.com/webstore/detail/${config.extensionId}`,
+      id: `${extensionId}@${ctx.version}`,
+      url: `https://chrome.google.com/webstore/detail/${extensionId}`,
     };
   },
 


### PR DESCRIPTION
Fixes #632.

Changes:
- require browser-chrome extensionId before package or publish work starts
- reject extension IDs that are not single URL path segments
- trim and validate optional sourceDir text
- use the normalized extensionId consistently in plans, logs, and publish result URLs
- add regression tests proving invalid config fails before zip work

Validation:
- vitest run packages/targets/browser-chrome/src/index.test.ts
- tsc -p packages/targets/browser-chrome/tsconfig.json --noEmit