### PR TITLE
feat(ai): integrate AI21 adapter (jamba-large/jamba-mini)

### DIFF
--- a/packages/ai/ai21/src/index.test.ts
+++ b/packages/ai/ai21/src/index.test.ts
@@ -1,4 +1,105 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { AI21_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('AI21 OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ AI21_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'jamba-large' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from ai21' } }],
+        model: 'jamba-mini',
+        usage: { prompt_tokens: 7, completion_tokens: 3 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'jamba-mini',
+      system: 'be brief',
+      maxTokens: 20,
+      temperature: 0.2,
+      extra: { top_p: 0.9 },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.ai21.com/studio/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'jamba-mini',
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 20,
+      temperature: 0.2,
+      top_p: 0.9,
+    });
+    expect(result).toEqual({
+      text: 'hi from ai21',
+      model: 'jamba-mini',
+      inputTokens: 7,
+      outputTokens: 3,
+    });
+  });
+
+  it('normalizes configured base URLs with trailing slashes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'ok' } }], model: 'jamba-large' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://proxy.example.com/' });
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://proxy.example.com/v1/chat/completions');
+  });
+
+  it('includes status and redacted response body excerpt on errors', async () => {
+    const apiKey = 'test-key-crossing-truncation-boundary';
+    const prefix = 'x'.repeat(190);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => `${prefix}${apiKey} rate limited`,
+    }));
+
+    let error: unknown;
+    try {
+      await adapter.generate(ctx({ AI21_API_KEY: apiKey }), 'hello', {}, {});
+    } catch (exc) {
+      error = exc;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('AI21 429:');
+    expect((error as Error).message).toContain('[redacted]');
+    expect((error as Error).message).not.toContain(apiKey);
+    expect((error as Error).message).not.toContain(apiKey.slice(0, 10));
+  });
+});

--- a/packages/ai/ai21/src/index.ts
+++ b/packages/ai/ai21/src/index.ts
@@ -4,17 +4,59 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.ai21.com/studio';
+
+function chatCompletionsUrl(baseUrl?: string): string {
+  return `${(baseUrl ?? DEFAULT_BASE).replace(/\/+$/, '')}/v1/chat/completions`;
+}
+
+function redact(value: string, apiKey: string): string {
+  return apiKey ? value.split(apiKey).join('[redacted]') : value;
+}
+
 export default defineAi<Config>({
   id: 'ai-ai21',
   label: 'AI21',
-  defaultModel: 'jamba-1.5-large',
-  models: ['jamba-1.5-large'],
+  defaultModel: 'jamba-large',
+  models: ['jamba-large', 'jamba-mini'],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('AI21_API_KEY');
-    if (!apiKey) throw new Error('AI21_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-ai21 · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-ai21 integration not yet implemented]', model: 'jamba-1.5-large' };
+    if (!apiKey) throw new Error('AI21_API_KEY not in vault');
+    const model = opts.model ?? 'jamba-large';
+    ctx.log(`ai21 · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(chatCompletionsUrl(config.baseUrl), {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`AI21 ${res.status}: ${redact(await res.text(), apiKey).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({


### PR DESCRIPTION
Closes #762.

## What

Converts `packages/ai/ai21` from a BYOK stub into a working integration, following the groq/deepseek adapter shape from #63 exactly:

- `generate()` makes a real call to `https://api.ai21.com/studio/v1/chat/completions` (AI21 is OpenAI Chat Completions-compatible, Bearer auth)
- `ctx.dryRun` short-circuits before the network call
- Errors include status + first 200 chars of the response body with the API key redacted
- `inputTokens` / `outputTokens` mapped from `data.usage` when present
- Configurable `baseUrl` with trailing-slash normalization, same as the other adapters

Also updates the model IDs: the stub pinned the deprecated `jamba-1.5-large`; AI21's current API reference specifies the unversioned `jamba-large` / `jamba-mini` (https://docs.ai21.com/reference/jamba-1-6-api-ref). Default is `jamba-large`.

## Tests

`packages/ai/ai21/src/index.test.ts` mirrors the groq adapter's test suite (mocked `fetch`, fully offline): dry-run short-circuit, request shape + usage token mapping, base URL normalization, and error redaction across the truncation boundary.

```
vitest run packages/ai/ai21 → 6 passed (6)
pnpm --filter @profullstack/sh1pt-ai-ai21 typecheck → clean
```

`tokenSetup()` block kept as-is (already wired in the stub).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
