### PR TITLE
fix(cli): ignore non-inst ids in scale next id

### DIFF
--- a/packages/cli/src/commands/scale.test.ts
+++ b/packages/cli/src/commands/scale.test.ts
@@ -55,6 +55,8 @@ describe('getNextId', () => {
   it('ignores ids that do not match the inst- pattern', () => {
     const instances: FleetEntry[] = [
       { id: 'custom-id', provider: 'aws', status: 'running', createdAt: '', hourlyRate: 0.096 },
+      { id: '123-custom', provider: 'aws', status: 'running', createdAt: '', hourlyRate: 0.096 },
+      { id: 'inst-custom', provider: 'aws', status: 'running', createdAt: '', hourlyRate: 0.096 },
     ];
     expect(getNextId(instances)).toBe('inst-0001');
   });

--- a/packages/cli/src/commands/scale.ts
+++ b/packages/cli/src/commands/scale.ts
@@ -113,8 +113,9 @@ const PROVIDER_PRICING: Record<string, { hourly: number; spot: number }> = {
 /** Generate the next sequential instance ID (inst-0001, inst-0002, …). */
 export function getNextId(instances: FleetEntry[]): string {
   const nums = instances
-    .map(i => parseInt(i.id.replace(/^inst-/, ''), 10))
-    .filter(n => !isNaN(n));
+    .map((i) => /^inst-(\d+)$/.exec(i.id)?.[1])
+    .filter((value): value is string => value !== undefined)
+    .map((value) => Number.parseInt(value, 10));
   const max = nums.length > 0 ? Math.max(...nums) : 0;
   return `inst-${String(max + 1).padStart(4, '0')}`;
 }


### PR DESCRIPTION
## What changed
- Makes `getNextId` only consider IDs that match `inst-<digits>`.
- Adds regression coverage for numeric-looking unrelated IDs like `123-custom`.

Closes #691.

## Validation
- `./node_modules/.bin/vitest.CMD run packages/cli/src/commands/scale.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt typecheck`