### PR TITLE
Validate Deno Deploy config

### DIFF
--- a/packages/targets/deploy-denodeploy/src/index.test.ts
+++ b/packages/targets/deploy-denodeploy/src/index.test.ts
@@ -72,6 +72,36 @@ describe('Deno Deploy target', () => {
     });
   });
 
+  it('rejects invalid Deno Deploy config before plan or CLI work', async () => {
+    await expect(adapter.build(fakeBuildContext() as any, {
+      project: 'bad/project',
+      entrypoint: 'src/server.ts',
+    })).rejects.toThrow('project must contain only letters');
+
+    await expect(adapter.ship(fakeShipContext({
+      dryRun: true,
+    }) as any, {
+      project: 'edge-api',
+      entrypoint: '   ',
+    })).rejects.toThrow('deploy-denodeploy requires entrypoint');
+
+    await expect(adapter.ship(fakeShipContext({
+      dryRun: true,
+    }) as any, {
+      project: 'edge-api',
+      entrypoint: 'src/server.ts',
+      includeFiles: ['   '],
+    })).rejects.toThrow('deploy-denodeploy requires includeFiles[0]');
+
+    await expect(adapter.ship(fakeShipContext({
+      dryRun: true,
+    }) as any, {
+      project: 'edge-api',
+      entrypoint: 'src/server.ts',
+      env: { 'bad-key': 'value' },
+    })).rejects.toThrow('env "bad-key" must be a valid environment variable name');
+  });
+
   it('requires a vault token for real deployments', async () => {
     await expect(adapter.ship(fakeShipContext({
       dryRun: false,

--- a/packages/targets/deploy-denodeploy/src/index.ts
+++ b/packages/targets/deploy-denodeploy/src/index.ts
@@ -13,7 +13,60 @@ interface Config {
   prod?: boolean;                // false = preview deployment
 }
 
+function requireText(value: string | undefined, field: string): string {
+  const text = value?.trim();
+  if (!text) throw new Error(`deploy-denodeploy requires ${field}`);
+  return text;
+}
+
+function optionalText(value: string | undefined, field: string): string | undefined {
+  return value === undefined ? undefined : requireText(value, field);
+}
+
+function requireSlug(value: string | undefined, field: string): string {
+  const text = requireText(value, field);
+  if (!/^[A-Za-z0-9._-]+$/.test(text)) {
+    throw new Error(`deploy-denodeploy ${field} must contain only letters, numbers, dots, underscores, or hyphens`);
+  }
+  return text;
+}
+
+function optionalSlug(value: string | undefined, field: string): string | undefined {
+  return value === undefined ? undefined : requireSlug(value, field);
+}
+
+function textList(value: string[] | undefined, field: string): string[] | undefined {
+  return value?.map((entry, index) => requireText(entry, `${field}[${index}]`));
+}
+
+function envVars(value: Record<string, string> | undefined): Record<string, string> | undefined {
+  if (value === undefined) return undefined;
+  for (const [key, entryValue] of Object.entries(value)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+      throw new Error(`deploy-denodeploy env "${key}" must be a valid environment variable name`);
+    }
+    if (typeof entryValue !== 'string') {
+      throw new Error(`deploy-denodeploy env "${key}" must be a string`);
+    }
+  }
+  return value;
+}
+
+function normalizedConfig(config: Config): Config {
+  return {
+    ...config,
+    project: requireSlug(config.project, 'project'),
+    entrypoint: requireText(config.entrypoint, 'entrypoint'),
+    org: optionalSlug(config.org, 'org'),
+    includeFiles: textList(config.includeFiles, 'includeFiles'),
+    excludeFiles: textList(config.excludeFiles, 'excludeFiles'),
+    env: envVars(config.env),
+    envFiles: textList(config.envFiles, 'envFiles'),
+  };
+}
+
 function deployArgs(ctx: { channel: string }, config: Config): string[] {
+  config = normalizedConfig(config);
   const prod = config.prod ?? ctx.channel === 'stable';
   const args = [
     'deploy',
@@ -30,6 +83,7 @@ function deployArgs(ctx: { channel: string }, config: Config): string[] {
 }
 
 function renderPlan(ctx: { channel: string; projectDir: string; version: string }, config: Config): string {
+  config = normalizedConfig(config);
   const prod = config.prod ?? ctx.channel === 'stable';
   return `${JSON.stringify({
     provider: 'deno-deploy',
@@ -82,6 +136,7 @@ export default defineTarget<Config>({
   kind: 'web',
   label: 'Deno Deploy',
   async build(ctx, config) {
+    config = normalizedConfig(config);
     const planPath = join(ctx.outDir, 'deno-deploy.json');
     ctx.log(`deployctl plan - project=${config.project} entrypoint=${config.entrypoint}`);
     await mkdir(ctx.outDir, { recursive: true });
@@ -89,6 +144,7 @@ export default defineTarget<Config>({
     return { artifact: planPath };
   },
   async ship(ctx, config) {
+    config = normalizedConfig(config);
     const kind = (config.prod ?? ctx.channel === 'stable') ? 'production' : 'preview';
     ctx.log(`deployctl deploy - project=${config.project} kind=${kind}`);
     if (ctx.dryRun) return { id: 'dry-run', meta: { command: ['deployctl', ...deployArgs(ctx, config)] } };


### PR DESCRIPTION
Fixes #650.

Changes:
- validate project and org slugs
- reject blank entrypoint, file include/exclude, and env-file entries
- validate environment variable names and values
- normalize config before plan rendering and deployctl args
- add regression tests for invalid config before CLI work

Validation:
- vitest run packages/targets/deploy-denodeploy/src/index.test.ts
- tsc -p packages/targets/deploy-denodeploy/tsconfig.json --noEmit