### PR TITLE
fix(cli): classify trailing slash forge repos as git

### DIFF
--- a/packages/cli/src/input.test.ts
+++ b/packages/cli/src/input.test.ts
@@ -14,10 +14,22 @@ describe('resolveInput', () => {
     expect(r.inferredName).toBe('sh1pt');
   });
 
+  it('detects forge repo urls with a trailing slash', () => {
+    const r = resolveInput('https://github.com/profullstack/sh1pt/');
+    expect(r.kind).toBe('git');
+    expect(r.value).toBe('https://github.com/profullstack/sh1pt');
+    expect(r.inferredName).toBe('sh1pt');
+  });
+
   it('detects gitlab repo urls', () => {
     const r = resolveInput('https://gitlab.com/some-org/some-repo');
     expect(r.kind).toBe('git');
     expect(r.inferredName).toBe('some-repo');
+  });
+
+  it('keeps forge subpath urls classified as live sites', () => {
+    const r = resolveInput('https://github.com/profullstack/sh1pt/issues/1');
+    expect(r.kind).toBe('url');
   });
 
   it('detects bitbucket repo urls', () => {

--- a/packages/cli/src/input.ts
+++ b/packages/cli/src/input.ts
@@ -66,11 +66,11 @@ export function resolveInput(raw: string): ResolvedInput {
 }
 
 function isForgeRepoUrl(u: string): boolean {
-  // Match repo-root URLs only: https://github.com/<org>/<repo>
+  // Match repo-root URLs only: https://github.com/<org>/<repo>[/]
   // with no additional path segments (issues/123, tree/main, etc.).
   // Subpath URLs like /issues/ or /tree/ are live-site pages, not clone targets.
   const m = u.match(
-    /^https?:\/\/(www\.)?(github\.com|gitlab\.com|bitbucket\.org|codeberg\.org)\/([^/\s]+)\/([^/\s?#]+)([?#].*)?$/i,
+    /^https?:\/\/(www\.)?(github\.com|gitlab\.com|bitbucket\.org|codeberg\.org)\/([^/\s]+)\/([^/\s?#]+)\/?([?#].*)?$/i,
   );
   if (!m) return false;
   // Reject if the URL path continues beyond /<org>/<repo>


### PR DESCRIPTION
## What changed
- Allows repo-root forge URLs with a trailing slash to be classified as `git` inputs.
- Keeps deeper forge paths such as `/issues/1` classified as live-site URLs.
- Adds regression coverage for both cases.

Closes #689.

## Validation
- `./node_modules/.bin/vitest.CMD run packages/cli/src/input.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt typecheck`