### PR TITLE
Validate Coolify deploy config

### DIFF
--- a/packages/targets/deploy-coolify/src/index.test.ts
+++ b/packages/targets/deploy-coolify/src/index.test.ts
@@ -1,4 +1,103 @@
-import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeShipContext, makeVault, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { execMock } = vi.hoisted(() => ({
+  execMock: vi.fn(),
+}));
+
+vi.mock('@profullstack/sh1pt-core', async () => ({
+  ...await vi.importActual<typeof import('@profullstack/sh1pt-core')>('@profullstack/sh1pt-core'),
+  exec: execMock,
+}));
+
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'deploy', requireKind: true });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const baseConfig = {
+  baseUrl: 'https://coolify.example.com/',
+  projectUuid: 'project-123',
+};
+
+describe('Coolify deployment target', () => {
+  it('keeps dry-run shipping side-effect free while validating config', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      channel: 'beta',
+      dryRun: true,
+    }) as any, baseConfig)).resolves.toEqual({ id: 'dry-run' });
+
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid Coolify config before curl work', async () => {
+    await expect(adapter.ship(fakeShipContext({
+      dryRun: true,
+    }) as any, {
+      ...baseConfig,
+      baseUrl: 'http://coolify.example.com',
+    })).rejects.toThrow('baseUrl must use HTTPS');
+
+    await expect(adapter.ship(fakeShipContext({
+      dryRun: true,
+    }) as any, {
+      ...baseConfig,
+      projectUuid: 'project/123',
+    })).rejects.toThrow('projectUuid must be a single URL-safe segment');
+
+    await expect(adapter.ship(fakeShipContext({
+      dryRun: true,
+    }) as any, {
+      ...baseConfig,
+      applicationUuid: '   ',
+    })).rejects.toThrow('deploy-coolify requires applicationUuid');
+
+    await expect(adapter.ship(fakeShipContext({
+      dryRun: true,
+    }) as any, {
+      ...baseConfig,
+      environmentName: 'bad env',
+    })).rejects.toThrow('environmentName must contain only letters');
+
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  it('posts a deployment to the normalized Coolify deploy URL', async () => {
+    execMock.mockResolvedValue({ exitCode: 0, stdout: '{"status":"queued"}\n', stderr: '' });
+
+    const ctx = fakeShipContext({
+      channel: 'stable',
+      dryRun: false,
+      version: '1.2.3',
+      secret: makeVault({ COOLIFY_API_TOKEN: 'mock-token' }),
+    });
+
+    const result = await adapter.ship(ctx as any, {
+      ...baseConfig,
+      applicationUuid: 'app-123',
+    });
+
+    expect(execMock).toHaveBeenCalledWith('curl', [
+      '-s',
+      '-X',
+      'POST',
+      'https://coolify.example.com/api/v1/deploy?uuid=app-123',
+      '-H',
+      'Authorization: Bearer mock-token',
+    ], {
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+    expect(result).toEqual({
+      id: 'app-123@1.2.3',
+      meta: {
+        baseUrl: 'https://coolify.example.com',
+        environment: 'production',
+        rawResponse: '{"status":"queued"}',
+      },
+    });
+  });
+});

--- a/packages/targets/deploy-coolify/src/index.ts
+++ b/packages/targets/deploy-coolify/src/index.ts
@@ -17,6 +17,61 @@ interface Config {
   applicationUuid?: string;        // existing app to redeploy
 }
 
+function requireText(value: string | undefined, field: string): string {
+  const text = value?.trim();
+  if (!text) throw new Error(`deploy-coolify requires ${field}`);
+  return text;
+}
+
+function optionalText(value: string | undefined, field: string): string | undefined {
+  return value === undefined ? undefined : requireText(value, field);
+}
+
+function baseUrl(value: string | undefined): string {
+  const url = requireText(value, 'baseUrl').replace(/\/+$/, '');
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error('deploy-coolify baseUrl must be a valid HTTPS URL');
+  }
+  if (parsed.protocol !== 'https:') throw new Error('deploy-coolify baseUrl must use HTTPS');
+  return url;
+}
+
+function uuidSegment(value: string | undefined, field: string): string {
+  const text = requireText(value, field);
+  if (/[\\/?#\s\x00-\x1F\x7F]/.test(text)) {
+    throw new Error(`deploy-coolify ${field} must be a single URL-safe segment`);
+  }
+  return text;
+}
+
+function optionalUuidSegment(value: string | undefined, field: string): string | undefined {
+  return value === undefined ? undefined : uuidSegment(value, field);
+}
+
+function environmentName(config: Config, channel: string): string {
+  const env = config.environmentName === undefined
+    ? (channel === 'stable' ? 'production' : 'staging')
+    : requireText(config.environmentName, 'environmentName');
+  if (!/^[A-Za-z0-9._-]+$/.test(env)) {
+    throw new Error('deploy-coolify environmentName must contain only letters, numbers, dots, underscores, or hyphens');
+  }
+  return env;
+}
+
+function normalizedConfig(config: Config, channel: string): Config {
+  return {
+    ...config,
+    baseUrl: baseUrl(config.baseUrl),
+    projectUuid: uuidSegment(config.projectUuid, 'projectUuid'),
+    serverUuid: optionalUuidSegment(config.serverUuid, 'serverUuid'),
+    environmentName: environmentName(config, channel),
+    applicationUuid: optionalUuidSegment(config.applicationUuid, 'applicationUuid'),
+  };
+}
+
 export default defineTarget<Config>({
   id: 'deploy-coolify',
   kind: 'web',
@@ -26,6 +81,7 @@ export default defineTarget<Config>({
     return { artifact: ctx.projectDir };
   },
   async ship(ctx, config) {
+    config = normalizedConfig(config, ctx.channel);
     const env = config.environmentName ?? (ctx.channel === 'stable' ? 'production' : 'staging');
     ctx.log(`coolify · deploy · project=${config.projectUuid} · env=${env}`);
     if (ctx.dryRun) return { id: 'dry-run' };


### PR DESCRIPTION
Fixes #652.

Changes:
- validate baseUrl as HTTPS and normalize trailing slashes
- validate project/server/application UUIDs as URL-safe segments
- validate environmentName and reject blank values
- normalize config before dry-run and curl execution
- add regression tests with mocked curl deployment

Validation:
- vitest run packages/targets/deploy-coolify/src/index.test.ts
- tsc -p packages/targets/deploy-coolify/tsconfig.json --noEmit