### PR TITLE
fix: decode json pointer escapes in openapi refs

### DIFF
--- a/packages/openapi/src/core/normalize.test.ts
+++ b/packages/openapi/src/core/normalize.test.ts
@@ -70,6 +70,37 @@ describe('normalize', () => {
     expect(createPet.requestBody?.required).toBe(true);
   });
 
+  it('decodes JSON Pointer escapes when resolving refs', () => {
+    const ir = normalize({
+      openapi: '3.0.0',
+      info: { title: 'EscapedRefs', version: '1' },
+      paths: {
+        '/escaped': {
+          get: {
+            responses: {
+              '200': { $ref: '#/components/responses/Foo~1Bar~0Baz' },
+            },
+          },
+        },
+      },
+      components: {
+        responses: {
+          'Foo/Bar~Baz': {
+            description: 'escaped ok',
+            content: {
+              'application/json': {
+                schema: { type: 'object', properties: { ok: { type: 'boolean' } } },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(ir.operations[0]?.responses[0]?.description).toBe('escaped ok');
+    expect(ir.operations[0]?.responses[0]?.contentType).toBe('application/json');
+  });
+
   it('auto-generates operationId when missing', () => {
     const ir = normalize({
       openapi: '3.0.0',

--- a/packages/openapi/src/core/normalize.ts
+++ b/packages/openapi/src/core/normalize.ts
@@ -134,7 +134,8 @@ function resolveRef(node: unknown, root: Record<string, unknown>): unknown {
   const parts = ref.slice(2).split('/');
   let cur: unknown = root;
   for (const p of parts) {
-    if (cur && typeof cur === 'object') cur = (cur as Record<string, unknown>)[p];
+    const key = p.replace(/~1/g, '/').replace(/~0/g, '~');
+    if (cur && typeof cur === 'object') cur = (cur as Record<string, unknown>)[key];
     else return undefined;
   }
   return cur;


### PR DESCRIPTION
Fixes #680

## Summary

- decode `~1` and `~0` in in-document OpenAPI `$ref` path segments
- add regression coverage for escaped response component keys

## Tests

- `corepack pnpm vitest run packages/openapi/src/core/normalize.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt-openapi typecheck`