### PR TITLE
feat(cli): add threads oauth registration guide

### DIFF
--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -359,7 +359,7 @@ const OAUTH_REGISTRATION_GUIDES: OAuthRegistrationGuide[] = [
     scopes: ['threads_basic', 'threads_content_publish'],
     steps: [
       'Go to https://developers.facebook.com/apps/ and click "Create App"',
-      'Choose "Other" or "Business" as the app type',
+      'Choose "Business" as the app type',
       'Add the "Threads API" product to the app',
       'Under "Settings → Basic", note your App ID and App Secret',
       'Under "Threads API → Settings", add the redirect URIs listed below to "Valid OAuth Redirect URIs"',

--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -351,6 +351,22 @@ const OAUTH_REGISTRATION_GUIDES: OAuthRegistrationGuide[] = [
     ],
   },
   {
+    platform: 'threads',
+    label: 'Threads (Meta)',
+    url: 'https://developers.facebook.com/apps/',
+    docUrl: 'https://developers.facebook.com/docs/threads',
+    redirectUris: ['http://127.0.0.1:8765/callback', 'https://sh1pt.com/auth/callback'],
+    scopes: ['threads_basic', 'threads_content_publish'],
+    steps: [
+      'Go to https://developers.facebook.com/apps/ and click "Create App"',
+      'Choose "Other" or "Business" as the app type',
+      'Add the "Threads API" product to the app',
+      'Under "Settings → Basic", note your App ID and App Secret',
+      'Under "Threads API → Settings", add the redirect URIs listed below to "Valid OAuth Redirect URIs"',
+      'Ensure "threads_basic" and "threads_content_publish" permissions are configured',
+    ],
+  },
+  {
     platform: 'tiktok',
     label: 'TikTok',
     url: 'https://developers.tiktok.com/apps/',


### PR DESCRIPTION
This PR adds the missing OAuth registration guide for Threads (Meta) to the \promote social register\ command. This resolves #403.