### PR TITLE
Fix generated SDK query parameter names

### DIFF
--- a/packages/openapi/src/gen-sdk-ts/index.test.ts
+++ b/packages/openapi/src/gen-sdk-ts/index.test.ts
@@ -11,7 +11,12 @@ const SPEC = {
   servers: [{ url: 'https://api.petstore.io/v1' }],
   paths: {
     '/pets': {
-      get: { operationId: 'listPets', tags: ['pets'], responses: { '200': { description: 'ok' } } },
+      get: {
+        operationId: 'listPets',
+        tags: ['pets'],
+        parameters: [{ name: 'page-size', in: 'query', schema: { type: 'integer' } }],
+        responses: { '200': { description: 'ok' } },
+      },
       post: {
         operationId: 'createPet',
         tags: ['pets'],
@@ -38,7 +43,8 @@ describe('generateTsSdk', () => {
     expect(files.map((f) => f.path).sort()).toEqual(['client.ts', 'package.json']);
     const src = await readFile(join(outDir, 'client.ts'), 'utf8');
     expect(src).toContain('class PetstoreClient');
-    expect(src).toContain('async listPets()');
+    expect(src).toContain('async listPets(opts: { query?: { _page_size?: number } } = {})');
+    expect(src).toContain('query: { "page-size": opts.query?._page_size }');
     expect(src).toContain('async getPet(petId: string)');
     expect(src).toContain('${encodeURIComponent(petId)}');
     expect(src).toContain('async createPet(opts: { body: unknown }):');

--- a/packages/openapi/src/gen-sdk-ts/index.ts
+++ b/packages/openapi/src/gen-sdk-ts/index.ts
@@ -117,7 +117,9 @@ function renderMethod(op: Operation): string {
 
   const pathExpr = op.path.replace(/\{([^}]+)\}/g, (_, n) => `\${encodeURIComponent(${safe(n)})}`);
   const callParts: string[] = [];
-  if (queryParams.length) callParts.push('query: opts.query');
+  if (queryParams.length) {
+    callParts.push(`query: { ${queryParams.map((p) => `${JSON.stringify(p.name)}: opts.query?.${safe(p.name)}`).join(', ')} }`);
+  }
   if (headerParams.length) callParts.push('headers: opts.headers');
   if (op.requestBody) callParts.push('body: opts.body');
   const callOpts = callParts.length ? `, { ${callParts.join(', ')} }` : '';


### PR DESCRIPTION
## Summary
- Preserve original OpenAPI query parameter names when generating TypeScript SDK request options.
- Keep sanitized TypeScript option names for caller ergonomics, but map them back to the wire-level query keys before calling `request`.
- Add regression coverage for a hyphenated query parameter (`page-size`).

## Verification
- `pnpm exec vitest run packages/openapi/src/gen-sdk-ts/index.test.ts`
- `pnpm --filter @profullstack/sh1pt-openapi typecheck`