### PR TITLE
fix(cli): audit shorthand workflow containers

### DIFF
--- a/packages/cli/src/commands/build-actions.test.ts
+++ b/packages/cli/src/commands/build-actions.test.ts
@@ -61,4 +61,26 @@ jobs:
 
     expect(findings).toHaveLength(0);
   });
+
+  it('detects unpinned shorthand job container images', () => {
+    const findings = auditWorkflowContent('workflow.yml', `
+name: Container
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container: node:22
+    steps:
+      - uses: actions/checkout@v4
+      - run: pnpm test
+`);
+
+    expect(findings).toContainEqual(expect.objectContaining({
+      rule: 'unpinned-docker-image',
+      message: 'image node:22 is not pinned to a digest',
+    }));
+  });
 });

--- a/packages/cli/src/commands/build-actions.ts
+++ b/packages/cli/src/commands/build-actions.ts
@@ -141,6 +141,14 @@ export function auditWorkflowContent(file: string, content: string): WorkflowAud
     }
   }
 
+  for (const match of content.matchAll(/^\s*container:\s*([^\s#]+)\s*(?:#.*)?$/gm)) {
+    const image = match[1];
+    if (!image) continue;
+    if (!image.includes('@sha256:')) {
+      add('unpinned-docker-image', 'medium', `image ${image} is not pinned to a digest`);
+    }
+  }
+
   return findings;
 }
 


### PR DESCRIPTION
## What changed
- Flags shorthand GitHub Actions job containers such as `container: node:22` when the image is not digest-pinned.
- Keeps the existing object-form `container.image` detection.
- Adds regression coverage for the shorthand form.

Closes #697.

## Validation
- `./node_modules/.bin/vitest.CMD run packages/cli/src/commands/build-actions.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt typecheck`