### PR TITLE
Implement Reka AI and Arcee AI adapters

### DIFF
--- a/packages/ai/arcee/src/index.test.ts
+++ b/packages/ai/arcee/src/index.test.ts
@@ -1,4 +1,109 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { ARCEE_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Arcee OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ ARCEE_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'virtuoso-large' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from arcee' } }],
+        model: 'virtuoso-medium',
+        usage: { prompt_tokens: 7, completion_tokens: 3 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'virtuoso-medium',
+      system: 'be brief',
+      maxTokens: 20,
+      temperature: 0.2,
+      extra: { top_p: 0.9 },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.arcee.ai/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'virtuoso-medium',
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 20,
+      temperature: 0.2,
+      top_p: 0.9,
+    });
+    expect(result).toEqual({
+      text: 'hi from arcee',
+      model: 'virtuoso-medium',
+      inputTokens: 7,
+      outputTokens: 3,
+    });
+  });
+
+  it('normalizes configured base URLs with trailing slashes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'ok' } }], model: 'virtuoso-large' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://proxy.example.com/' });
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://proxy.example.com/v1/chat/completions');
+  });
+
+  it('includes status and redacted response body excerpt on errors', async () => {
+    const apiKey = 'test-key-crossing-truncation-boundary';
+    const prefix = 'x'.repeat(190);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => `${prefix}${apiKey} rate limited`,
+    }));
+
+    let error: unknown;
+    try {
+      await adapter.generate(ctx({ ARCEE_API_KEY: apiKey }), 'hello', {}, {});
+    } catch (exc) {
+      error = exc;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('Arcee 429:');
+    expect((error as Error).message).toContain('[redacted]');
+    expect((error as Error).message).not.toContain(apiKey);
+    expect((error as Error).message).not.toContain(apiKey.slice(0, 10));
+  });
+
+  it('throws when the API key is missing from the vault', async () => {
+    await expect(adapter.generate(ctx({}), 'hello', {}, {})).rejects.toThrow('ARCEE_API_KEY not in vault');
+  });
+});

