### PR TITLE
fix(actions): stop pinning pnpm version in node-pnpm packs

### DIFF
--- a/packages/actions/node-pnpm-ci/README.md
+++ b/packages/actions/node-pnpm-ci/README.md
@@ -4,6 +4,10 @@ Installs a GitHub Actions workflow for Node and TypeScript projects that use pnp
 
 The workflow installs dependencies, runs typecheck, and runs tests with explicit read-only repository permissions.
 
+## Requirements
+
+The repository's `package.json` must declare a `packageManager` field (e.g. `"packageManager": "pnpm@10.0.0"`). `pnpm/action-setup@v4` reads the pnpm version from there. The workflow does **not** pin a pnpm `version` itself — pinning one that disagrees with `packageManager` fails the run with `ERR_PNPM_BAD_PM_VERSION`.
+
 ## Output
 
 `node-pnpm-ci` writes `.github/workflows/ci.yml` through a pull request.

--- a/packages/actions/node-pnpm-ci/action.yml
+++ b/packages/actions/node-pnpm-ci/action.yml
@@ -1,6 +1,6 @@
 id: node-pnpm-ci
 name: Node pnpm CI
-version: 1.0.0
+version: 1.1.0
 category: ci
 description: Least-privilege Node/TypeScript CI workflow using pnpm install, typecheck, and test.
 provider: github

--- a/packages/actions/node-pnpm-ci/schema.json
+++ b/packages/actions/node-pnpm-ci/schema.json
@@ -9,11 +9,6 @@
       "default": "22",
       "description": "Node.js version to install."
     },
-    "pnpmVersion": {
-      "type": "string",
-      "default": "9",
-      "description": "pnpm major version to install."
-    },
     "installCommand": {
       "type": "string",
       "default": "pnpm install --frozen-lockfile",

--- a/packages/actions/node-pnpm-ci/sh1pt.actionpack.yaml
+++ b/packages/actions/node-pnpm-ci/sh1pt.actionpack.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1
 id: node-pnpm-ci
 name: Node pnpm CI
 description: Least-privilege Node/TypeScript CI workflow using pnpm — install, typecheck, test.
-version: 1.0.0
+version: 1.1.0
 publisher: profullstack
 visibility: public
 license: MIT
@@ -29,10 +29,6 @@ inputs:
     type: string
     default: '22'
     description: Node.js version to install.
-  pnpmVersion:
-    type: string
-    default: '9'
-    description: pnpm major version to install.
   installCommand:
     type: string
     default: pnpm install --frozen-lockfile

--- a/packages/actions/node-pnpm-ci/workflow.yml
+++ b/packages/actions/node-pnpm-ci/workflow.yml
@@ -19,9 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # pnpm version is read from the "packageManager" field in package.json.
+      # Do not pin a version here — it conflicts with packageManager and fails
+      # with ERR_PNPM_BAD_PM_VERSION.
       - uses: pnpm/action-setup@v4
-        with:
-          version: {{pnpmVersion}}
 
       - uses: actions/setup-node@v4
         with:

--- a/packages/actions/node-pnpm-test/README.md
+++ b/packages/actions/node-pnpm-test/README.md
@@ -4,6 +4,10 @@ Installs the lightweight test workflow used by the sh1pt repository.
 
 The workflow runs on pull requests and pushes to the configured branch, installs with pnpm, and runs the configured test command with `CI=true`.
 
+## Requirements
+
+The repository's `package.json` must declare a `packageManager` field (e.g. `"packageManager": "pnpm@10.0.0"`). `pnpm/action-setup@v4` reads the pnpm version from there. The workflow does **not** pin a pnpm `version` itself — pinning one that disagrees with `packageManager` fails the run with `ERR_PNPM_BAD_PM_VERSION`.
+
 ## Output
 
 `node-pnpm-test` writes `.github/workflows/test.yml` through a pull request.

--- a/packages/actions/node-pnpm-test/action.yml
+++ b/packages/actions/node-pnpm-test/action.yml
@@ -1,6 +1,6 @@
 id: node-pnpm-test
 name: Node pnpm Test
-version: 1.0.0
+version: 1.1.0
 category: test
 description: Node/pnpm test workflow based on sh1pt's own repository test workflow.
 provider: github

--- a/packages/actions/node-pnpm-test/schema.json
+++ b/packages/actions/node-pnpm-test/schema.json
@@ -9,11 +9,6 @@
       "default": "22",
       "description": "Node.js version to install."
     },
