### PR TITLE
Parse quoted payment config keys

### DIFF
--- a/packages/cli/src/commands/config-payments.ts
+++ b/packages/cli/src/commands/config-payments.ts
@@ -1,0 +1,106 @@
+type PaymentProviderSummary = {
+  key: string;
+  use: string;
+  enabled: boolean;
+  isDefault: boolean;
+};
+
+export type PaymentsSummary = {
+  path: string;
+  defaultProvider?: string;
+  platformFeeBps?: number;
+  providers: PaymentProviderSummary[];
+};
+
+export function parsePaymentsSummary(source: string, path = 'sh1pt.config.ts'): PaymentsSummary | undefined {
+  const payments = readObjectBody(source, 'payments');
+  if (!payments) return undefined;
+  const providers = readObjectBody(payments, 'providers');
+  const defaultProvider = readStringProperty(payments, 'defaultProvider');
+  const fee = readNumberProperty(payments, 'platformFeeBps');
+  const providerBlocks = providers ? readTopLevelObjectEntries(providers) : [];
+  return {
+    path,
+    defaultProvider,
+    platformFeeBps: fee,
+    providers: providerBlocks.map(({ key, body }) => {
+      const use = readStringProperty(body, 'use') ?? key;
+      const enabled = readBooleanProperty(body, 'enabled') ?? true;
+      return { key, use, enabled, isDefault: use === defaultProvider || key === defaultProvider };
+    }),
+  };
+}
+
+function readObjectBody(source: string, property: string): string | undefined {
+  const match = new RegExp(`(?:^|[,{\\s])${propertyKeyPattern(property)}\\s*:`).exec(source);
+  if (!match) return undefined;
+  const open = source.indexOf('{', match.index + match[0].length);
+  if (open === -1) return undefined;
+  const close = findMatchingBrace(source, open);
+  return close === -1 ? undefined : source.slice(open + 1, close);
+}
+
+function readTopLevelObjectEntries(source: string): Array<{ key: string; body: string }> {
+  const entries: Array<{ key: string; body: string }> = [];
+  const keyRe = /(?:^|,)\s*(['"]?[A-Za-z0-9_-]+['"]?)\s*:/g;
+  let match: RegExpExecArray | null;
+  while ((match = keyRe.exec(source))) {
+    const rawKey = match[1];
+    if (!rawKey) continue;
+    const open = source.indexOf('{', keyRe.lastIndex);
+    if (open === -1) continue;
+    const between = source.slice(keyRe.lastIndex, open).trim();
+    if (between.length > 0) continue;
+    const close = findMatchingBrace(source, open);
+    if (close === -1) continue;
+    entries.push({ key: rawKey.replace(/^['"]|['"]$/g, ''), body: source.slice(open + 1, close) });
+    keyRe.lastIndex = close + 1;
+  }
+  return entries;
+}
+
+function findMatchingBrace(source: string, open: number): number {
+  let depth = 0;
+  let quote: '"' | "'" | '`' | undefined;
+  for (let i = open; i < source.length; i += 1) {
+    const ch = source[i];
+    const prev = source[i - 1];
+    if (quote) {
+      if (ch === quote && prev !== '\\') quote = undefined;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch;
+      continue;
+    }
+    if (ch === '{') depth += 1;
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+function readStringProperty(source: string, key: string): string | undefined {
+  const match = new RegExp(`${propertyKeyPattern(key)}\\s*:\\s*['"]([^'"]+)['"]`).exec(source);
+  return match?.[1];
+}
+
+function readNumberProperty(source: string, key: string): number | undefined {
+  const match = new RegExp(`${propertyKeyPattern(key)}\\s*:\\s*(\\d+)`).exec(source);
+  return match?.[1] ? Number(match[1]) : undefined;
+}
+
+function readBooleanProperty(source: string, key: string): boolean | undefined {
+  const match = new RegExp(`${propertyKeyPattern(key)}\\s*:\\s*(true|false)`).exec(source);
+  return match?.[1] === undefined ? undefined : match[1] === 'true';
+}
+
+function propertyKeyPattern(key: string): string {
+  return `['"]?${escapeRegExp(key)}['"]?`;
+}
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/cli/src/commands/config.test.ts
+++ b/packages/cli/src/commands/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parsePaymentsSummary } from './config.js';
+import { parsePaymentsSummary } from './config-payments.js';
 
 describe('parsePaymentsSummary', () => {
   it('extracts configured providers, default, and platform fee from sh1pt config text', () => {
@@ -34,5 +34,28 @@ describe('parsePaymentsSummary', () => {
 
   it('returns undefined when no payments block exists', () => {
     expect(parsePaymentsSummary('export default defineConfig({ name: "demo" })')).toBeUndefined();
+  });
+
+  it('extracts payments when config object keys are quoted', () => {
+    const summary = parsePaymentsSummary(`
+      export default defineConfig({
+        "payments": {
+          "defaultProvider": "coinpay",
+          "providers": {
+            "coinpay": { "use": "payment-coinpay", "enabled": true },
+          },
+          "platformFeeBps": 250,
+        },
+      });
+    `);
+
+    expect(summary).toEqual({
+      path: 'sh1pt.config.ts',
+      defaultProvider: 'coinpay',
+      platformFeeBps: 250,
+      providers: [
+        { key: 'coinpay', use: 'payment-coinpay', enabled: true, isDefault: true },
+      ],
+    });
   });
 });

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -5,22 +5,11 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { runSetup, type SetupContext, type SetupPromptDef, type AdapterWithSetup } from '@profullstack/sh1pt-core';
 import { ensureInstalled, loadInstalledPackage } from '../installer.js';
+import { parsePaymentsSummary, type PaymentsSummary } from './config-payments.js';
+
+export { parsePaymentsSummary } from './config-payments.js';
 
 type Stack = 'node' | 'bun' | 'python' | 'rust' | 'cpp' | 'dotnet' | 'custom';
-
-type PaymentProviderSummary = {
-  key: string;
-  use: string;
-  enabled: boolean;
-  isDefault: boolean;
-};
-
-type PaymentsSummary = {
-  path: string;
-  defaultProvider?: string;
-  platformFeeBps?: number;
-  providers: PaymentProviderSummary[];
-};
 
 const STACKS: Array<{ value: Stack; title: string; description: string; supported: boolean }> = [
   { value: 'node',   title: 'Node + TypeScript + React',  description: 'Next.js / Expo / Tauri / Chrome ext', supported: true  },
@@ -417,25 +406,6 @@ function urlKeyFor(target: string): string {
   } as Record<string, string>)[target] ?? 'WEBHOOK_URL';
 }
 
-export function parsePaymentsSummary(source: string, path = 'sh1pt.config.ts'): PaymentsSummary | undefined {
-  const payments = readObjectBody(source, 'payments');
-  if (!payments) return undefined;
-  const providers = readObjectBody(payments, 'providers');
-  const defaultProvider = readStringProperty(payments, 'defaultProvider');
-  const fee = readNumberProperty(payments, 'platformFeeBps');
-  const providerBlocks = providers ? readTopLevelObjectEntries(providers) : [];
-  return {
-    path,
-    defaultProvider,
-    platformFeeBps: fee,
-    providers: providerBlocks.map(({ key, body }) => {
-      const use = readStringProperty(body, 'use') ?? key;
-      const enabled = readBooleanProperty(body, 'enabled') ?? true;
-      return { key, use, enabled, isDefault: use === defaultProvider || key === defaultProvider };
-    }),
-  };
-}
-
 function readPaymentsSummary(cwd: string, configPath: string): PaymentsSummary {
   const path = configPath.startsWith('/') ? configPath : join(cwd, configPath);
   if (!existsSync(path)) {
@@ -463,76 +433,6 @@ function renderPaymentsSummary(summary: PaymentsSummary): void {
   if (summary.platformFeeBps !== undefined) {
     console.log(kleur.dim(`platformFeeBps: ${summary.platformFeeBps}`));
   }
-}
-
-function readObjectBody(source: string, property: string): string | undefined {
-  const match = new RegExp(`(?:^|[,{\\s])${escapeRegExp(property)}\\s*:`).exec(source);
-  if (!match) return undefined;
-  const open = source.indexOf('{', match.index + match[0].length);
-  if (open === -1) return undefined;
-  const close = findMatchingBrace(source, open);
-  return close === -1 ? undefined : source.slice(open + 1, close);
-}
-
-function readTopLevelObjectEntries(source: string): Array<{ key: string; body: string }> {
-  const entries: Array<{ key: string; body: string }> = [];
-  const keyRe = /(?:^|,)\s*(['"]?[A-Za-z0-9_-]+['"]?)\s*:/g;
-  let match: RegExpExecArray | null;
-  while ((match = keyRe.exec(source))) {
-    const rawKey = match[1];
-    if (!rawKey) continue;
-    const open = source.indexOf('{', keyRe.lastIndex);
-    if (open === -1) continue;
-    const between = source.slice(keyRe.lastIndex, open).trim();
-    if (between.length > 0) continue;
-    const close = findMatchingBrace(source, open);
-    if (close === -1) continue;
-    entries.push({ key: rawKey.replace(/^['"]|['"]$/g, ''), body: source.slice(open + 1, close) });
-    keyRe.lastIndex = close + 1;
-  }
-  return entries;
-}
-
-function findMatchingBrace(source: string, open: number): number {
-  let depth = 0;
-  let quote: '"' | "'" | '`' | undefined;
-  for (let i = open; i < source.length; i += 1) {
-    const ch = source[i];
-    const prev = source[i - 1];
-    if (quote) {
-      if (ch === quote && prev !== '\\') quote = undefined;
-      continue;
-    }
-    if (ch === '"' || ch === "'" || ch === '`') {
-      quote = ch;
-      continue;
-    }
-    if (ch === '{') depth += 1;
-    if (ch === '}') {
-      depth -= 1;
-      if (depth === 0) return i;
-    }
-  }
-  return -1;
-}
-
-function readStringProperty(source: string, key: string): string | undefined {
-  const match = new RegExp(`${escapeRegExp(key)}\\s*:\\s*['"]([^'"]+)['"]`).exec(source);
-  return match?.[1];
-}
-
-function readNumberProperty(source: string, key: string): number | undefined {
-  const match = new RegExp(`${escapeRegExp(key)}\\s*:\\s*(\\d+)`).exec(source);
-  return match?.[1] ? Number(match[1]) : undefined;
-}
-
-function readBooleanProperty(source: string, key: string): boolean | undefined {
-  const match = new RegExp(`${escapeRegExp(key)}\\s*:\\s*(true|false)`).exec(source);
-  return match?.[1] === undefined ? undefined : match[1] === 'true';
-}
-
-function escapeRegExp(input: string): string {
-  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 // Build the SetupContext the CLI hands to every adapter.setup(). Today


### PR DESCRIPTION
Closes #740.

## Summary
- Teach the payments config parser to match quoted object keys such as `"payments"`, `"providers"`, and `"defaultProvider"`.
- Move the payments parser into a dependency-light module so parser tests do not need the full CLI runtime imports.
- Add regression coverage for JSON-style quoted config keys.

## Verification
- `corepack pnpm vitest run packages/cli/src/commands/config.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt typecheck` *(fails on existing workspace/module-resolution errors unrelated to this change: missing `@profullstack/sh1pt-core`, `@profullstack/sh1pt-openapi/*`, etc.)*