### PR TITLE
Validate Safari extension config

### DIFF
--- a/packages/targets/browser-safari/src/index.test.ts
+++ b/packages/targets/browser-safari/src/index.test.ts
@@ -1,4 +1,4 @@
-import { fakeBuildContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -56,5 +56,29 @@ describe('Safari extension build planning', () => {
     });
     expect(plan.archive.args).toContain('-archivePath');
     expect(plan.archive.args).toContain('generic/platform=macos');
+  });
+
+  it('rejects invalid Safari config before Xcode or App Store work', async () => {
+    await expect(adapter.build(fakeBuildContext({ dryRun: true }) as any, {
+      bundleId: '',
+    })).rejects.toThrow('browser-safari requires bundleId');
+
+    await expect(adapter.build(fakeBuildContext({ dryRun: true }) as any, {
+      bundleId: 'com acme.Extension',
+    })).rejects.toThrow('bundleId must look like a reverse-DNS identifier');
+
+    await expect(adapter.build(fakeBuildContext({ dryRun: true }) as any, {
+      bundleId: 'com.acme.Extension',
+      projectDir: '',
+    })).rejects.toThrow('browser-safari requires projectDir');
+
+    await expect(adapter.build(fakeBuildContext({ dryRun: true }) as any, {
+      bundleId: 'com.acme.Extension',
+      scheme: '',
+    })).rejects.toThrow('browser-safari requires scheme');
+
+    await expect(adapter.ship(fakeShipContext({ dryRun: true }) as any, {
+      bundleId: 'Extension',
+    })).rejects.toThrow('bundleId must look like a reverse-DNS identifier');
   });
 });

--- a/packages/targets/browser-safari/src/index.ts
+++ b/packages/targets/browser-safari/src/index.ts
@@ -57,6 +57,35 @@ function b64url(buf: Buffer | string): string {
   return b.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
+function requireValue(value: string | undefined, field: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed) throw new Error(`browser-safari requires ${field}`);
+  return trimmed;
+}
+
+function optionalValue(value: string | undefined, field: string): string | undefined {
+  return value === undefined ? undefined : requireValue(value, field);
+}
+
+function bundleId(value: string | undefined): string {
+  const id = requireValue(value, 'bundleId');
+  if (!/^[A-Za-z0-9][A-Za-z0-9-]*(\.[A-Za-z0-9][A-Za-z0-9-]*)+$/.test(id)) {
+    throw new Error('browser-safari bundleId must look like a reverse-DNS identifier');
+  }
+  return id;
+}
+
+function normalizedConfig(config: Config): Config {
+  return {
+    ...config,
+    bundleId: bundleId(config.bundleId),
+    appleId: optionalValue(config.appleId, 'appleId'),
+    teamId: optionalValue(config.teamId, 'teamId'),
+    scheme: optionalValue(config.scheme, 'scheme') ?? 'App',
+    projectDir: optionalValue(config.projectDir, 'projectDir') ?? '.',
+  };
+}
+
 function safeFileStem(value: string): string {
   return value.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-|-$/g, '') || 'safari-extension';
 }
@@ -81,6 +110,7 @@ function buildPlan(
   ctx: { projectDir: string; outDir: string; version: string },
   config: Config,
 ): SafariPackagePlan {
+  config = normalizedConfig(config);
   const projectDir = resolveLike(ctx.projectDir, config.projectDir ?? '.');
   const scheme = config.scheme ?? 'App';
   const archivePath = joinLike(ctx.outDir, `${safeFileStem(config.bundleId)}-${safeFileStem(ctx.version)}.xcarchive`);
@@ -133,9 +163,9 @@ export default defineTarget<Config>({
   label: 'App Store (Safari ext.)',
   async build(ctx, config) {
     const plan = buildPlan(ctx, config);
-    const artifact = planPath(ctx.outDir, config.bundleId, ctx.version);
+    const artifact = planPath(ctx.outDir, plan.bundleId, ctx.version);
 
-    ctx.log(`build Safari Web Extension for ${config.bundleId} v${ctx.version}`);
+    ctx.log(`build Safari Web Extension for ${plan.bundleId} v${ctx.version}`);
     await mkdir(ctx.outDir, { recursive: true });
 
     if (ctx.dryRun) {
@@ -172,6 +202,7 @@ export default defineTarget<Config>({
     return { artifact: plan.archivePath };
   },
   async ship(ctx, config) {
+    config = normalizedConfig(config);
     ctx.log(`upload ${config.bundleId} to App Store Connect v${ctx.version}`);
     if (ctx.dryRun) {
       return { id: `${config.bundleId}@${ctx.version}`, url: `https://apps.apple.com/app/${config.bundleId}` };


### PR DESCRIPTION
Fixes #666.

Changes:
- validate Safari bundle IDs as reverse-DNS identifiers
- reject blank scheme and projectDir values before Xcode planning
- normalize optional Apple/Safari config before build and ship
- use the normalized bundle ID for dry-run artifacts and logs
- add regression coverage for invalid config before Xcode or App Store work

Validation:
- vitest run packages/targets/browser-safari/src/index.test.ts
- tsc -p packages/targets/browser-safari/tsconfig.json --noEmit