### PR TITLE
fix: encode openapi generated path parameters

### DIFF
--- a/packages/openapi/src/gen-mcp/index.test.ts
+++ b/packages/openapi/src/gen-mcp/index.test.ts
@@ -30,6 +30,7 @@ describe('generateMcpServer', () => {
     const index = await readFile(join(outDir, 'index.js'), 'utf8');
     expect(index).toContain('name: "getPet"');
     expect(index).toContain('case "getPet":');
+    expect(index).toContain('${encodeURIComponent(String(a["petId"]))}');
     expect(index).toContain('@modelcontextprotocol/sdk');
 
     const pkg = JSON.parse(await readFile(join(outDir, 'package.json'), 'utf8'));

--- a/packages/openapi/src/gen-mcp/index.ts
+++ b/packages/openapi/src/gen-mcp/index.ts
@@ -137,7 +137,10 @@ function toolDescriptor(op: Operation): string {
 }
 
 function toolHandler(op: Operation): string {
-  const pathExpr = op.path.replace(/\{([^}]+)\}/g, (_, n) => `\${a[${JSON.stringify(n)}]}`);
+  const pathExpr = op.path.replace(
+    /\{([^}]+)\}/g,
+    (_, n) => `\${encodeURIComponent(String(a[${JSON.stringify(n)}]))}`,
+  );
   const queryParams = op.parameters.filter((p) => p.in === 'query');
   const callParts: string[] = [];
   if (queryParams.length) callParts.push(`query: { ${queryParams.map((p) => `${JSON.stringify(p.name)}: a[${JSON.stringify(p.name)}]`).join(', ')} }`);

--- a/packages/openapi/src/gen-sdk-ts/index.test.ts
+++ b/packages/openapi/src/gen-sdk-ts/index.test.ts
@@ -40,6 +40,7 @@ describe('generateTsSdk', () => {
     expect(src).toContain('class PetstoreClient');
     expect(src).toContain('async listPets()');
     expect(src).toContain('async getPet(petId: string)');
+    expect(src).toContain('${encodeURIComponent(petId)}');
     expect(src).toContain('async createPet(opts: { body: unknown }):');
     expect(src).toContain('pets = {');
   });

--- a/packages/openapi/src/gen-sdk-ts/index.ts
+++ b/packages/openapi/src/gen-sdk-ts/index.ts
@@ -115,7 +115,7 @@ function renderMethod(op: Operation): string {
   if (op.requestBody) optsParts.push(`body${op.requestBody.required ? '' : '?'}: unknown`);
   if (optsParts.length) args.push(`opts: { ${optsParts.join('; ')} }${requiresOpts(op) ? '' : ' = {}'}`);
 
-  const pathExpr = op.path.replace(/\{([^}]+)\}/g, (_, n) => `\${${safe(n)}}`);
+  const pathExpr = op.path.replace(/\{([^}]+)\}/g, (_, n) => `\${encodeURIComponent(${safe(n)})}`);
   const callParts: string[] = [];
   if (queryParams.length) callParts.push('query: opts.query');
   if (headerParams.length) callParts.push('headers: opts.headers');


### PR DESCRIPTION
Fixes #682

## Summary

- encode generated SDK path parameters with `encodeURIComponent`
- encode generated MCP path parameters with `encodeURIComponent(String(...))`
- add regression assertions for both generators

## Tests

- `corepack pnpm vitest run packages/openapi/src/gen-sdk-ts/index.test.ts packages/openapi/src/gen-mcp/index.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt-openapi typecheck`