### PR TITLE
fix(core): serialize config store mutations

### DIFF
--- a/packages/core/src/config-store.test.ts
+++ b/packages/core/src/config-store.test.ts
@@ -2,7 +2,7 @@ import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { configPath, readConfig } from './config-store.js';
+import { configPath, deleteAdapterConfig, readConfig, setAdapterConfig } from './config-store.js';
 
 const ORIGINAL_XDG_CONFIG_HOME = process.env.XDG_CONFIG_HOME;
 let tempDir: string | undefined;
@@ -30,6 +30,31 @@ describe('readConfig', () => {
     await expect(readConfig()).resolves.toEqual({
       version: 1,
       adapters: {},
+    });
+  });
+
+  it('preserves concurrent adapter configuration mutations', async () => {
+    tempDir = path.join(tmpdir(), `sh1pt-config-${Date.now()}`);
+    process.env.XDG_CONFIG_HOME = tempDir;
+
+    await Promise.all([
+      setAdapterConfig('target-a', { region: 'us-east' }),
+      setAdapterConfig('target-b', { region: 'eu-west' }),
+      setAdapterConfig('target-c', { region: 'ap-south' }),
+    ]);
+
+    await Promise.all([
+      deleteAdapterConfig('target-b'),
+      setAdapterConfig('target-d', { region: 'us-west' }),
+    ]);
+
+    await expect(readConfig()).resolves.toEqual({
+      version: 1,
+      adapters: {
+        'target-a': { region: 'us-east' },
+        'target-c': { region: 'ap-south' },
+        'target-d': { region: 'us-west' },
+      },
     });
   });
 });

--- a/packages/core/src/config-store.test.ts
+++ b/packages/core/src/config-store.test.ts
@@ -2,7 +2,7 @@ import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { configPath, deleteAdapterConfig, readConfig, setAdapterConfig } from './config-store.js';
+import { configPath, deleteAdapterConfig, readConfig, setAdapterConfig, writeConfig } from './config-store.js';
 
 const ORIGINAL_XDG_CONFIG_HOME = process.env.XDG_CONFIG_HOME;
 let tempDir: string | undefined;
@@ -38,6 +38,10 @@ describe('readConfig', () => {
     process.env.XDG_CONFIG_HOME = tempDir;
 
     await Promise.all([
+      writeConfig({
+        version: 1,
+        adapters: { base: { enabled: true } },
+      }),
       setAdapterConfig('target-a', { region: 'us-east' }),
       setAdapterConfig('target-b', { region: 'eu-west' }),
       setAdapterConfig('target-c', { region: 'ap-south' }),
@@ -51,6 +55,7 @@ describe('readConfig', () => {
     await expect(readConfig()).resolves.toEqual({
       version: 1,
       adapters: {
+        base: { enabled: true },
         'target-a': { region: 'us-east' },
         'target-c': { region: 'ap-south' },
         'target-d': { region: 'us-west' },

--- a/packages/core/src/config-store.ts
+++ b/packages/core/src/config-store.ts
@@ -25,7 +25,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 let configMutationLock: Promise<void> = Promise.resolve();
 
 function withConfigMutationLock<T>(mutation: () => Promise<T>): Promise<T> {
-  const next = configMutationLock.then(mutation, mutation);
+  const next = configMutationLock.then(mutation);
   configMutationLock = next.then(
     () => {},
     () => {},
@@ -48,11 +48,15 @@ export async function readConfig(): Promise<Sh1ptConfig> {
   }
 }
 
-export async function writeConfig(cfg: Sh1ptConfig): Promise<void> {
+async function writeConfigFile(cfg: Sh1ptConfig): Promise<void> {
   await fs.mkdir(configDir(), { recursive: true, mode: 0o700 });
   const tmp = `${configPath()}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
   await fs.writeFile(tmp, JSON.stringify(cfg, null, 2) + '\n', { mode: 0o600 });
   await fs.rename(tmp, configPath());
+}
+
+export function writeConfig(cfg: Sh1ptConfig): Promise<void> {
+  return withConfigMutationLock(() => writeConfigFile(cfg));
 }
 
 export async function getAdapterConfig<T = unknown>(adapterId: string): Promise<T | undefined> {
@@ -65,7 +69,7 @@ export async function setAdapterConfig(adapterId: string, adapterConfig: unknown
   return withConfigMutationLock(async () => {
     const cfg = await readConfig();
     cfg.adapters[adapterId] = adapterConfig;
-    await writeConfig(cfg);
+    await writeConfigFile(cfg);
   });
 }
 
@@ -74,6 +78,6 @@ export async function deleteAdapterConfig(adapterId: string): Promise<void> {
     const cfg = await readConfig();
     if (!(adapterId in cfg.adapters)) return;
     delete cfg.adapters[adapterId];
-    await writeConfig(cfg);
+    await writeConfigFile(cfg);
   });
 }

--- a/packages/core/src/config-store.ts
+++ b/packages/core/src/config-store.ts
@@ -22,6 +22,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
+let configMutationLock: Promise<void> = Promise.resolve();
+
+function withConfigMutationLock<T>(mutation: () => Promise<T>): Promise<T> {
+  const next = configMutationLock.then(mutation, mutation);
+  configMutationLock = next.then(
+    () => {},
+    () => {},
+  );
+  return next;
+}
+
 export async function readConfig(): Promise<Sh1ptConfig> {
   try {
     const raw = await fs.readFile(configPath(), 'utf8');
@@ -39,7 +50,7 @@ export async function readConfig(): Promise<Sh1ptConfig> {
 
 export async function writeConfig(cfg: Sh1ptConfig): Promise<void> {
   await fs.mkdir(configDir(), { recursive: true, mode: 0o700 });
-  const tmp = `${configPath()}.tmp`;
+  const tmp = `${configPath()}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
   await fs.writeFile(tmp, JSON.stringify(cfg, null, 2) + '\n', { mode: 0o600 });
   await fs.rename(tmp, configPath());
 }
@@ -51,14 +62,18 @@ export async function getAdapterConfig<T = unknown>(adapterId: string): Promise<
 }
 
 export async function setAdapterConfig(adapterId: string, adapterConfig: unknown): Promise<void> {
-  const cfg = await readConfig();
-  cfg.adapters[adapterId] = adapterConfig;
-  await writeConfig(cfg);
+  return withConfigMutationLock(async () => {
+    const cfg = await readConfig();
+    cfg.adapters[adapterId] = adapterConfig;
+    await writeConfig(cfg);
+  });
 }
 
 export async function deleteAdapterConfig(adapterId: string): Promise<void> {
-  const cfg = await readConfig();
-  if (!(adapterId in cfg.adapters)) return;
-  delete cfg.adapters[adapterId];
-  await writeConfig(cfg);
+  return withConfigMutationLock(async () => {
+    const cfg = await readConfig();
+    if (!(adapterId in cfg.adapters)) return;
+    delete cfg.adapters[adapterId];
+    await writeConfig(cfg);
+  });
 }


### PR DESCRIPTION
## Summary
- serialize adapter config read-modify-write mutations so concurrent setup operations do not overwrite each other
- use unique temporary paths for config writes to avoid concurrent temp-file collisions
- add a regression test covering concurrent set and delete operations

## Root cause
`setAdapterConfig()` and `deleteAdapterConfig()` independently read and rewrote the same config file. Concurrent calls could read the same snapshot and the last rename would silently discard another mutation.

## Validation
- `corepack pnpm vitest run packages/core/src`
- `corepack pnpm --filter @profullstack/sh1pt-core typecheck`
- `git diff --check`