### PR TITLE
fix(openapi): slug docs tag paths

### DIFF
--- a/packages/openapi/src/gen-docs/index.test.ts
+++ b/packages/openapi/src/gen-docs/index.test.ts
@@ -13,6 +13,9 @@ const SPEC = {
     '/pets': {
       get: { operationId: 'listPets', tags: ['pets'], summary: 'List pets', responses: { '200': { description: 'ok' } } },
     },
+    '/admin/tools': {
+      get: { operationId: 'listAdminTools', tags: ['Admin/Tools'], summary: 'List admin tools', responses: { '200': { description: 'ok' } } },
+    },
   },
 };
 
@@ -24,15 +27,19 @@ describe('generateDocsSite', () => {
     const paths = files.map((f) => f.path).sort();
     expect(paths).toContain('index.md');
     expect(paths).toContain('sidebar.json');
+    expect(paths).toContain('admin-tools/listadmintools.md');
     expect(paths).toContain('pets/listpets.md');
 
     const overview = await readFile(join(outDir, 'index.md'), 'utf8');
     expect(overview).toContain('# Petstore');
     expect(overview).toContain('https://api.petstore.io/v1');
     expect(overview).toContain('[`GET /pets`]');
+    expect(overview).toContain('./admin-tools/listadmintools.md');
 
     const sidebar = JSON.parse(await readFile(join(outDir, 'sidebar.json'), 'utf8'));
     expect(sidebar.groups[0].label).toBe('pets');
     expect(sidebar.groups[0].pages[0].method).toBe('GET');
+    expect(sidebar.groups[1].label).toBe('Admin/Tools');
+    expect(sidebar.groups[1].pages[0].href).toBe('admin-tools/listadmintools.md');
   });
 });

--- a/packages/openapi/src/gen-docs/index.ts
+++ b/packages/openapi/src/gen-docs/index.ts
@@ -40,14 +40,14 @@ ${ir.servers.length ? `## Servers\n\n${ir.servers.map((s) => `- \`${s}\``).join(
 ## Endpoints
 
 ${Object.entries(groups)
-  .map(([tag, ops]) => `### ${tag}\n\n${ops.map((o) => `- [\`${o.method.toUpperCase()} ${o.path}\`](./${tag}/${slug(o.id)}.md) — ${o.summary ?? ''}`).join('\n')}`)
+  .map(([tag, ops]) => `### ${tag}\n\n${ops.map((o) => `- [\`${o.method.toUpperCase()} ${o.path}\`](./${slug(tag)}/${slug(o.id)}.md) — ${o.summary ?? ''}`).join('\n')}`)
   .join('\n\n')}
 `;
 
   const opPages: GeneratedFile[] = [];
   for (const [tag, ops] of Object.entries(groups)) {
     for (const op of ops) {
-      opPages.push({ path: `${tag}/${slug(op.id)}.md`, contents: renderOpPage(op) });
+      opPages.push({ path: `${slug(tag)}/${slug(op.id)}.md`, contents: renderOpPage(op) });
     }
   }
 
@@ -60,7 +60,7 @@ ${Object.entries(groups)
         label: o.id,
         method: o.method.toUpperCase(),
         path: o.path,
-        href: `${tag}/${slug(o.id)}.md`,
+        href: `${slug(tag)}/${slug(o.id)}.md`,
       })),
     })),
   };


### PR DESCRIPTION
## What changed
- Uses slugged tag names for generated docs file paths, overview links, and sidebar hrefs.
- Keeps the original OpenAPI tag label visible in headings/sidebar labels.
- Adds regression coverage for a tag containing `/`.

Closes #693.

## Validation
- `./node_modules/.bin/vitest.CMD run packages/openapi/src/gen-docs/index.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt-openapi typecheck`