### PR TITLE
[codex] Parse multiline MCP SSE events

### DIFF
--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -280,10 +280,28 @@ export async function callHttpMcpTool(
 }
 
 function parseSseJsonRpc(text: string): unknown {
-  for (const line of text.split('\n')) {
-    const trimmed = line.trim();
-    if (!trimmed.startsWith('data: ')) continue;
-    const data = trimmed.slice(6);
+  const events: string[] = [];
+  let dataLines: string[] = [];
+
+  const flush = () => {
+    if (dataLines.length === 0) return;
+    events.push(dataLines.join('\n'));
+    dataLines = [];
+  };
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trimEnd();
+    if (line === '') {
+      flush();
+      continue;
+    }
+    if (!line.startsWith('data:')) continue;
+    const data = line.slice(5).replace(/^ /, '');
+    dataLines.push(data);
+  }
+  flush();
+
+  for (const data of events) {
     if (data === '[DONE]') continue;
     try {
       const parsed = JSON.parse(data) as JsonRpcResponse;

--- a/packages/mcp-servers/specification-website/src/index.test.ts
+++ b/packages/mcp-servers/specification-website/src/index.test.ts
@@ -40,4 +40,38 @@ describe('mcp-server-specification-website HTTP tool calls', () => {
       (globalThis as any).fetch = originalFetch;
     }
   });
+
+  it('parses SSE JSON-RPC payloads split across multiple data lines', async () => {
+    const originalFetch = globalThis.fetch;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).fetch = async (_url: unknown, init?: { body?: string }) => {
+      const body = JSON.parse(init?.body ?? '{}') as { method: string; id: number };
+      if (body.method === 'initialize') {
+        return new Response(
+          JSON.stringify({ jsonrpc: '2.0', id: body.id, result: { protocolVersion: '2025-03-26', capabilities: {} } }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (body.method === 'tools/call') {
+        return new Response(
+          [
+            `data: {"jsonrpc":"2.0","id":${body.id},`,
+            'data: "result":{"content":[{"type":"text","text":"split spec result"}]}}',
+            '',
+          ].join('\n'),
+          { status: 200, headers: { 'content-type': 'text/event-stream' } },
+        );
+      }
+      return new Response(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: null }), { status: 200, headers: { 'content-type': 'application/json' } });
+    };
+
+    try {
+      const ctx = { ...fakeConnectContext({}), dryRun: false };
+      const result = await adapter.callTool(ctx, { name: 'search', arguments: { query: 'performance' } }, {});
+      expect(result.content?.[0]).toEqual({ type: 'text', text: 'split spec result' });
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).fetch = originalFetch;
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- parse HTTP MCP SSE responses as events instead of isolated physical lines
- join multiline `data:` fields before JSON-RPC parsing
- add an adapter-level regression for a split SSE JSON-RPC tool result

Fixes #705.

## Validation

- `./node_modules/.bin/vitest.CMD run packages/mcp-servers/specification-website/src/index.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt-core typecheck`
- `corepack pnpm --filter @profullstack/sh1pt-mcp-server-specification-website typecheck`