### PR TITLE
[High] fix(stripe): enforce 5-minute timestamp tolerance to prevent webhook replay attacks

### DIFF
--- a/packages/payments/stripe/src/index.ts
+++ b/packages/payments/stripe/src/index.ts
@@ -184,6 +184,21 @@ function verifyStripeSignature(rawBody: string, header: string, secret: string):
     throw new Error('Stripe-Signature missing t or v1');
   }
 
+  // Reject replayed webhooks per Stripe's guidance:
+  // https://docs.stripe.com/webhooks/signatures#replay-prevention
+  const TOLERANCE_SECONDS = 300; // 5 minutes — matches Stripe's own SDK default
+  const ts = Number(timestamp);
+  if (!Number.isFinite(ts)) {
+    throw new Error('Stripe-Signature t is not numeric');
+  }
+  const skew = Math.abs(Math.floor(Date.now() / 1000) - ts);
+  if (skew > TOLERANCE_SECONDS) {
+    throw new Error(
+      `Stripe webhook timestamp ${ts} is outside the ${TOLERANCE_SECONDS}s tolerance (skew: ${skew}s). ` +
+      'Reject to prevent replay attacks.',
+    );
+  }
+
   const expected = createHmac('sha256', secret)
     .update(`${timestamp}.${rawBody}`)
     .digest('hex');


### PR DESCRIPTION
Stripe's own SDK and documentation require implementations to reject webhook events whose timestamp (t=) is more than 5 minutes from the current wall clock, preventing replay attacks where an attacker captures a valid (payload, signature) pair and re-submits it later.

The previous `verifyStripeSignature()` verified the HMAC correctly but never compared the timestamp against `Date.now()`, so a captured webhook could be replayed indefinitely and re-trigger business logic (refunds, orders marked paid, etc.).

**Fix:** add a 300-second (5 min) tolerance check, matching the default in Stripe's official stripe-node SDK, before computing the HMAC. Also validate that `t=` is a finite number to guard against NaN-based bypasses.

Ref: https://docs.stripe.com/webhooks/signatures#replay-prevention

**Severity: High**