### PR TITLE
fix(cli): handle malformed Bluesky profile URLs

### DIFF
--- a/packages/cli/src/social-follow.test.ts
+++ b/packages/cli/src/social-follow.test.ts
@@ -26,6 +26,12 @@ describe('social follow target parsing', () => {
     expect(() => parseSocialFollowTarget('https://example.com/alice')).toThrow('only supports bsky.app URLs');
   });
 
+  it('rejects malformed Bluesky profile URLs with a useful error', () => {
+    expect(() => parseSocialFollowTarget('https://bsky.app/profile/%E0%A4%A')).toThrow(
+      'Could not parse Bluesky profile URL',
+    );
+  });
+
   it('normalizes follow actions', () => {
     expect(normalizeFollowAction(undefined)).toBe('follow');
     expect(normalizeFollowAction('follow')).toBe('follow');

--- a/packages/cli/src/social-follow.ts
+++ b/packages/cli/src/social-follow.ts
@@ -94,7 +94,12 @@ export function parseSocialFollowTarget(input: string, explicitPlatform?: string
     throw new Error(`social follow only supports bsky.app URLs today; got ${host}`);
   }
 
-  const segments = url.pathname.split('/').filter(Boolean).map(decodeURIComponent);
+  let segments: string[];
+  try {
+    segments = url.pathname.split('/').filter(Boolean).map(decodeURIComponent);
+  } catch {
+    throw new Error(`Could not parse Bluesky profile URL ${input}`);
+  }
   const profileIndex = segments.indexOf('profile');
   const actor = profileIndex >= 0 ? segments[profileIndex + 1] : undefined;
   if (!actor) throw new Error(`Could not find a Bluesky profile handle or DID in ${input}`);


### PR DESCRIPTION
## Summary

- catch malformed percent-encoding in Bluesky profile URL paths
- return a clear user-facing validation error instead of a raw URIError
- add a focused regression test

Closes #727

## Validation

- `pnpm exec vitest run packages/cli/src/social-follow.test.ts` (7 tests passed)
- `pnpm --filter @profullstack/sh1pt... build`
- `pnpm --filter @profullstack/sh1pt typecheck`