### PR TITLE
Trim social follow action values

### DIFF
--- a/packages/cli/src/social-follow.test.ts
+++ b/packages/cli/src/social-follow.test.ts
@@ -29,6 +29,7 @@ describe('social follow target parsing', () => {
   it('normalizes follow actions', () => {
     expect(normalizeFollowAction(undefined)).toBe('follow');
     expect(normalizeFollowAction('follow')).toBe('follow');
+    expect(normalizeFollowAction(' unfollow ')).toBe('unfollow');
     expect(normalizeFollowAction('follow', true)).toBe('unfollow');
     expect(() => normalizeFollowAction('block')).toThrow('Expected --action follow or --action unfollow');
   });

--- a/packages/cli/src/social-follow.ts
+++ b/packages/cli/src/social-follow.ts
@@ -110,7 +110,7 @@ export function parseSocialFollowTarget(input: string, explicitPlatform?: string
 
 export function normalizeFollowAction(action: string | undefined, unfollow = false): SocialFollowAction {
   if (unfollow) return 'unfollow';
-  const normalized = (action ?? 'follow').toLowerCase();
+  const normalized = (action ?? 'follow').trim().toLowerCase();
   if (normalized === 'follow' || normalized === 'unfollow') return normalized;
   throw new Error(`Expected --action follow or --action unfollow; got "${action}"`);
 }


### PR DESCRIPTION
Closes #736.

## Summary
- Trim surrounding whitespace before normalizing `sh1pt promote social follow --action` values.
- Add a regression assertion for `" unfollow "`.

## Verification
- `corepack pnpm vitest run packages/cli/src/social-follow.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt typecheck` *(fails on existing workspace/module-resolution errors unrelated to this change: missing `@profullstack/sh1pt-core`, `@profullstack/sh1pt-openapi/*`, etc.)*