### PR TITLE
fix(core): ignore array adapters in config store

### DIFF
--- a/packages/core/src/config-store.test.ts
+++ b/packages/core/src/config-store.test.ts
@@ -1,0 +1,35 @@
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { configPath, readConfig } from './config-store.js';
+
+const ORIGINAL_XDG_CONFIG_HOME = process.env.XDG_CONFIG_HOME;
+let tempDir: string | undefined;
+
+describe('readConfig', () => {
+  afterEach(async () => {
+    if (ORIGINAL_XDG_CONFIG_HOME === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = ORIGINAL_XDG_CONFIG_HOME;
+
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  it('ignores malformed adapters arrays', async () => {
+    tempDir = path.join(tmpdir(), `sh1pt-config-${Date.now()}`);
+    process.env.XDG_CONFIG_HOME = tempDir;
+    await mkdir(path.dirname(configPath()), { recursive: true });
+    await writeFile(configPath(), JSON.stringify({
+      version: 1,
+      adapters: [{ id: 'target' }],
+    }));
+
+    await expect(readConfig()).resolves.toEqual({
+      version: 1,
+      adapters: {},
+    });
+  });
+});

--- a/packages/core/src/config-store.ts
+++ b/packages/core/src/config-store.ts
@@ -18,13 +18,17 @@ export function configPath(): string {
   return path.join(configDir(), 'config.json');
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
 export async function readConfig(): Promise<Sh1ptConfig> {
   try {
     const raw = await fs.readFile(configPath(), 'utf8');
     const parsed = JSON.parse(raw) as Partial<Sh1ptConfig>;
     return {
       version: typeof parsed.version === 'number' ? parsed.version : CONFIG_VERSION,
-      adapters: parsed.adapters && typeof parsed.adapters === 'object' ? parsed.adapters : {},
+      adapters: isRecord(parsed.adapters) ? parsed.adapters : {},
     };
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;


### PR DESCRIPTION
## What changed
- Makes `readConfig()` accept only record-shaped adapter maps.
- Falls back to `{}` for malformed `adapters` arrays.
- Adds regression coverage for a config file containing `adapters: []`.

Closes #701.

## Validation
- `./node_modules/.bin/vitest.CMD run packages/core/src/config-store.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt-core typecheck`