### PR TITLE
Trim Bluesky social follow targets

### DIFF
--- a/packages/cli/src/social-follow.test.ts
+++ b/packages/cli/src/social-follow.test.ts
@@ -22,6 +22,19 @@ describe('social follow target parsing', () => {
     });
   });
 
+  it('trims whitespace around Bluesky handles and URLs', () => {
+    expect(parseSocialFollowTarget(' @alice.bsky.social ', 'bluesky')).toEqual({
+      platform: 'bluesky',
+      actor: 'alice.bsky.social',
+      source: 'profile',
+    });
+    expect(parseSocialFollowTarget(' https://bsky.app/profile/source.bsky.social/followers ')).toEqual({
+      platform: 'bluesky',
+      actor: 'source.bsky.social',
+      source: 'followers',
+    });
+  });
+
   it('rejects unsupported social URLs', () => {
     expect(() => parseSocialFollowTarget('https://example.com/alice')).toThrow('only supports bsky.app URLs');
   });

--- a/packages/cli/src/social-follow.ts
+++ b/packages/cli/src/social-follow.ts
@@ -74,6 +74,7 @@ interface BlueskyCreateRecordResponse extends BlueskyErrorResponse {
 }
 
 export function parseSocialFollowTarget(input: string, explicitPlatform?: string): SocialFollowTarget {
+  input = input.trim();
   const platform = normalizePlatform(explicitPlatform);
   if (platform && platform !== 'bluesky') {
     throw new Error(`social follow only supports Bluesky URLs today; got --platform ${explicitPlatform}`);


### PR DESCRIPTION
Fixes #734.

## Summary
- Trim social follow target input before URL parsing and bare Bluesky handle fallback
- Preserve existing parsing behavior for profile/follows/followers sources
- Add regression coverage for whitespace-padded Bluesky handles and URLs

## Verification
- `corepack pnpm vitest run packages/cli/src/social-follow.test.ts`

## Note
- `corepack pnpm --filter @profullstack/sh1pt typecheck` still fails on pre-existing workspace resolution/type errors unrelated to this patch, including unresolved `@profullstack/sh1pt-core`, `@profullstack/sh1pt-actions-fleet-core`, and `@profullstack/sh1pt-openapi/*`.