### PR TITLE
fix(actions-fleet): match renderer header format in existingBodyHash

### DIFF
--- a/packages/actions-fleet-core/src/diff/plan.test.ts
+++ b/packages/actions-fleet-core/src/diff/plan.test.ts
@@ -33,14 +33,16 @@ function makeRender(content: string, hash: string): RenderResult {
 }
 
 function withHeader(packId: string, version: string, hash: string, body: string): string {
+  // Mirror the real renderer (buildManagedHeader + body): header lines joined
+  // by single newlines, then the body immediately after the '# hash:' line —
+  // no blank line between header and body.
   return [
     '# Managed by sh1pt Actions Fleet',
     `# pack: ${packId}@${version}`,
     '# install: sh1pt-actions-store',
     `# hash: sha256:${hash}`,
     '',
-    body,
-  ].join('\n');
+  ].join('\n') + body;
 }
 
 describe('parseManagedHeader', () => {

--- a/packages/actions-fleet-core/src/diff/plan.ts
+++ b/packages/actions-fleet-core/src/diff/plan.ts
@@ -111,15 +111,20 @@ function sha256(text: string): string {
 }
 
 /**
- * Compute the body hash of an existing managed file. Mirrors the renderer:
- * strip the managed header (up to and including the first blank line) and
- * hash whatever remains.
+ * Compute the body hash of an existing managed file. Mirrors the renderer
+ * (`buildManagedHeader` in action-pack/render.ts), which emits the marker,
+ * `# pack:`, `# install:` and `# hash:` lines separated by single newlines
+ * and then the body immediately after the `# hash:` line's newline — there is
+ * no blank line between the header and the body. Strip through that `# hash:`
+ * line and hash whatever remains.
  */
 function existingBodyHash(content: string): string | null {
   if (!content.startsWith(HEADER_MARKER)) return null;
-  const blankAt = content.indexOf('\n\n');
-  if (blankAt < 0) return null;
-  const body = content.slice(blankAt + 2);
+  const hashAt = content.indexOf('\n# hash:');
+  if (hashAt < 0) return null;
+  const afterHashLine = content.indexOf('\n', hashAt + 1);
+  if (afterHashLine < 0) return null;
+  const body = content.slice(afterHashLine + 1);
   return sha256(body);
 }
 

--- a/packages/actions-fleet-core/src/local/install.test.ts
+++ b/packages/actions-fleet-core/src/local/install.test.ts
@@ -28,14 +28,15 @@ function makeRender(destination: string, content: string, hash: string): RenderR
 }
 
 function withHeader(hash: string, body: string): string {
+  // Mirror the real renderer: single-newline header, body straight after the
+  // '# hash:' line (no blank line between header and body).
   return [
     '# Managed by sh1pt Actions Fleet',
     '# pack: test-pack@1.0.0',
     '# install: sh1pt-actions-store',
     `# hash: sha256:${hash}`,
     '',
-    body,
-  ].join('\n');
+  ].join('\n') + body;
 }
 
 describe('installPlan', () => {

--- a/packages/actions-fleet-core/src/remote/plan-remote.test.ts
+++ b/packages/actions-fleet-core/src/remote/plan-remote.test.ts
@@ -8,14 +8,15 @@ function bodyHash(body: string): string {
 }
 
 function withHeader(packId: string, version: string, hash: string, body: string): string {
+  // Mirror the real renderer: single-newline header, body straight after the
+  // '# hash:' line (no blank line between header and body).
   return [
     '# Managed by sh1pt Actions Fleet',
     `# pack: ${packId}@${version}`,
     '# install: sh1pt-actions-store',
     `# hash: sha256:${hash}`,
     '',
-    body,
-  ].join('\n');
+  ].join('\n') + body;
 }
 
 function singleFileRender(hash: string): RenderResult {


### PR DESCRIPTION
## Problem

`existingBodyHash()` (plan.ts) stripped the managed header by searching for a blank line (`'\n\n'`), but the renderer (`buildManagedHeader` in `action-pack/render.ts`) separates the header from the body with a **single** newline after the `# hash:` line — no blank line. So on any real installed file the search returned `null` or sliced at the wrong offset, `existingBodyHash()` never equalled `file.hash`, and the `unchanged` status was never produced: every managed file was always planned as `update-managed` and rewritten (see #760).

The bug was masked because the test `withHeader()` fixtures inserted an extra blank line the real renderer does not emit.

## Fix

- `plan.ts`: strip through the `# hash:` line (mirroring the renderer) instead of searching for a blank line.
- `plan.test.ts`, `plan-remote.test.ts`, `install.test.ts`: correct the `withHeader()` helpers to match real renderer output (single newline, no blank line between header and body).

## Verification

Verified the format logic standalone: with the new `existingBodyHash`, the real renderer's output hashes back to `file.hash` (→ `unchanged`), the corrected fixtures equal the renderer's output byte-for-byte, and a differing body is still detected as changed. `parseManagedHeader` is unaffected (it scans the first lines and stops at the first blank/body line either way).

Fixes #760.
