### PR TITLE
fix(cli): filter malformed local vault secrets

### DIFF
--- a/packages/cli/src/local-vault.test.ts
+++ b/packages/cli/src/local-vault.test.ts
@@ -1,0 +1,38 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getSecretFromLocal, listSecretsLocal, localVaultPath } from './local-vault.js';
+
+const ORIGINAL_XDG_CONFIG_HOME = process.env.XDG_CONFIG_HOME;
+let tempDir: string | undefined;
+
+describe('local vault', () => {
+  afterEach(async () => {
+    if (ORIGINAL_XDG_CONFIG_HOME === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = ORIGINAL_XDG_CONFIG_HOME;
+
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  it('ignores malformed non-string secret values when reading asynchronously', async () => {
+    tempDir = join(tmpdir(), `sh1pt-vault-${Date.now()}`);
+    process.env.XDG_CONFIG_HOME = tempDir;
+    await mkdir(join(tempDir, 'sh1pt'), { recursive: true });
+    await writeFile(localVaultPath(), JSON.stringify({
+      version: 1,
+      secrets: {
+        TOKEN: 'secret',
+        COUNT: 123,
+        FLAGS: ['x'],
+      },
+    }));
+
+    expect(await getSecretFromLocal('TOKEN')).toBe('secret');
+    expect(await getSecretFromLocal('COUNT')).toBeUndefined();
+    expect(await listSecretsLocal()).toEqual([{ key: 'TOKEN' }]);
+  });
+});

--- a/packages/cli/src/local-vault.ts
+++ b/packages/cli/src/local-vault.ts
@@ -28,6 +28,15 @@ export function localVaultPath(): string {
   return path.join(configDir(), 'secrets.json');
 }
 
+function normalizeSecrets(value: unknown): Record<string, string> {
+  const secrets: Record<string, string> = {};
+  if (!value || typeof value !== 'object') return secrets;
+  for (const [key, secret] of Object.entries(value)) {
+    if (typeof secret === 'string') secrets[key] = secret;
+  }
+  return secrets;
+}
+
 // Sync read for SetupContext init. Returns empty map on missing file.
 // Warns once if the file is world/group-readable.
 export function loadLocalVaultSync(): Map<string, string> {
@@ -43,10 +52,8 @@ export function loadLocalVaultSync(): Map<string, string> {
     }
     const raw = readFileSync(file, 'utf8');
     const parsed = JSON.parse(raw) as Partial<LocalVault>;
-    if (parsed.secrets && typeof parsed.secrets === 'object') {
-      for (const [k, v] of Object.entries(parsed.secrets)) {
-        if (typeof v === 'string') out.set(k, v);
-      }
+    for (const [k, v] of Object.entries(normalizeSecrets(parsed.secrets))) {
+      out.set(k, v);
     }
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
@@ -63,7 +70,7 @@ async function readVault(): Promise<LocalVault> {
     const parsed = JSON.parse(raw) as Partial<LocalVault>;
     return {
       version: typeof parsed.version === 'number' ? parsed.version : VAULT_VERSION,
-      secrets: parsed.secrets && typeof parsed.secrets === 'object' ? { ...parsed.secrets } : {},
+      secrets: normalizeSecrets(parsed.secrets),
     };
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') {


### PR DESCRIPTION
## What changed
- Normalizes local vault secrets through one string-only filter for sync and async reads.
- Prevents malformed non-string values from being returned by `getSecretFromLocal()` or listed by `listSecretsLocal()`.
- Adds regression coverage with a malformed `secrets.json`.

Closes #699.

## Validation
- `./node_modules/.bin/vitest.CMD run packages/cli/src/local-vault.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt typecheck`