-    "pnpmVersion": {
-      "type": "string",
-      "default": "9.12.0",
-      "description": "pnpm version to install."
-    },
     "pushBranch": {
       "type": "string",
       "default": "master",

--- a/packages/actions/node-pnpm-test/sh1pt.actionpack.yaml
+++ b/packages/actions/node-pnpm-test/sh1pt.actionpack.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1
 id: node-pnpm-test
 name: Node pnpm Test
 description: Node/pnpm test workflow based on sh1pt's own repository test workflow.
-version: 1.0.0
+version: 1.1.0
 publisher: profullstack
 visibility: public
 license: MIT
@@ -26,10 +26,6 @@ inputs:
     type: string
     default: '22'
     description: Node.js version to install.
-  pnpmVersion:
-    type: string
-    default: 9.12.0
-    description: pnpm version to install.
   pushBranch:
     type: string
     default: master

--- a/packages/actions/node-pnpm-test/workflow.yml
+++ b/packages/actions/node-pnpm-test/workflow.yml
@@ -15,9 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # pnpm version is read from the "packageManager" field in package.json.
+      # Do not pin a version here — it conflicts with packageManager and fails
+      # with ERR_PNPM_BAD_PM_VERSION.
       - uses: pnpm/action-setup@v4
-        with:
-          version: {{pnpmVersion}}
 
       - uses: actions/setup-node@v4
         with:

--- a/packages/actions/src/index.test.ts
+++ b/packages/actions/src/index.test.ts
@@ -40,7 +40,9 @@ describe('built-in packs', () => {
     const file = result.files[0];
     expect(file?.destination).toBe('.github/workflows/ci.yml');
     expect(file?.content).toContain("node-version: '22'");
-    expect(file?.content).toContain('version: 9');
+    expect(file?.content).toContain('pnpm/action-setup@v4');
+    // pnpm version comes from package.json's packageManager field, not a pinned input.
+    expect(file?.content).not.toContain('version: 9');
     expect(file?.content).toContain('pnpm install --frozen-lockfile');
     expect(file?.content).toContain('${{ github.workflow }}');
     expect(file?.content).toContain('# Managed by sh1pt Actions Fleet');
@@ -73,7 +75,9 @@ describe('built-in packs', () => {
     expect(file?.destination).toBe('.github/workflows/test.yml');
     expect(file?.content).toContain('branches: [master]');
     expect(file?.content).toContain('node-version: 22');
-    expect(file?.content).toContain('version: 9.12.0');
+    expect(file?.content).toContain('pnpm/action-setup@v4');
+    // pnpm version comes from package.json's packageManager field, not a pinned input.
+    expect(file?.content).not.toContain('version: 9.12.0');
     expect(file?.content).toContain('pnpm test');
     expect(file?.content).toContain('# Managed by sh1pt Actions Fleet');
   });


### PR DESCRIPTION
## Problem

The `node-pnpm-ci` and `node-pnpm-test` action packs hardcoded a pinned `version:` for `pnpm/action-setup@v4` (`9` and `9.12.0`). When the target repository declares a `packageManager` field in `package.json` (e.g. `"packageManager": "pnpm@10.0.0"`), action-setup@v4 refuses the conflict and fails the run:

```
ERR_PNPM_BAD_PM_VERSION
Multiple versions of pnpm specified:
  - version 9 in the GitHub Action config with the key "version"
  - version pnpm@10.0.0 in the package.json with the key "packageManager"
```

This broke **b1dz.com** CI after these packs were installed there.

## Fix

Rely on `packageManager` as the single source of truth (pnpm's official recommendation):

- Drop the pinned `version` input from both workflow templates — action-setup@v4 reads the version from `packageManager`.
- Remove the now-unused `pnpmVersion` input from both `schema.json` and `sh1pt.actionpack.yaml`.
- Bump both packs `1.0.0 → 1.1.0`.
- Document the `packageManager` requirement in both READMEs.
- Update `packages/actions/src/index.test.ts` accordingly.

All 43 actions / actions-fleet-core tests pass.

> Note: this fixes future installs. Repos that already received the old workflows (e.g. b1dz.com) need their live `ci.yml`/`test.yml` patched separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)