### PR TITLE
Sync CLI adapter registry with package directories

### DIFF
--- a/packages/cli/src/adapter-registry.test.ts
+++ b/packages/cli/src/adapter-registry.test.ts
@@ -2,9 +2,12 @@ import { readdirSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import { categoryById } from './adapter-registry.js';
+import { CATEGORIES } from './adapter-registry.js';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const excludedPackageDirs = new Map<string, Set<string>>([
+  ['bots', new Set(['core'])],
+]);
 
 function packageDirs(path: string): string[] {
   return readdirSync(path)
@@ -13,11 +16,13 @@ function packageDirs(path: string): string[] {
 }
 
 describe('adapter registry', () => {
-  it('lists every target package directory', () => {
-    const targets = categoryById('targets');
+  for (const category of CATEGORIES) {
+    it(`lists every ${category.id} package directory`, () => {
+      const excluded = excludedPackageDirs.get(category.id) ?? new Set<string>();
+      const dirs = packageDirs(join(repoRoot, 'packages', category.id))
+        .filter((name) => !excluded.has(name));
 
-    expect(targets?.adapters.slice().sort()).toEqual(
-      packageDirs(join(repoRoot, 'packages', 'targets'))
-    );
-  });
+      expect(category.adapters.slice().sort()).toEqual(dirs);
+    });
+  }
 });

--- a/packages/cli/src/adapter-registry.ts
+++ b/packages/cli/src/adapter-registry.ts
@@ -42,7 +42,7 @@ export const CATEGORIES: readonly AdapterCategory[] = [
       'chutes', 'clarifai', 'claude', 'cloudflare', 'cohere', 'deepinfra',
       'deepseek', 'featherless', 'fireworks', 'friendli', 'gemini',
       'gmicloud', 'google-vertex', 'groq', 'inception', 'inceptron',
-      'infermatic', 'inflection', 'ionet', 'kimi', 'liquid', 'mancer',
+      'infermatic', 'inflection', 'ionet', 'kimi', 'liquid', 'litellm', 'mancer',
       'minimax', 'mistral', 'moonshot', 'morph', 'nebius', 'nextbit',
       'novita', 'openai', 'openinference', 'parasail', 'perceptron',
       'perplexity', 'phala', 'qwen', 'reka', 'relace', 'sambanova',
@@ -126,7 +126,7 @@ export const CATEGORIES: readonly AdapterCategory[] = [
     id: 'mcp-servers',
     pkgPrefix: '@profullstack/sh1pt-mcp-server',
     description: 'MCP server callers - tool calls over configured MCP transports',
-    adapters: ['penpot'],
+    adapters: ['penpot', 'specification-website'],
   },
   {
     id: 'outreach',
@@ -144,7 +144,7 @@ export const CATEGORIES: readonly AdapterCategory[] = [
     id: 'promo',
     pkgPrefix: '@profullstack/sh1pt-promo',
     description: 'Ad networks + fundraising rails',
-    adapters: ['angellist', 'apple-search', 'capitalreach', 'google', 'kickstarter', 'linkedin', 'meta', 'microsoft', 'openvc', 'reddit', 'tiktok', 'wefunder', 'x', 'youtube'],
+    adapters: ['angellist', 'apple-search', 'capitalreach', 'google', 'kickstarter', 'linkedin', 'meta', 'microsoft', 'openvc', 'posthog', 'reddit', 'tiktok', 'wefunder', 'x', 'youtube'],
   },
   {
     id: 'recipes',


### PR DESCRIPTION
Closes #738.

## Summary
- Add existing `litellm`, `specification-website`, and `posthog` packages to the CLI adapter registry.
- Expand the adapter registry test to verify every category against `packages/<category>`.
- Preserve the intentional `bots/core` exclusion documented in the registry comment.

## Verification
- `corepack pnpm vitest run packages/cli/src/adapter-registry.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt typecheck` *(fails on existing workspace/module-resolution errors unrelated to this change: missing `@profullstack/sh1pt-core`, `@profullstack/sh1pt-openapi/*`, etc.)*