### PR TITLE
[Med] fix(policy): respect Rule.appliesTo in lint() to prevent false-positive errors

### DIFF
--- a/packages/policy/src/linter.ts
+++ b/packages/policy/src/linter.ts
@@ -16,7 +16,19 @@ export const defaultRules: Rule[] = [
 ];
 
 export async function lint(ctx: LintContext, rules: Rule[] = defaultRules): Promise<LintResult> {
-  const findings = (await Promise.all(rules.map((r) => r.run(ctx)))).flat();
+  // Filter rules to those that apply to at least one target kind present in
+  // the manifest. Rules with no appliesTo constraint run against all targets.
+  // Without this filter, mobile-only rules (e.g. mobile/bundle-id) fire
+  // false-positive errors on web/api targets that happen to carry a bundleId
+  // config field for unrelated purposes.
+  const manifestKinds = new Set(
+    Object.values(ctx.manifest.targets ?? {}).map((t) => t.kind),
+  );
+  const applicable = rules.filter(
+    (r) => !r.appliesTo || r.appliesTo.length === 0 || r.appliesTo.some((k) => manifestKinds.has(k)),
+  );
+
+  const findings = (await Promise.all(applicable.map((r) => r.run(ctx)))).flat();
   const errors = findings.filter((f) => f.severity === 'error').length;
   const warnings = findings.filter((f) => f.severity === 'warn').length;
   return { findings, errors, warnings, passed: errors === 0 };


### PR DESCRIPTION
Rule declares an `appliesTo?: TargetKind[]` field documented as 'empty = applies to every target kind'. Two rules (bundleId, iconSizes) set it to `['mobile', 'tv', 'wearable']`. But `lint()` called `r.run(ctx)` for every rule unconditionally, ignoring `appliesTo` entirely.

**Result:** a manifest with a 'web' or 'api' target that incidentally carries a `config.bundleId` field (a legitimate pattern for internal naming, telemetry ids, etc.) receives hard 'error' findings from the mobile/bundle-id rule, causing CI gates to fail for non-applicable checks.

Confirmed via grep: `appliesTo` is referenced in rule.ts (interface), bundle-id.ts, and icon-sizes.ts — never in linter.ts.

**Fix:** before running rules, collect the set of target kinds present in the manifest and filter to rules whose `appliesTo` overlaps that set (or is empty/undefined, meaning universal). Adds no overhead for the common single-kind case.

**Severity: Medium**