### PR TITLE
Validate Slack target config

### DIFF
--- a/packages/targets/chat-slack/src/index.test.ts
+++ b/packages/targets/chat-slack/src/index.test.ts
@@ -70,4 +70,57 @@ describe('Slack app manifest generation', () => {
       scopes: { bot: ['chat:write'] },
     })).resolves.toEqual({ id: 'dry-run' });
   });
+
+  it('rejects invalid Slack config before rendering or shipping', async () => {
+    await expect(adapter.build(fakeBuildContext() as any, {
+      appId: 'not-an-app',
+      clientId: '123.456',
+      distribution: 'workspace',
+      requestUrl: 'https://example.com/slack/events',
+      scopes: { bot: ['chat:write'] },
+    })).rejects.toThrow('appId must look like a Slack app ID');
+
+    await expect(adapter.build(fakeBuildContext() as any, {
+      appId: 'A123456',
+      clientId: 'client-id',
+      distribution: 'workspace',
+      requestUrl: 'https://example.com/slack/events',
+      scopes: { bot: ['chat:write'] },
+    })).rejects.toThrow('clientId must look like a Slack client ID');
+
+    await expect(adapter.build(fakeBuildContext() as any, {
+      appId: 'A123456',
+      clientId: '123.456',
+      distribution: 'global',
+      requestUrl: 'https://example.com/slack/events',
+      scopes: { bot: ['chat:write'] },
+    } as any)).rejects.toThrow('distribution must be workspace or directory');
+
+    await expect(adapter.ship(fakeShipContext({ dryRun: true }) as any, {
+      appId: 'A123456',
+      clientId: '123.456',
+      distribution: 'workspace',
+      requestUrl: 'http://example.com/slack/events',
+      scopes: { bot: ['chat:write'] },
+    })).rejects.toThrow('requestUrl must be an https URL');
+
+    await expect(adapter.build(fakeBuildContext() as any, {
+      appId: 'A123456',
+      clientId: '123.456',
+      distribution: 'workspace',
+      requestUrl: 'https://example.com/slack/events',
+      scopes: {},
+    })).rejects.toThrow('requires at least one bot or user scope');
+
+    await expect(adapter.build(fakeBuildContext() as any, {
+      appId: 'A123456',
+      clientId: '123.456',
+      distribution: 'workspace',
+      requestUrl: 'https://example.com/slack/events',
+      slashCommands: [
+        { command: 'ship', url: 'https://example.com/slack/commands', description: 'Ship it' },
+      ],
+      scopes: { bot: ['chat:write'] },
+    })).rejects.toThrow('slash command must start with /');
+  });
 });

--- a/packages/targets/chat-slack/src/index.ts
+++ b/packages/targets/chat-slack/src/index.ts
@@ -23,6 +23,88 @@ function yamlString(value: string): string {
   return JSON.stringify(value);
 }
 
