### PR TITLE
Validate Vercel deploy config

### DIFF
--- a/packages/targets/deploy-vercel/src/index.test.ts
+++ b/packages/targets/deploy-vercel/src/index.test.ts
@@ -65,6 +65,24 @@ describe('Vercel deployment target', () => {
     });
   });
 
+  it('rejects invalid Vercel config before plan or CLI work', async () => {
+    await expect(adapter.build(fakeBuildContext() as any, {
+      dir: '   ',
+    })).rejects.toThrow('deploy-vercel requires dir');
+
+    await expect(adapter.ship(fakeShipContext({
+      dryRun: true,
+    }) as any, {
+      project: 'bad/project',
+    })).rejects.toThrow('project must contain only letters');
+
+    await expect(adapter.ship(fakeShipContext({
+      dryRun: true,
+    }) as any, {
+      org: 'bad org',
+    })).rejects.toThrow('org must contain only letters');
+  });
+
   it('requires a vault token for real deployments', async () => {
     await expect(adapter.ship(fakeShipContext({
       dryRun: false,

--- a/packages/targets/deploy-vercel/src/index.ts
+++ b/packages/targets/deploy-vercel/src/index.ts
@@ -9,12 +9,41 @@ interface Config {
   dir?: string;
 }
 
+function requireText(value: string | undefined, field: string): string {
+  const text = value?.trim();
+  if (!text) throw new Error(`deploy-vercel requires ${field}`);
+  return text;
+}
+
+function optionalText(value: string | undefined, field: string): string | undefined {
+  return value === undefined ? undefined : requireText(value, field);
+}
+
+function optionalSlug(value: string | undefined, field: string): string | undefined {
+  const slug = optionalText(value, field);
+  if (slug && !/^[A-Za-z0-9._-]+$/.test(slug)) {
+    throw new Error(`deploy-vercel ${field} must contain only letters, numbers, dots, underscores, or hyphens`);
+  }
+  return slug;
+}
+
+function normalizedConfig(config: Config): Config {
+  return {
+    ...config,
+    project: optionalSlug(config.project, 'project'),
+    org: optionalSlug(config.org, 'org'),
+    dir: optionalText(config.dir, 'dir'),
+  };
+}
+
 function deployDir(ctx: { projectDir: string }, config: Config): string {
+  config = normalizedConfig(config);
   if (!config.dir) return ctx.projectDir;
   return isAbsolute(config.dir) ? config.dir : join(ctx.projectDir, config.dir);
 }
 
 function deployArgs(ctx: { channel: string; projectDir: string }, config: Config, token?: string): string[] {
+  config = normalizedConfig(config);
   const prod = config.prod ?? ctx.channel === 'stable';
   const args = ['--yes', 'vercel', 'deploy', deployDir(ctx, config), '--yes'];
   if (prod) args.push('--prod');
@@ -24,6 +53,7 @@ function deployArgs(ctx: { channel: string; projectDir: string }, config: Config
 }
 
 function renderPlan(ctx: { channel: string; projectDir: string }, config: Config): string {
+  config = normalizedConfig(config);
   const prod = config.prod ?? ctx.channel === 'stable';
   return `${JSON.stringify({
     provider: 'vercel',
@@ -51,6 +81,7 @@ export default defineTarget<Config>({
     return { artifact: planPath };
   },
   async ship(ctx, config) {
+    config = normalizedConfig(config);
     const prod = config.prod ?? ctx.channel === 'stable';
     ctx.log(`vercel deploy ${prod ? '--prod' : ''} · project=${config.project ?? 'linked'}`);
     if (ctx.dryRun) return { id: 'dry-run', meta: { command: ['npx', ...deployArgs(ctx, config)] } };


### PR DESCRIPTION
Fixes #638.

Changes:
- validate optional project and org values as Vercel-safe slugs
- reject blank dir values before plan or CLI work
- normalize deploy config before rendering plans and shipping
- keep dry-run output side-effect free while still validating input
- add regression tests for invalid config

Validation:
- vitest run packages/targets/deploy-vercel/src/index.test.ts
- tsc -p packages/targets/deploy-vercel/tsconfig.json --noEmit