### PR TITLE
Validate Signal target config

### DIFF
--- a/packages/targets/chat-signal/src/index.test.ts
+++ b/packages/targets/chat-signal/src/index.test.ts
@@ -1,4 +1,4 @@
-import { contractTestTarget, fakeBuildContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { contractTestTarget, fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -37,5 +37,28 @@ describe('Signal target planning', () => {
       deviceName: 'sh1pt-test',
       captchaTokenPresent: true,
     });
+  });
+
+  it('rejects invalid Signal config before writing a plan or registering', async () => {
+    await expect(adapter.build(fakeBuildContext() as any, {
+      phoneNumber: '415-555-1234',
+      runtime: 'signal-cli',
+    })).rejects.toThrow('phoneNumber must be a valid E.164 number');
+
+    await expect(adapter.build(fakeBuildContext() as any, {
+      phoneNumber: '+14155551234',
+      runtime: 'desktop',
+    } as any)).rejects.toThrow('runtime must be signal-cli or signald');
+
+    await expect(adapter.build(fakeBuildContext() as any, {
+      phoneNumber: '+14155551234',
+      runtime: 'signal-cli',
+      deviceName: '',
+    })).rejects.toThrow('chat-signal requires deviceName');
+
+    await expect(adapter.ship(fakeShipContext({ dryRun: false }) as any, {
+      phoneNumber: '+14155551234',
+      runtime: 'signal-cli',
+    })).rejects.toThrow('requires captchaToken for Signal registration');
   });
 });

--- a/packages/targets/chat-signal/src/index.ts
+++ b/packages/targets/chat-signal/src/index.ts
@@ -19,11 +19,45 @@ interface Config {
   deviceName?: string;
 }
 
+function requireValue(value: string | undefined, field: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed) throw new Error(`chat-signal requires ${field}`);
+  return trimmed;
+}
+
+function optionalValue(value: string | undefined, field: string): string | undefined {
+  return value === undefined ? undefined : requireValue(value, field);
+}
+
+function phoneNumber(value: string | undefined): string {
+  const phone = requireValue(value, 'phoneNumber');
+  if (!/^\+[1-9]\d{7,14}$/.test(phone)) throw new Error('chat-signal phoneNumber must be a valid E.164 number');
+  return phone;
+}
+
+function runtime(value: Config['runtime'] | undefined): Config['runtime'] {
+  if (value !== 'signal-cli' && value !== 'signald') {
+    throw new Error('chat-signal runtime must be signal-cli or signald');
+  }
+  return value;
+}
+
+function normalizedConfig(config: Config): Config {
+  return {
+    ...config,
+    phoneNumber: phoneNumber(config.phoneNumber),
+    runtime: runtime(config.runtime),
+    captchaToken: optionalValue(config.captchaToken, 'captchaToken'),
+    deviceName: optionalValue(config.deviceName, 'deviceName'),
+  };
+}
+
 export default defineTarget<Config>({
   id: 'chat-signal',
   kind: 'chat',
   label: 'Signal (signal-cli / signald)',
   async build(ctx, config) {
+    config = normalizedConfig(config);
     ctx.log(`prepare ${config.runtime} config for ${config.phoneNumber}`);
     const artifactDir = join(ctx.outDir, 'signal-runtime');
     const planPath = join(artifactDir, 'signal-runtime-plan.json');
@@ -37,8 +71,10 @@ export default defineTarget<Config>({
     return { artifact: planPath };
   },
   async ship(ctx, config) {
+    config = normalizedConfig(config);
     ctx.log(`register Signal number ${config.phoneNumber} (${config.runtime})`);
     if (ctx.dryRun) return { id: 'dry-run' };
+    if (!config.captchaToken) throw new Error('chat-signal requires captchaToken for Signal registration');
     // TODO:
     //  - signal-cli register -v <phone> (requires captchaToken)
     //  - verify with SMS/voice code (human step unless using a SIP gateway)


### PR DESCRIPTION
Fixes #674.

Changes:
- validate Signal phone numbers as E.164 values
- require runtime to be signal-cli or signald
- reject blank captchaToken and deviceName values when provided
- validate config before writing runtime plans or dry-run shipping
- require captchaToken before real registration flow returns success
- add regression coverage for invalid config before planning/registering

Validation:
- vitest run packages/targets/chat-signal/src/index.test.ts
- tsc -p packages/targets/chat-signal/tsconfig.json --noEmit