### PR TITLE
Validate deploy numeric options before actions run

### DIFF
--- a/packages/cli/src/commands/deploy.test.ts
+++ b/packages/cli/src/commands/deploy.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { parsePositiveFiniteNumber, parsePositiveSafeInteger } from './deploy.js';
+
+describe('deploy numeric option parsers', () => {
+  it('accepts positive safe integer resource counts', () => {
+    expect(parsePositiveSafeInteger('4')).toBe(4);
+  });
+
+  it.each(['nope', '0', '-1', '1.5', 'Infinity', '9007199254740992'])(
+    'rejects invalid resource count %s',
+    (value) => {
+      expect(() => parsePositiveSafeInteger(value)).toThrow('positive safe integer');
+    },
+  );
+
+  it('accepts positive finite memory and price values', () => {
+    expect(parsePositiveFiniteNumber('0.5')).toBe(0.5);
+    expect(parsePositiveFiniteNumber('12.75')).toBe(12.75);
+  });
+
+  it.each(['nope', '0', '-1', 'NaN', 'Infinity', '-Infinity'])(
+    'rejects invalid finite value %s',
+    (value) => {
+      expect(() => parsePositiveFiniteNumber(value)).toThrow('positive finite number');
+    },
+  );
+});

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -1,5 +1,21 @@
-import { Command } from 'commander';
+import { Command, InvalidArgumentError } from 'commander';
 import kleur from 'kleur';
+
+export function parsePositiveSafeInteger(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new InvalidArgumentError('must be a positive safe integer');
+  }
+  return parsed;
+}
+
+export function parsePositiveFiniteNumber(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new InvalidArgumentError('must be a positive finite number');
+  }
+  return parsed;
+}
 
 export const deployCmd = new Command('deploy')
   .description('Provision cloud infrastructure — VPS, GPU, bare metal, managed databases, object storage')
@@ -21,10 +37,10 @@ deployCmd
   .command('quote')
   .description('Price-check a spec across every connected provider before provisioning')
   .requiredOption('--kind <kind>', 'cpu-vps | gpu | bare-metal | managed-db | block-storage | object-storage')
-  .option('--cpu <n>', 'vCPU count', Number)
-  .option('--memory <gb>', 'RAM in GB', Number)
+  .option('--cpu <n>', 'vCPU count', parsePositiveSafeInteger)
+  .option('--memory <gb>', 'RAM in GB', parsePositiveFiniteNumber)
   .option('--gpu <model>', 'GPU model, e.g. A100, H100, RTX-4090')
-  .option('--gpu-count <n>', 'GPUs per instance', Number)
+  .option('--gpu-count <n>', 'GPUs per instance', parsePositiveSafeInteger)
   .option('--region <id>')
   .option('--spot', 'accept interruptible / spot instances for lower price')
   .action((opts) => {
@@ -37,14 +53,14 @@ deployCmd
   .description('Spin up a new instance (WILL start billing — pair with a --max-hourly-price guardrail)')
   .requiredOption('--provider <id>', 'e.g. cloud-runpod, cloud-digitalocean')
   .requiredOption('--kind <kind>')
-  .option('--cpu <n>', 'vCPU count', Number)
-  .option('--memory <gb>', 'memory in GB', Number)
+  .option('--cpu <n>', 'vCPU count', parsePositiveSafeInteger)
+  .option('--memory <gb>', 'memory in GB', parsePositiveFiniteNumber)
   .option('--gpu <model>', 'GPU model, e.g. A100, H100')
-  .option('--gpu-count <n>', 'number of GPUs', Number)
+  .option('--gpu-count <n>', 'number of GPUs', parsePositiveSafeInteger)
   .option('--region <id>')
   .option('--image <name>')
   .option('--spot')
-  .option('--max-hourly-price <usd>', 'abort if quote exceeds this (strongly recommended for GPU)', Number)
+  .option('--max-hourly-price <usd>', 'abort if quote exceeds this (strongly recommended for GPU)', parsePositiveFiniteNumber)
   .option('--dry-run', 'show the plan without starting a bill')
   .action((opts) => {
     if (opts.kind === 'gpu' && !opts.maxHourlyPrice) {


### PR DESCRIPTION
Fixes #743.

## Changes
- require positive safe integers for CPU and GPU counts
- require positive finite numbers for memory and maximum hourly price
- reject NaN, Infinity, fractions for counts, non-positive values, and unsafe integers during Commander parsing
- add focused regression tests

## Verification
- `corepack pnpm vitest run packages/cli/src/commands/deploy.test.ts` (14 passed)
- `corepack pnpm --filter @profullstack/sh1pt typecheck` attempted; it still fails on existing workspace/module-resolution errors unrelated to this PR