### PR TITLE
Add run artifacts CLI subcommand

### DIFF
--- a/packages/cli/src/commands/runs.test.ts
+++ b/packages/cli/src/commands/runs.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { runsCmd } from './runs.js';
+
+describe('run command registration', () => {
+  it('registers cloud run subcommands', () => {
+    const subcommands = runsCmd.commands.map((command) => command.name());
+
+    expect(subcommands).toContain('list');
+    expect(subcommands).toContain('status');
+    expect(subcommands).toContain('logs');
+    expect(subcommands).toContain('artifacts');
+  });
+});

--- a/packages/cli/src/commands/runs.ts
+++ b/packages/cli/src/commands/runs.ts
@@ -46,3 +46,16 @@ runsCmd
     console.log(kleur.dim(`[stub] run logs · id=${runId} · follow=${!!opts.follow}${target}`));
     // TODO: stream NDJSON-over-SSE from /v1/runs/:id/logs.
   });
+
+runsCmd
+  .command('artifacts <runId>')
+  .description('List artifacts produced by one cloud run.')
+  .option('--json', 'emit machine-readable JSON')
+  .action((runId: string, opts: { json?: boolean }) => {
+    if (opts.json) {
+      console.log(JSON.stringify({ id: runId, artifacts: [] }, null, 2));
+      return;
+    }
+    console.log(kleur.dim(`[stub] run artifacts · id=${runId}`));
+    // TODO: GET /v1/runs/:id/artifacts.
+  });


### PR DESCRIPTION
Refs #133.

Adds a `sh1pt run artifacts <runId>` subcommand alongside the existing run list, status, and logs commands. The command currently matches the stubbed run-command style and supports `--json` output for future API integration.

Changes:
- register `run artifacts <runId>` with human-readable stub output
- add `--json` output returning `{ id, artifacts: [] }`
- extend run command registration coverage to include `artifacts`

Tests:
- `git diff --check origin/master...HEAD`
- `pnpm --filter @profullstack/sh1pt-cli test -- runs.test.ts` blocked locally: `pnpm` not available in PATH

/claim #133