### PR TITLE
Validate Deno package publish config

### DIFF
--- a/packages/targets/pkg-deno/src/index.test.ts
+++ b/packages/targets/pkg-deno/src/index.test.ts
@@ -137,4 +137,30 @@ describe('deno.land/x package target', () => {
       sourceRepo: '',
     })).rejects.toThrow('pkg-deno requires sourceRepo');
   });
+
+  it('rejects invalid deno.land/x publish config before git work', async () => {
+    await expect(adapter.ship(fakeShipContext({ dryRun: true }) as any, {
+      moduleName: 'MyMod',
+      sourceRepo: 'acme/my-mod',
+    })).rejects.toThrow('moduleName must contain only lowercase');
+
+    await expect(adapter.ship(fakeShipContext({ dryRun: true }) as any, {
+      moduleName: 'my_mod',
+      sourceRepo: 'acme',
+    })).rejects.toThrow('sourceRepo must look like owner/repo');
+
+    await expect(adapter.ship(fakeShipContext({ dryRun: true }) as any, {
+      moduleName: 'my_mod',
+      sourceRepo: 'acme/my-mod',
+      remote: 'up stream',
+    })).rejects.toThrow('remote must not contain whitespace');
+
+    await expect(adapter.ship(fakeShipContext({ dryRun: true }) as any, {
+      moduleName: 'my_mod',
+      sourceRepo: 'acme/my-mod',
+      tagPrefix: 'release ',
+    })).rejects.toThrow('tagPrefix must not contain whitespace');
+
+    expect(execMock).not.toHaveBeenCalled();
+  });
 });

--- a/packages/targets/pkg-deno/src/index.ts
+++ b/packages/targets/pkg-deno/src/index.ts
@@ -20,18 +20,67 @@ function requireValue(value: string | undefined, field: string): string {
   return trimmed;
 }
 
+function optionalValue(value: string | undefined, field: string): string | undefined {
+  return value === undefined ? undefined : requireValue(value, field);
+}
+
+function moduleName(value: string | undefined): string {
+  const name = requireValue(value, 'moduleName');
+  if (!/^[a-z0-9_]+$/.test(name)) {
+    throw new Error('pkg-deno moduleName must contain only lowercase letters, numbers, or underscores');
+  }
+  return name;
+}
+
+function sourceRepo(value: string | undefined): string {
+  const repo = requireValue(value, 'sourceRepo');
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) {
+    throw new Error('pkg-deno sourceRepo must look like owner/repo');
+  }
+  return repo;
+}
+
+function gitRemote(value: string | undefined): string {
+  const remote = optionalValue(value, 'remote') ?? 'origin';
+  if (value !== undefined && remote !== value) throw new Error('pkg-deno remote must not contain whitespace');
+  if (/\s/.test(remote)) throw new Error('pkg-deno remote must not contain whitespace');
+  return remote;
+}
+
+function tagPrefix(value: string | undefined): string {
+  if (value === undefined || value === '') return '';
+  const prefix = value;
+  if (prefix !== prefix.trim()) throw new Error('pkg-deno tagPrefix must not contain whitespace');
+  if (/\s/.test(prefix)) throw new Error('pkg-deno tagPrefix must not contain whitespace');
+  return prefix;
+}
+
+function normalizedConfig(config: Config): Config {
+  return {
+    ...config,
+    moduleName: moduleName(config.moduleName),
+    sourceRepo: sourceRepo(config.sourceRepo),
+    tagPrefix: tagPrefix(config.tagPrefix),
+    remote: gitRemote(config.remote),
+    tagMessage: optionalValue(config.tagMessage, 'tagMessage'),
+  };
+}
+
 function tagFor(config: Config, version: string): string {
+  config = normalizedConfig(config);
   return `${config.tagPrefix ?? ''}${version}`;
 }
 
 function urlFor(config: Config, tag: string): string {
-  return `https://deno.land/x/${requireValue(config.moduleName, 'moduleName')}@${tag}`;
+  config = normalizedConfig(config);
+  return `https://deno.land/x/${config.moduleName}@${tag}`;
 }
 
 function buildPlan(config: Config, version: string) {
-  const moduleName = requireValue(config.moduleName, 'moduleName');
-  const sourceRepo = requireValue(config.sourceRepo, 'sourceRepo');
-  const remote = config.remote?.trim() || 'origin';
+  config = normalizedConfig(config);
+  const moduleName = config.moduleName;
+  const sourceRepo = config.sourceRepo;
+  const remote = config.remote ?? 'origin';
   const tag = tagFor(config, version);
   const tagCommand = config.tagMessage
     ? ['tag', '-a', tag, '-m', config.tagMessage]


### PR DESCRIPTION
Fixes #662.

Changes:
- validate deno.land/x module names
- validate sourceRepo as owner/repo
- reject remote names and tag prefixes containing whitespace
- normalize config before tag plan generation and ship
- add regression tests for invalid publish config before git work

Validation:
- vitest run packages/targets/pkg-deno/src/index.test.ts
- tsc -p packages/targets/pkg-deno/tsconfig.json --noEmit