### PR TITLE
fix(affiliates): reject non-HTTP destination URLs

### DIFF
--- a/packages/affiliates/admitad/src/index.test.ts
+++ b/packages/affiliates/admitad/src/index.test.ts
@@ -56,6 +56,19 @@ describe('admitad affiliate adapter', () => {
     );
   });
 
+  it('rejects non-HTTP destination URLs before calling Admitad', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(adapter.getTrackingLink?.(
+      ctx,
+      '234433',
+      'javascript:alert(1)',
+      { websiteId: '232236' },
+    )).rejects.toThrow('Admitad destinationUrl must use HTTP or HTTPS');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('aggregates publisher website and action statistics', async () => {
     vi.stubGlobal('fetch', vi.fn()
       .mockResolvedValueOnce(jsonResponse({

--- a/packages/affiliates/admitad/src/index.ts
+++ b/packages/affiliates/admitad/src/index.ts
@@ -1,4 +1,4 @@
-import { defineAffiliate, tokenSetup, type AffiliateConnectContext } from '@profullstack/sh1pt-core';
+import { defineAffiliate, parseHttpUrl, tokenSetup, type AffiliateConnectContext } from '@profullstack/sh1pt-core';
 
 interface Config {
   accountId?: string;
@@ -41,6 +41,7 @@ export default defineAffiliate<Config>({
     ctx.log(`admitad deeplink · campaign=${programId}`);
     const websiteId = admitadWebsiteId(config);
     if (!websiteId) throw new Error('Admitad websiteId/accountId is required to generate deeplinks');
+    if (destinationUrl) parseHttpUrl(destinationUrl, 'Admitad destinationUrl');
 
     const query: Record<string, string | string[]> = { ulp: destinationUrl };
     for (const key of ['subid', 'subid1', 'subid2', 'subid3', 'subid4'] as const) {

--- a/packages/affiliates/cj/src/index.test.ts
+++ b/packages/affiliates/cj/src/index.test.ts
@@ -58,6 +58,19 @@ describe('CJ affiliate adapter', () => {
     expect(request.headers.authorization).toBe('Bearer cj-token');
   });
 
+  it('rejects non-HTTP destination URLs before calling Link Search', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(adapter.getTrackingLink?.(
+      ctx(),
+      '15058',
+      'data:text/html,hello',
+      { websiteId: '12345' },
+    )).rejects.toThrow('CJ destinationUrl must use HTTP or HTTPS');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('falls back to the first HTML href when Link Search omits clickUrl', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(xmlResponse(`
       <cj-api>

--- a/packages/affiliates/cj/src/index.ts
+++ b/packages/affiliates/cj/src/index.ts
@@ -1,4 +1,4 @@
-import { defineAffiliate, tokenSetup, type AffiliateConnectContext } from '@profullstack/sh1pt-core';
+import { defineAffiliate, parseHttpUrl, tokenSetup, type AffiliateConnectContext } from '@profullstack/sh1pt-core';
 
 interface Config {
   accountId?: string;
@@ -33,6 +33,7 @@ export default defineAffiliate<Config>({
     ctx.log(`cj link search · advertiser=${programId}`);
     const websiteId = config.websiteId;
     if (!websiteId) throw new Error('CJ websiteId is required to generate publisher tracking links');
+    if (destinationUrl) parseHttpUrl(destinationUrl, 'CJ destinationUrl');
 
     const xml = await cjLinkSearch(ctx, config, {
       'website-id': websiteId,

--- a/packages/affiliates/ebay-partner/src/index.test.ts
+++ b/packages/affiliates/ebay-partner/src/index.test.ts
@@ -78,6 +78,15 @@ describe('eBay Partner Network affiliate adapter', () => {
     );
   });
 
+  it('rejects non-HTTP destination URLs', async () => {
+    await expect(adapter.getTrackingLink?.(
+      ctx(),
+      '5338461150',
+      'javascript:alert(1)',
+      {},
+    )).rejects.toThrow('destinationUrl must use HTTP or HTTPS');
+  });
+
   it('aggregates Partner Reporting campaign metrics', async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonTextResponse({
       Records: [

--- a/packages/affiliates/ebay-partner/src/index.ts
+++ b/packages/affiliates/ebay-partner/src/index.ts
@@ -1,4 +1,4 @@
-import { defineAffiliate, tokenSetup, type AffiliateConnectContext } from '@profullstack/sh1pt-core';
+import { defineAffiliate, parseHttpUrl, tokenSetup, type AffiliateConnectContext } from '@profullstack/sh1pt-core';
 
 interface Config {
   accountId?: string;
@@ -48,12 +48,7 @@ export default defineAffiliate<Config>({
     if (!campaignId) throw new Error('eBay Partner campaignId is required to build tracking links');
     if (!destinationUrl) throw new Error('eBay Partner destinationUrl is required to build tracking links');
 
-    let url: URL;
-    try {
-      url = new URL(destinationUrl);
-    } catch {
-      throw new Error('eBay Partner destinationUrl must be an absolute URL');
-    }
+    const url = parseHttpUrl(destinationUrl, 'eBay Partner destinationUrl');
 
     url.searchParams.set('mkevt', config.eventType ?? DEFAULT_EVENT_TYPE);
     url.searchParams.set('mkcid', config.channelId ?? DEFAULT_CHANNEL_ID);

--- a/packages/affiliates/flexoffers/src/index.test.ts
+++ b/packages/affiliates/flexoffers/src/index.test.ts
@@ -100,6 +100,15 @@ describe('FlexOffers affiliate adapter', () => {
     )).rejects.toThrow('Domain ID is required');
   });
 
+  it('rejects non-HTTP destination URLs', async () => {
+    await expect(adapter.getTrackingLink?.(
+      ctx({}),
+      '171465',
+      'ftp://merchant.example/product',
+      { accountId: '177', useDeeplinkApi: false },
+    )).rejects.toThrow('destinationUrl must use HTTP or HTTPS');
+  });
+
   it('loads sales stats across explicit statuses', async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(jsonResponse({

--- a/packages/affiliates/flexoffers/src/index.ts
+++ b/packages/affiliates/flexoffers/src/index.ts
@@ -1,4 +1,4 @@
-import { defineAffiliate, tokenSetup, type AffiliateConnectContext } from '@profullstack/sh1pt-core';
+import { defineAffiliate, parseHttpUrl, tokenSetup, type AffiliateConnectContext } from '@profullstack/sh1pt-core';
 
 interface Config {
   accountId?: string;
@@ -57,11 +57,7 @@ export default defineAffiliate<Config>({
   async getTrackingLink(ctx, programId, destinationUrl, config) {
     ctx.log(`flexoffers deeplink · advertiser=${programId}`);
     if (!destinationUrl) throw new Error('FlexOffers destinationUrl is required');
-    try {
-      new URL(destinationUrl);
-    } catch {
-      throw new Error('FlexOffers destinationUrl must be an absolute URL');
-    }
+    parseHttpUrl(destinationUrl, 'FlexOffers destinationUrl');
 
     if (config.useDeeplinkApi !== false) {
       const data = await flexoffersGet(ctx, config, '/deeplink', deeplinkQuery(programId, destinationUrl, config));

--- a/packages/affiliates/impact/src/index.test.ts
+++ b/packages/affiliates/impact/src/index.test.ts
@@ -65,6 +65,19 @@ describe('Impact affiliate adapter', () => {
     expect(request.method).toBe('POST');
   });
 
+  it('rejects non-HTTP destination URLs before calling Impact', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(adapter.getTrackingLink?.(
+      ctx(),
+      '10000',
+      'mailto:merchant@example.com',
+      { accountId: 'IRSid' },
+    )).rejects.toThrow('Impact destinationUrl must use HTTP or HTTPS');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('supports regular program-level links when no deeplink is provided', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonTextResponse({
       TrackingUrl: 'https://example.sjv.io/c/123456/98765/101010',

--- a/packages/affiliates/impact/src/index.ts
+++ b/packages/affiliates/impact/src/index.ts
@@ -1,4 +1,4 @@
-import { defineAffiliate, tokenSetup, type AffiliateConnectContext } from '@profullstack/sh1pt-core';
+import { defineAffiliate, parseHttpUrl, tokenSetup, type AffiliateConnectContext } from '@profullstack/sh1pt-core';
 
 interface Config {
   accountId?: string;
@@ -36,6 +36,7 @@ export default defineAffiliate<Config>({
   async getTrackingLink(ctx, programId, destinationUrl, config) {
     ctx.log(`impact tracking link - program=${programId}`);
     const { accountSid } = requireAuth(ctx, config);
+    if (destinationUrl) parseHttpUrl(destinationUrl, 'Impact destinationUrl');
     const query = trackingLinkQuery(destinationUrl, config);
     const data = await impactRequest(
       ctx,

--- a/packages/affiliates/rakuten/src/index.test.ts
+++ b/packages/affiliates/rakuten/src/index.test.ts
@@ -68,6 +68,15 @@ describe('Rakuten Advertising affiliate adapter', () => {
       .rejects.toThrow('must be an absolute URL');
   });
 
+  it('rejects non-HTTP destination URLs', async () => {
+    await expect(adapter.getTrackingLink?.(
+      ctx(),
+      '123',
+      'data:text/html,not-a-product',
+      {},
+    )).rejects.toThrow('destinationUrl must use HTTP or HTTPS');
+  });
+
   it('aggregates Events API rows for one advertiser', async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
       transactions: [

--- a/packages/affiliates/rakuten/src/index.ts
+++ b/packages/affiliates/rakuten/src/index.ts
@@ -1,4 +1,4 @@
-import { defineAffiliate, tokenSetup, type AffiliateConnectContext } from '@profullstack/sh1pt-core';
+import { defineAffiliate, parseHttpUrl, tokenSetup, type AffiliateConnectContext } from '@profullstack/sh1pt-core';
 
 interface Config {
   accountId?: string;
@@ -39,11 +39,7 @@ export default defineAffiliate<Config>({
     const affiliateId = config.accountId ?? ctx.secret(ENCRYPTED_ID_KEY);
     if (!affiliateId) throw new Error('Rakuten accountId / encrypted affiliate ID is required');
     if (!destinationUrl) throw new Error('Rakuten destinationUrl is required');
-    try {
-      new URL(destinationUrl);
-    } catch {
-      throw new Error('Rakuten destinationUrl must be an absolute URL');
-    }
+    parseHttpUrl(destinationUrl, 'Rakuten destinationUrl');
     const url = new URL(config.trackingBaseUrl ?? DEFAULT_TRACKING_BASE);
     url.searchParams.set('id', affiliateId);
     url.searchParams.set('mid', programId);

--- a/packages/affiliates/shareasale/src/index.test.ts
+++ b/packages/affiliates/shareasale/src/index.test.ts
@@ -63,6 +63,11 @@ describe('ShareASale affiliate adapter', () => {
       .rejects.toThrow('must be an absolute URL');
   });
 
+  it('rejects non-HTTP destination URLs', async () => {
+    await expect(adapter.getTrackingLink?.(ctx(), '47', 'javascript:alert(1)', {}))
+      .rejects.toThrow('destinationUrl must use HTTP or HTTPS');
+  });
+
   it('aggregates JSON daily activity stats for one merchant', async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
       data: [

--- a/packages/affiliates/shareasale/src/index.ts
+++ b/packages/affiliates/shareasale/src/index.ts
@@ -1,4 +1,4 @@
-import { defineAffiliate, tokenSetup, type AffiliateConnectContext } from '@profullstack/sh1pt-core';
+import { defineAffiliate, parseHttpUrl, tokenSetup, type AffiliateConnectContext } from '@profullstack/sh1pt-core';
 
 interface Config {
   accountId?: string;
@@ -39,11 +39,7 @@ export default defineAffiliate<Config>({
     ctx.log(`shareasale tracking link · merchant=${programId}`);
     const affiliateId = affiliateIdFor(ctx, config);
     if (!destinationUrl) throw new Error('ShareASale destinationUrl is required');
-    try {
-      new URL(destinationUrl);
-    } catch {
-      throw new Error('ShareASale destinationUrl must be an absolute URL');
-    }
+    parseHttpUrl(destinationUrl, 'ShareASale destinationUrl');
     const url = new URL(config.linkBaseUrl ?? DEFAULT_LINK_BASE);
     if (config.bannerId) url.searchParams.set('b', config.bannerId);
     url.searchParams.set('u', affiliateId);

--- a/packages/affiliates/sovrn/src/index.test.ts
+++ b/packages/affiliates/sovrn/src/index.test.ts
@@ -83,6 +83,15 @@ describe('Sovrn Commerce affiliate adapter', () => {
       .rejects.toThrow('must be an absolute URL');
   });
 
+  it('rejects non-HTTP destination URLs', async () => {
+    await expect(adapter.getTrackingLink?.(
+      ctx(),
+      '9876543',
+      'mailto:test@example.com',
+      { apiKey: 'public-api-key' },
+    )).rejects.toThrow('destinationUrl must use HTTP or HTTPS');
+  });
+
   it('aggregates link report totals for stats', async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
       data: [

--- a/packages/affiliates/sovrn/src/index.ts
+++ b/packages/affiliates/sovrn/src/index.ts
@@ -1,4 +1,4 @@
-import { defineAffiliate, tokenSetup, type AffiliateConnectContext } from '@profullstack/sh1pt-core';
+import { defineAffiliate, parseHttpUrl, tokenSetup, type AffiliateConnectContext } from '@profullstack/sh1pt-core';
 
 interface Config {
   accountId?: string;
@@ -58,11 +58,7 @@ export default defineAffiliate<Config>({
     ctx.log(`sovrn tracking link · campaign=${programId}`);
     const key = commerceKey(ctx, config);
     if (!destinationUrl) throw new Error('Sovrn destinationUrl is required');
-    try {
-      new URL(destinationUrl);
-    } catch {
-      throw new Error('Sovrn destinationUrl must be an absolute URL');
-    }
+    parseHttpUrl(destinationUrl, 'Sovrn destinationUrl');
     const url = new URL(trimSlash(config.linkBaseUrl ?? DEFAULT_LINK_BASE));
     url.searchParams.set('key', key);
     url.searchParams.set('u', destinationUrl);

--- a/packages/affiliates/tradedoubler/src/index.test.ts
+++ b/packages/affiliates/tradedoubler/src/index.test.ts
@@ -72,6 +72,15 @@ describe('Tradedoubler affiliate adapter', () => {
       .rejects.toThrow('must be an absolute URL');
   });
 
+  it('rejects non-HTTP destination URLs', async () => {
+    await expect(adapter.getTrackingLink?.(
+      ctx(),
+      '41305',
+      'ftp://merchant.example/product',
+      { accountId: '2038177' },
+    )).rejects.toThrow('destinationUrl must use HTTP or HTTPS');
+  });
+
   it('uses matrix syntax to scope product-feed stats by program', async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
       feeds: [

--- a/packages/affiliates/tradedoubler/src/index.ts
+++ b/packages/affiliates/tradedoubler/src/index.ts
@@ -1,4 +1,4 @@
-import { defineAffiliate, tokenSetup, type AffiliateConnectContext } from '@profullstack/sh1pt-core';
+import { defineAffiliate, parseHttpUrl, tokenSetup, type AffiliateConnectContext } from '@profullstack/sh1pt-core';
 
 interface Config {
   accountId?: string;
@@ -37,11 +37,7 @@ export default defineAffiliate<Config>({
     const publisherId = config.accountId ?? ctx.secret(PUBLISHER_ID_KEY);
     if (!publisherId) throw new Error('Tradedoubler accountId / publisher id is required');
     if (!destinationUrl) throw new Error('Tradedoubler destinationUrl is required');
-    try {
-      new URL(destinationUrl);
-    } catch {
-      throw new Error('Tradedoubler destinationUrl must be an absolute URL');
-    }
+    parseHttpUrl(destinationUrl, 'Tradedoubler destinationUrl');
     const parts = [
       matrixPart('a', publisherId),
       matrixPart('p', programId),

--- a/packages/core/src/affiliate.ts
+++ b/packages/core/src/affiliate.ts
@@ -76,6 +76,19 @@ export function defineAffiliate<Config>(n: AffiliateNetwork<Config>): AffiliateN
   return autoSetup(n);
 }
 
+export function parseHttpUrl(value: string, label = 'URL'): URL {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error(`${label} must be an absolute URL`);
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`${label} must use HTTP or HTTPS`);
+  }
+  return url;
+}
+
 const affiliateRegistry = new Map<string, AffiliateNetwork<any>>();
 
 export function registerAffiliateNetwork(n: AffiliateNetwork<any>): void {


### PR DESCRIPTION
## Summary

- add a shared `parseHttpUrl` helper that accepts only absolute HTTP/HTTPS URLs
- apply it to eBay Partner, FlexOffers, Rakuten, ShareASale, Sovrn, and Tradedoubler
- add one non-HTTP destination regression test per affected adapter

## Why

`new URL()` accepts schemes such as `javascript:`, `data:`, `mailto:`, and `ftp:`. The affected adapters previously treated those values as valid destinations; eBay could emit a direct non-web URL, while redirect-style adapters could encode one into a tracking link.

Fixes #722.

## Validation

- focused affiliate tests: 69 passed across 6 files
- affected packages: 7 typechecks passed
- affected packages: 7 builds passed
- full test run: 2,701 passed, 1 skipped
- full run also reported 12 unrelated clean-checkout package-resolution failures and one pre-existing Windows path-separator assertion in the VS Code target tests
- `git diff --check` passed