--- a/packages/ai/arcee/src/index.ts
+++ b/packages/ai/arcee/src/index.ts
@@ -4,23 +4,65 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.arcee.ai';
+
+function chatCompletionsUrl(baseUrl?: string): string {
+  return `${(baseUrl ?? DEFAULT_BASE).replace(/\/+$/, '')}/v1/chat/completions`;
+}
+
+function redact(value: string, apiKey: string): string {
+  return apiKey ? value.split(apiKey).join('[redacted]') : value;
+}
+
 export default defineAi<Config>({
   id: 'ai-arcee',
   label: 'Arcee AI',
   defaultModel: 'virtuoso-large',
-  models: ['virtuoso-large'],
+  models: ['virtuoso-large', 'virtuoso-medium', 'virtuoso-small'],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('ARCEE_API_KEY');
-    if (!apiKey) throw new Error('ARCEE_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-arcee · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-arcee integration not yet implemented]', model: 'virtuoso-large' };
+    if (!apiKey) throw new Error('ARCEE_API_KEY not in vault');
+    const model = opts.model ?? 'virtuoso-large';
+    ctx.log(`arcee · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(chatCompletionsUrl(config.baseUrl), {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Arcee ${res.status}: ${redact(await res.text(), apiKey).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'ARCEE_API_KEY',
     label: 'Arcee AI',
-    vendorDocUrl: 'https://www.arcee.ai',
+    vendorDocUrl: 'https://docs.arcee.ai',
     steps: [
       'Sign in at https://www.arcee.ai and create an API key',
       'Copy the key — usually shown once',

--- a/packages/ai/reka/src/index.test.ts
+++ b/packages/ai/reka/src/index.test.ts
@@ -1,4 +1,109 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { REKA_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Reka OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ REKA_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'reka-core' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from reka' } }],
+        model: 'reka-core-vision',
+        usage: { prompt_tokens: 7, completion_tokens: 3 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'reka-core-vision',
+      system: 'be brief',
+      maxTokens: 20,
+      temperature: 0.2,
+      extra: { top_p: 0.9 },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.reka.ai/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'reka-core-vision',
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 20,
+      temperature: 0.2,
+      top_p: 0.9,
+    });
+    expect(result).toEqual({
+      text: 'hi from reka',
+      model: 'reka-core-vision',
+      inputTokens: 7,
+      outputTokens: 3,
+    });
+  });
+
+  it('normalizes configured base URLs with trailing slashes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'ok' } }], model: 'reka-core' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://proxy.example.com/' });
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://proxy.example.com/v1/chat/completions');
+  });
+
+  it('includes status and redacted response body excerpt on errors', async () => {
+    const apiKey = 'test-key-crossing-truncation-boundary';
+    const prefix = 'x'.repeat(190);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => `${prefix}${apiKey} rate limited`,
+    }));
+
+    let error: unknown;
+    try {
+      await adapter.generate(ctx({ REKA_API_KEY: apiKey }), 'hello', {}, {});
+    } catch (exc) {
+      error = exc;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('Reka 429:');
+    expect((error as Error).message).toContain('[redacted]');
+    expect((error as Error).message).not.toContain(apiKey);
+    expect((error as Error).message).not.toContain(apiKey.slice(0, 10));
+  });
+
+  it('throws when the API key is missing from the vault', async () => {
+    await expect(adapter.generate(ctx({}), 'hello', {}, {})).rejects.toThrow('REKA_API_KEY not in vault');
+  });
+});

--- a/packages/ai/reka/src/index.ts
+++ b/packages/ai/reka/src/index.ts
@@ -4,23 +4,65 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.reka.ai';
+
+function chatCompletionsUrl(baseUrl?: string): string {
+  return `${(baseUrl ?? DEFAULT_BASE).replace(/\/+$/, '')}/v1/chat/completions`;
+}
+
+function redact(value: string, apiKey: string): string {
+  return apiKey ? value.split(apiKey).join('[redacted]') : value;
+}
+
 export default defineAi<Config>({
   id: 'ai-reka',
   label: 'Reka AI',
   defaultModel: 'reka-core',
-  models: ['reka-core'],
+  models: ['reka-core', 'reka-core-vision'],
 
-  async generate(ctx, prompt, _opts, _config) {
+  async generate(ctx, prompt, opts, config) {
     const apiKey = ctx.secret('REKA_API_KEY');
-    if (!apiKey) throw new Error('REKA_API_KEY not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-reka · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-reka integration not yet implemented]', model: 'reka-core' };
+    if (!apiKey) throw new Error('REKA_API_KEY not in vault');
+    const model = opts.model ?? 'reka-core';
+    ctx.log(`reka · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(chatCompletionsUrl(config.baseUrl), {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Reka ${res.status}: ${redact(await res.text(), apiKey).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
     secretKey: 'REKA_API_KEY',
     label: 'Reka AI',
-    vendorDocUrl: 'https://www.reka.ai',
+    vendorDocUrl: 'https://docs.reka.ai',
     steps: [
       'Sign in at https://www.reka.ai and create an API key',
       'Copy the key — usually shown once',


### PR DESCRIPTION
## Summary
- Replaces the placeholder stubs for `packages/ai/reka` and `packages/ai/arcee` with real implementations
- Both follow the OpenAI-compatible chat-completions pattern already used by the `groq` adapter: `defineAi` config with a `baseUrl` override, redacted error messages on non-2xx responses, and `usage` token mapping to `inputTokens`/`outputTokens`
- Reka: `https://api.reka.ai/v1/chat/completions`, default model `reka-core`, adds `reka-core-vision`
- Arcee: `https://api.arcee.ai/v1/chat/completions`, default model `virtuoso-large`, adds `virtuoso-medium`/`virtuoso-small`

## Test plan
- [x] Added unit tests for both adapters mirroring `packages/ai/groq/src/index.test.ts` (dry-run short-circuit, request shape, base URL override, error redaction, missing-key throw)
- [ ] CI: `pnpm --filter @profullstack/sh1pt-ai-reka --filter @profullstack/sh1pt-ai-arcee typecheck && pnpm vitest run packages/ai/reka/src/index.test.ts packages/ai/arcee/src/index.test.ts`