### PR TITLE
Validate Steam target config

### DIFF
--- a/packages/targets/console-steam/src/index.test.ts
+++ b/packages/targets/console-steam/src/index.test.ts
@@ -1,4 +1,4 @@
-import { contractTestTarget, fakeBuildContext, smokeTest } from '@profullstack/sh1pt-core/testing';
+import { contractTestTarget, fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1pt-core/testing';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -40,5 +40,35 @@ describe('Steam target planning', () => {
     expect(plan.branch).toBe('beta');
     expect(plan.binariesDir).toBe('/tmp/builds');
     expect(plan.submitDeckVerification).toBe(true);
+  });
+
+  it('rejects invalid Steam config before planning or shipping', async () => {
+    await expect(adapter.build(fakeBuildContext() as any, {
+      ...sampleConfig,
+      steamAppId: 0,
+    })).rejects.toThrow('steamAppId must be a positive integer');
+
+    await expect(adapter.build(fakeBuildContext() as any, {
+      ...sampleConfig,
+      depotIds: [],
+    })).rejects.toThrow('requires at least one depot');
+
+    await expect(adapter.build(fakeBuildContext() as any, {
+      ...sampleConfig,
+      depotIds: [
+        { platform: 'linux', depotId: 123457 },
+        { platform: 'linux', depotId: 123458 },
+      ],
+    })).rejects.toThrow('duplicate depot platform: linux');
+
+    await expect(adapter.build(fakeBuildContext() as any, {
+      ...sampleConfig,
+      branch: 'beta branch',
+    })).rejects.toThrow('branch must not contain whitespace');
+
+    await expect(adapter.ship(fakeShipContext({ dryRun: true }) as any, {
+      ...sampleConfig,
+      binariesDir: '',
+    })).rejects.toThrow('console-steam requires binariesDir');
   });
 });

--- a/packages/targets/console-steam/src/index.ts
+++ b/packages/targets/console-steam/src/index.ts
@@ -15,11 +15,57 @@ interface Config {
   submitDeckVerification?: boolean;
 }
 
+function positiveInteger(value: number | undefined, field: string): number {
+  if (!Number.isInteger(value) || value === undefined || value <= 0) {
+    throw new Error(`console-steam ${field} must be a positive integer`);
+  }
+  return value;
+}
+
+function requireValue(value: string | undefined, field: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed) throw new Error(`console-steam requires ${field}`);
+  return trimmed;
+}
+
+function branch(value: string | undefined): string {
+  const name = requireValue(value, 'branch');
+  if (/\s/.test(name)) throw new Error('console-steam branch must not contain whitespace');
+  return name;
+}
+
+function depotIds(values: Config['depotIds'] | undefined): Config['depotIds'] {
+  if (!values?.length) throw new Error('console-steam requires at least one depot');
+  const seen = new Set<string>();
+  return values.map((depot) => {
+    if (depot.platform !== 'windows' && depot.platform !== 'macos' && depot.platform !== 'linux') {
+      throw new Error('console-steam depot platform must be windows, macos, or linux');
+    }
+    if (seen.has(depot.platform)) throw new Error(`console-steam duplicate depot platform: ${depot.platform}`);
+    seen.add(depot.platform);
+    return {
+      platform: depot.platform,
+      depotId: positiveInteger(depot.depotId, 'depotId'),
+    };
+  });
+}
+
+function normalizedConfig(config: Config): Config {
+  return {
+    ...config,
+    steamAppId: positiveInteger(config.steamAppId, 'steamAppId'),
+    depotIds: depotIds(config.depotIds),
+    branch: branch(config.branch),
+    binariesDir: requireValue(config.binariesDir, 'binariesDir'),
+  };
+}
+
 export default defineTarget<Config>({
   id: 'console-steam',
   kind: 'console',
   label: 'Steam / Steam Deck (SteamOS)',
   async build(ctx, config) {
+    config = normalizedConfig(config);
     const platforms = config.depotIds.map((d) => d.platform).join(',');
     ctx.log(`prepare Steam depots · platforms=${platforms}`);
     const artifactDir = join(ctx.outDir, 'steam');
@@ -35,6 +81,7 @@ export default defineTarget<Config>({
     return { artifact: planPath };
   },
   async ship(ctx, config) {
+    config = normalizedConfig(config);
     ctx.log(`steamcmd run_app_build · app=${config.steamAppId} · branch=${config.branch}`);
     if (ctx.dryRun) return { id: 'dry-run' };
     // TODO:


### PR DESCRIPTION
Fixes #676.

Changes:
- validate Steam app IDs and depot IDs as positive integers
- require at least one depot and reject duplicate depot platforms
- validate depot platforms as windows, macos, or linux
- reject blank binariesDir and whitespace-containing branch names
- normalize config before build planning and ship dry-runs
- add regression coverage for invalid Steam config before planning/shipping

Validation:
- vitest run packages/targets/console-steam/src/index.test.ts
- tsc -p packages/targets/console-steam/tsconfig.json --noEmit