### PR TITLE
[Low] fix(cli): fix unreachable branch in resolveInput — directories named *.json/yaml now fall through to 'path'

### DIFF
--- a/packages/cli/src/input.ts
+++ b/packages/cli/src/input.ts
@@ -54,11 +54,17 @@ export function resolveInput(raw: string): ResolvedInput {
   const abs = isAbsolute(input) ? input : resolve(process.cwd(), input);
   const ext = extname(abs).toLowerCase();
   const exists = existsSync(abs);
-  if (ext && DOC_EXTS.has(ext)) {
+  // A path qualifies as 'doc' when it has a recognised document extension
+  // AND is either a regular file or doesn't exist yet (future output path).
+  // Previously there were two branches: the first returned unconditionally
+  // on extension match, making the second (which correctly checked isFile())
+  // unreachable. This caused directories whose names end in a doc extension
+  // (e.g. './config.yaml/' used by consul-template or vault) to be
+  // classified as 'doc', leading to EISDIR when downstream code reads them.
+  const isDocLike = !!ext && DOC_EXTS.has(ext);
+  const isFileOrMissing = !exists || statSync(abs).isFile();
+  if (isDocLike && isFileOrMissing) {
     return { kind: 'doc', raw, value: abs, inferredName: baseNameWithoutExt(abs), exists };
-  }
-  if (exists && statSync(abs).isFile() && ext && DOC_EXTS.has(ext)) {
-    return { kind: 'doc', raw, value: abs, inferredName: baseNameWithoutExt(abs), exists: true };
   }
 
   // Default: treat as a local path (may or may not exist yet).


### PR DESCRIPTION
resolveInput() had two consecutive branches classifying local paths as 'doc' when their extension matched DOC_EXTS (.json, .yaml, .yml, .toml, .md, .pdf):

```
if (ext && DOC_EXTS.has(ext)) {             // always returns here
    return { kind: 'doc', … };
}
if (exists && statSync(abs).isFile() && ext && DOC_EXTS.has(ext)) {  // UNREACHABLE
    return { kind: 'doc', … };
}
```

The second branch was clearly intended to restrict 'doc' classification to actual files (excluding directories that happen to carry a doc-like extension), but the identical first predicate makes it dead code. The consequence: `sh1pt build --from ./config.yaml` where config.yaml is a directory (a real pattern in consul-template, vault, dotnet) returns kind='doc', and downstream callers fail with EISDIR when they try to read it as a file.

**Fix:** collapse to one correct check that returns 'doc' only when the path has a doc extension AND either does not exist yet (legitimate future-output path) or is a confirmed regular file. A directory named *.yaml now falls through to the 'path' default.

**Severity: Low**