### PR TITLE
Validate Firefox addon config

### DIFF
--- a/packages/targets/browser-firefox/src/index.test.ts
+++ b/packages/targets/browser-firefox/src/index.test.ts
@@ -1,4 +1,4 @@
-import { fakeBuildContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -105,5 +105,27 @@ describe('browser-firefox target adapter', () => {
       throwOnNonZero: true,
     });
     expect(result).toEqual({ artifact });
+  });
+
+  it('rejects invalid AMO package config before packaging or shipping', async () => {
+    await expect(adapter.build(fakeBuildContext({ dryRun: true }) as any, {
+      extensionId: '',
+    })).rejects.toThrow('browser-firefox requires extensionId');
+
+    await expect(adapter.build(fakeBuildContext({ dryRun: true }) as any, {
+      extensionId: 'my ext@example.com',
+    })).rejects.toThrow('extensionId must not contain whitespace');
+
+    await expect(adapter.build(fakeBuildContext({ dryRun: true }) as any, {
+      extensionId: 'myext@example.com',
+      sourceDir: '',
+    })).rejects.toThrow('browser-firefox requires sourceDir');
+
+    await expect(adapter.ship(fakeShipContext({ dryRun: true }) as any, {
+      extensionId: 'myext@example.com',
+      channel: 'beta',
+    } as any)).rejects.toThrow('channel must be listed or unlisted');
+
+    expect(execMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/targets/browser-firefox/src/index.ts
+++ b/packages/targets/browser-firefox/src/index.ts
@@ -22,8 +22,41 @@ interface FirefoxPackagePlan {
   };
 }
 
+function requireValue(value: string | undefined, field: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed) throw new Error(`browser-firefox requires ${field}`);
+  return trimmed;
+}
+
+function extensionId(value: string | undefined): string {
+  const id = requireValue(value, 'extensionId');
+  if (/\s/.test(id)) throw new Error('browser-firefox extensionId must not contain whitespace');
+  return id;
+}
+
+function configuredSourceDir(value: string | undefined): string {
+  return value === undefined ? 'dist' : requireValue(value, 'sourceDir');
+}
+
+function channel(value: string | undefined): 'listed' | 'unlisted' {
+  if (value === undefined) return 'listed';
+  if (value !== 'listed' && value !== 'unlisted') {
+    throw new Error('browser-firefox channel must be listed or unlisted');
+  }
+  return value;
+}
+
+function normalizedConfig(config: Config): Config {
+  return {
+    ...config,
+    extensionId: extensionId(config.extensionId),
+    sourceDir: configuredSourceDir(config.sourceDir),
+    channel: channel(config.channel),
+  };
+}
+
 function sourceDir(ctx: { projectDir: string }, config: Config): string {
-  const dir = config.sourceDir ?? 'dist';
+  const dir = configuredSourceDir(config.sourceDir);
   return isAbsolute(dir) ? dir : join(ctx.projectDir, dir);
 }
 
@@ -43,6 +76,7 @@ function packagePlan(
   ctx: { projectDir: string; outDir: string; version: string },
   config: Config,
 ): FirefoxPackagePlan {
+  config = normalizedConfig(config);
   const src = sourceDir(ctx, config);
   const filename = artifactName(ctx, config);
   return {
@@ -101,11 +135,11 @@ export default defineTarget<Config>({
     return { artifact: artifactPath(ctx, config) };
   },
   async ship(ctx, config) {
-    const channel = config.channel ?? 'listed';
-    ctx.log(`sign + submit ${config.extensionId} to AMO (channel: ${channel})`);
-    if (ctx.dryRun) return { id: 'dry-run' };
+    config = normalizedConfig(config);
+    ctx.log(`sign + submit ${config.extensionId} to AMO (channel: ${config.channel})`);
+    if (ctx.dryRun) return { id: 'dry-run', meta: { extensionId: config.extensionId, channel: config.channel } };
     // TODO: web-ext sign --api-key=${AMO_JWT_ISSUER} --api-secret=${AMO_JWT_SECRET}
-    //       --channel=${channel} --source-dir ${config.sourceDir ?? 'dist/'}
+    //       --channel=${config.channel} --source-dir ${config.sourceDir}
     // Or: POST https://addons.mozilla.org/api/v5/addons/<id>/versions/ with JWT auth
     return {
       id: `${config.extensionId}@${ctx.version}`,


### PR DESCRIPTION
Fixes #664.

Changes:
- validate Firefox AMO extension IDs before packaging or shipping
- reject blank sourceDir values instead of packaging the project root accidentally
- validate channel as listed or unlisted at runtime
- normalize config before plan generation and dry-run shipping
- add regression coverage that invalid config fails before web-ext runs

Validation:
- vitest run packages/targets/browser-firefox/src/index.test.ts
- tsc -p packages/targets/browser-firefox/tsconfig.json --noEmit