### PR TITLE
fix: reject backslash paths in action pack manifests

### DIFF
--- a/packages/actions-fleet-core/src/action-pack/schema.test.ts
+++ b/packages/actions-fleet-core/src/action-pack/schema.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { actionPackManifestSchema } from './schema.js';
-import { parseManifest, validateManifest, isSafeDestination, ActionPackValidationError } from './validate.js';
+import {
+  parseManifest,
+  validateManifest,
+  isSafeDestination,
+  isSafeTemplateSource,
+  ActionPackValidationError,
+} from './validate.js';
 
 const validManifest = {
   schemaVersion: 1,
@@ -110,6 +116,21 @@ describe('validateManifest path safety', () => {
     expect(() => validateManifest(bad)).toThrow(ActionPackValidationError);
   });
 
+  it('rejects Windows-style template source traversal', () => {
+    const bad = {
+      ...validManifest,
+      files: [
+        {
+          source: 'templates\\..\\escape.hbs',
+          destination: '.github/workflows/ci.yml',
+          mergeStrategy: 'replace-managed' as const,
+        },
+      ],
+    };
+    expect(() => validateManifest(bad)).toThrow(ActionPackValidationError);
+    expect(isSafeTemplateSource('templates\\..\\escape.hbs')).toBe(false);
+  });
+
   it('allows workflow files, dependabot, codeowners', () => {
     expect(isSafeDestination('.github/workflows/ci.yml')).toBe(true);
     expect(isSafeDestination('.github/workflows/release.yaml')).toBe(true);
@@ -122,6 +143,7 @@ describe('validateManifest path safety', () => {
     expect(isSafeDestination('.github/workflows/../../etc/passwd')).toBe(false);
     expect(isSafeDestination('.github/workflows/')).toBe(false);
     expect(isSafeDestination('.github/workflows/ci.txt')).toBe(false);
+    expect(isSafeDestination('.github\\workflows\\ci.yml')).toBe(false);
     expect(isSafeDestination('')).toBe(false);
     expect(isSafeDestination('.github/workflows/ci.yml\0.bad')).toBe(false);
   });

--- a/packages/actions-fleet-core/src/action-pack/validate.ts
+++ b/packages/actions-fleet-core/src/action-pack/validate.ts
@@ -23,6 +23,7 @@ export class ActionPackValidationError extends Error {
 export function isSafeDestination(destination: string): boolean {
   if (destination.length === 0) return false;
   if (destination.startsWith('/')) return false;
+  if (destination.includes('\\')) return false;
   if (destination.includes('\0')) return false;
   const segments = destination.split('/');
   for (const segment of segments) {
@@ -34,6 +35,7 @@ export function isSafeDestination(destination: string): boolean {
 export function isSafeTemplateSource(source: string): boolean {
   if (source.length === 0) return false;
   if (source.startsWith('/')) return false;
+  if (source.includes('\\')) return false;
   if (source.includes('\0')) return false;
   const segments = source.split('/');
   for (const segment of segments) {


### PR DESCRIPTION
Fixes #678

## Summary

- reject backslashes in action-pack template source paths and destinations
- add regression coverage for Windows-style `templates\\..\\escape.hbs` traversal and backslash workflow destinations

## Tests

- `corepack pnpm vitest run packages/actions-fleet-core/src/action-pack/schema.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt-actions-fleet-core typecheck`