### PR TITLE
fix(cli): implement ship target available listing

### DIFF
--- a/packages/cli/src/commands/ship.test.ts
+++ b/packages/cli/src/commands/ship.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { shipCmd } from './ship.js';
+import { availableTargetAdapters, shipCmd } from './ship.js';
 
 describe('shipCmd', () => {
   it('is registered as a top-level command named "ship"', () => {
@@ -33,5 +33,21 @@ describe('shipCmd', () => {
     expect(optNames).toContain('--channel');
     expect(optNames).toContain('--dry-run');
     expect(optNames).toContain('--skip-lint');
+  });
+
+  it('lists available target adapters from the registry', () => {
+    expect(availableTargetAdapters()).toContainEqual({
+      id: 'deploy-vercel',
+      package: '@profullstack/sh1pt-target-deploy-vercel',
+      setupCommand: 'sh1pt targets deploy-vercel setup',
+    });
+  });
+
+  it('supports JSON output for target available', () => {
+    const targetCmd = shipCmd.commands.find((c) => c.name() === 'target');
+    expect(targetCmd).toBeDefined();
+    const availableCmd = targetCmd!.commands.find((c) => c.name() === 'available');
+    expect(availableCmd).toBeDefined();
+    expect(availableCmd!.options.map((o) => o.long)).toContain('--json');
   });
 });

--- a/packages/cli/src/commands/ship.ts
+++ b/packages/cli/src/commands/ship.ts
@@ -6,6 +6,7 @@ import { lint } from '@profullstack/sh1pt-policy';
 import type { Manifest } from '@profullstack/sh1pt-core';
 import { existsSync, statSync } from 'node:fs';
 import { initAction } from './init.js';
+import { categoryById, packageFor } from '../adapter-registry.js';
 
 /**
  * Load the project manifest by dynamically importing a config file.
@@ -143,6 +144,20 @@ shipCmd
 
 const targetSubCmd = shipCmd.command('target').description('Manage targets in the manifest');
 
+export function availableTargetAdapters(): Array<{
+  id: string;
+  package: string;
+  setupCommand: string;
+}> {
+  const targets = categoryById('targets');
+  if (!targets) return [];
+  return targets.adapters.map((id) => ({
+    id,
+    package: packageFor(targets, id),
+    setupCommand: `sh1pt targets ${id} setup`,
+  }));
+}
+
 targetSubCmd
   .command('add <id>')
   .description('Add a target adapter to sh1pt.config.ts')
@@ -196,6 +211,17 @@ targetSubCmd
 targetSubCmd
   .command('available')
   .description('List every target adapter available to install')
-  .action(() => {
-    console.log(kleur.dim('[stub] target available — fetch from registry'));
+  .option('--json', 'output as JSON for automation')
+  .action((opts: { json?: boolean }) => {
+    const targets = availableTargetAdapters();
+
+    if (opts.json) {
+      console.log(JSON.stringify(targets, null, 2));
+      return;
+    }
+
+    console.log(kleur.bold(`Available target adapters (${targets.length}):`));
+    for (const target of targets) {
+      console.log(`  ${kleur.cyan(target.id)}  ${kleur.dim(target.package)}`);
+    }
   });


### PR DESCRIPTION
## What changed
- Implements `sh1pt ship target available` using the CLI adapter registry instead of printing a stub.
- Adds `--json` support so automation can consume the available target adapter list.
- Adds regression coverage for registry-backed target discovery and the JSON option.

Closes #687.

## Validation
- `./node_modules/.bin/vitest.CMD run packages/cli/src/commands/ship.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt typecheck`