### PR TITLE
[codex] Surface HTTP MCP JSON-RPC errors

### DIFF
--- a/packages/core/src/mcp-server.test.ts
+++ b/packages/core/src/mcp-server.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { callHttpMcpTool } from './mcp-server.js';
+
+describe('callHttpMcpTool', () => {
+  it('throws JSON-RPC errors returned by JSON responses', async () => {
+    const originalFetch = globalThis.fetch;
+    let callCount = 0;
+    globalThis.fetch = async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as { id: number; method: string };
+      callCount++;
+
+      if (body.method === 'initialize') {
+        return new Response(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: body.id,
+            result: { protocolVersion: '2025-03-26', capabilities: {} },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: body.id,
+          error: { code: -32601, message: 'unknown tool' },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    };
+
+    try {
+      await expect(callHttpMcpTool(
+        { log: () => {}, secret: () => undefined, dryRun: false },
+        { name: 'missing-tool' },
+        {},
+        { url: 'https://example.test/mcp' },
+      )).rejects.toThrow('MCP error -32601: unknown tool');
+      expect(callCount).toBe(2);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -263,7 +263,7 @@ export async function callHttpMcpTool(
     const ct = res.headers.get('content-type') ?? '';
     const result = ct.includes('text/event-stream')
       ? parseSseJsonRpc(await res.text())
-      : (await res.json() as JsonRpcResponse).result;
+      : parseJsonRpcResponse(await res.json());
     return { result, headers: res.headers };
   };
 
@@ -294,6 +294,12 @@ function parseSseJsonRpc(text: string): unknown {
     }
   }
   return null;
+}
+
+function parseJsonRpcResponse(payload: unknown): unknown {
+  const parsed = payload as JsonRpcResponse;
+  if (parsed.error) throw new Error(`MCP error ${parsed.error.code}: ${parsed.error.message}`);
+  return parsed.result;
 }
 
 function normalizeToolResult(result: unknown): McpToolResult {


### PR DESCRIPTION
## Summary

- surface JSON-RPC `error` payloads from normal JSON HTTP MCP responses
- keep the existing SSE error behavior unchanged through a shared JSON response parser
- add a regression test for an `initialize` success followed by a `tools/call` JSON-RPC error

Fixes #703.

## Validation

- `./node_modules/.bin/vitest.CMD run packages/core/src/mcp-server.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt-core typecheck`