+function requireValue(value: string | undefined, field: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed) throw new Error(`chat-slack requires ${field}`);
+  return trimmed;
+}
+
+function optionalValue(value: string | undefined, field: string): string | undefined {
+  return value === undefined ? undefined : requireValue(value, field);
+}
+
+function appId(value: string | undefined): string {
+  const id = requireValue(value, 'appId');
+  if (!/^A[A-Z0-9]+$/.test(id)) throw new Error('chat-slack appId must look like a Slack app ID');
+  return id;
+}
+
+function clientId(value: string | undefined): string {
+  const id = requireValue(value, 'clientId');
+  if (!/^\d+(\.\d+)?$/.test(id)) throw new Error('chat-slack clientId must look like a Slack client ID');
+  return id;
+}
+
+function httpsUrl(value: string | undefined, field: string): string {
+  const url = requireValue(value, field);
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`chat-slack ${field} must be an https URL`);
+  }
+  if (parsed.protocol !== 'https:') throw new Error(`chat-slack ${field} must be an https URL`);
+  return url;
+}
+
+function distribution(value: Config['distribution'] | undefined): Config['distribution'] {
+  if (value !== 'workspace' && value !== 'directory') {
+    throw new Error('chat-slack distribution must be workspace or directory');
+  }
+  return value;
+}
+
+function scopes(scopes: Config['scopes'] | undefined): Config['scopes'] {
+  if (!scopes) throw new Error('chat-slack requires scopes');
+  const bot = scopes.bot ?? [];
+  const user = scopes.user ?? [];
+  if (!bot.length && !user.length) throw new Error('chat-slack requires at least one bot or user scope');
+  for (const scope of [...bot, ...user]) {
+    if (!scope.trim() || /\s/.test(scope)) throw new Error('chat-slack scopes must not be blank or contain whitespace');
+  }
+  return { bot, user };
+}
+
+function slashCommands(commands: Config['slashCommands']): Config['slashCommands'] {
+  return (commands ?? []).map((command) => {
+    const name = requireValue(command.command, 'slash command');
+    if (!/^\/[a-z0-9_-]{1,32}$/.test(name)) {
+      throw new Error('chat-slack slash command must start with / and contain 1-32 lowercase letters, numbers, underscores, or hyphens');
+    }
+    return {
+      command: name,
+      url: httpsUrl(command.url, `slash command ${name} url`),
+      description: requireValue(command.description, `slash command ${name} description`),
+    };
+  });
+}
+
+function normalizedConfig(config: Config): Config {
+  return {
+    ...config,
+    appId: appId(config.appId),
+    clientId: clientId(config.clientId),
+    distribution: distribution(config.distribution),
+    requestUrl: httpsUrl(config.requestUrl, 'requestUrl'),
+    name: optionalValue(config.name, 'name'),
+    description: optionalValue(config.description, 'description'),
+    botDisplayName: optionalValue(config.botDisplayName, 'botDisplayName'),
+    botEvents: config.botEvents ?? [],
+    slashCommands: slashCommands(config.slashCommands),
+    scopes: scopes(config.scopes),
+  };
+}
+
 function renderList(values: string[], indent: string): string[] {
   return values.map((value) => `${indent}- ${yamlString(value)}`);
 }
@@ -36,6 +118,7 @@ function renderSlashCommands(commands: NonNullable<Config['slashCommands']>): st
 }
 
 function renderSlackManifest(config: Config): string {
+  config = normalizedConfig(config);
   const appName = config.name ?? config.appId;
   const botDisplayName = config.botDisplayName ?? appName;
   const botScopes = config.scopes.bot ?? [];
@@ -98,6 +181,7 @@ export default defineTarget<Config>({
   kind: 'chat',
   label: 'Slack App Directory',
   async build(ctx, config) {
+    config = normalizedConfig(config);
     const manifestPath = join(ctx.outDir, 'slack-manifest.yaml');
     ctx.log(`render slack app manifest · appId=${config.appId}`);
     await mkdir(ctx.outDir, { recursive: true });
@@ -105,6 +189,7 @@ export default defineTarget<Config>({
     return { artifact: manifestPath };
   },
   async ship(ctx, config) {
+    config = normalizedConfig(config);
     const dest = config.distribution === 'directory' ? 'App Directory (review queue)' : 'workspace (no review)';
     ctx.log(`slack · push app manifest → ${dest}`);
     if (ctx.dryRun) return { id: 'dry-run' };


### PR DESCRIPTION
Fixes #670.

Changes:
- validate Slack appId and clientId formats
- require workspace or directory distribution
- require HTTPS request URLs and slash command URLs
- reject missing or empty bot/user scopes
- validate slash command names before manifest rendering
- add regression coverage for invalid config before rendering or shipping

Validation:
- vitest run packages/targets/chat-slack/src/index.test.ts
- tsc -p packages/targets/chat-slack/tsconfig.json --noEmit