### PR TITLE
fix(cli): use homedir for credentials config fallback

### DIFF
--- a/packages/cli/src/credentials.test.ts
+++ b/packages/cli/src/credentials.test.ts
@@ -1,0 +1,31 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { configDir } from './credentials.js';
+
+const ORIGINAL_XDG_CONFIG_HOME = process.env.XDG_CONFIG_HOME;
+const ORIGINAL_HOME = process.env.HOME;
+
+describe('configDir', () => {
+  afterEach(() => {
+    if (ORIGINAL_XDG_CONFIG_HOME === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = ORIGINAL_XDG_CONFIG_HOME;
+
+    if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+    else process.env.HOME = ORIGINAL_HOME;
+  });
+
+  it('prefers XDG_CONFIG_HOME when set', () => {
+    process.env.XDG_CONFIG_HOME = join('tmp', 'xdg');
+    process.env.HOME = join('tmp', 'home');
+
+    expect(configDir()).toBe(join('tmp', 'xdg', 'sh1pt'));
+  });
+
+  it('falls back to the Node home directory when HOME is not set', () => {
+    delete process.env.XDG_CONFIG_HOME;
+    delete process.env.HOME;
+
+    expect(configDir()).toBe(join(homedir() || '.', '.config', 'sh1pt'));
+  });
+});

--- a/packages/cli/src/credentials.ts
+++ b/packages/cli/src/credentials.ts
@@ -8,6 +8,7 @@
 // access token is < 60s from expiry.
 
 import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
 const FILE_NAME = 'credentials.json';
@@ -22,7 +23,7 @@ export interface Credentials {
 export function configDir(): string {
   const xdg = process.env.XDG_CONFIG_HOME;
   if (xdg && xdg.length > 0) return join(xdg, 'sh1pt');
-  return join(process.env.HOME ?? '.', '.config', 'sh1pt');
+  return join(process.env.HOME || homedir() || '.', '.config', 'sh1pt');
 }
 
 export function credentialsPath(): string {


### PR DESCRIPTION
## What changed
- Keeps `XDG_CONFIG_HOME` as the first choice for CLI credentials.
- Falls back from `$HOME` to Node's `os.homedir()` before using `.`.
- Adds regression coverage for both the XDG path and missing-HOME fallback.

Closes #695.

## Validation
- `./node_modules/.bin/vitest.CMD run packages/cli/src/credentials.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt typecheck`