### PR TITLE
Preserve live URL query trailing slashes

### DIFF
--- a/packages/cli/src/input.test.ts
+++ b/packages/cli/src/input.test.ts
@@ -48,6 +48,15 @@ describe('resolveInput', () => {
     expect(r.inferredName).toBe('example.com');
   });
 
+  it('preserves query and fragment trailing slashes for live-site urls', () => {
+    expect(resolveInput('https://example.com/search/?q=/').value).toBe(
+      'https://example.com/search?q=/',
+    );
+    expect(resolveInput('https://example.com/docs/#/intro/').value).toBe(
+      'https://example.com/docs#/intro/',
+    );
+  });
+
   it('strips www from inferred hostname', () => {
     const r = resolveInput('https://www.acme.io');
     expect(r.inferredName).toBe('acme.io');

--- a/packages/cli/src/input.ts
+++ b/packages/cli/src/input.ts
@@ -104,8 +104,9 @@ function normalizeGitUrl(u: string): string {
 }
 
 function normalizeUrl(u: string): string {
-  // For live-site URLs keep query strings and fragments intact; only strip trailing slashes.
-  return u.replace(/\/+$/, '');
+  // For live-site URLs keep query strings and fragments intact; only strip
+  // trailing slashes from the path segment.
+  return u.replace(/\/+(?=[?#]|$)/, '');
 }
 
 function repoNameFromGit(u: string): string | undefined {


### PR DESCRIPTION
Fixes #731.

### What changed
- Keeps query strings and fragments intact when normalizing live-site URLs.
- Still strips trailing slashes from the path segment.
- Adds a regression test for query and fragment values ending in `/`.

### Validation
- `corepack pnpm vitest run packages/cli/src/input.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt typecheck` currently fails on existing workspace/type errors outside this change, including unresolved workspace package imports and unrelated implicit-any errors.