### PR TITLE
Implement AtlasCloud AI adapter

### DIFF
--- a/packages/ai/atlascloud/src/index.test.ts
+++ b/packages/ai/atlascloud/src/index.test.ts
@@ -1,4 +1,109 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { ATLASCLOUD_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('AtlasCloud OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ ATLASCLOUD_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'deepseek-ai/DeepSeek-V3-0324' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from atlascloud' } }],
+        model: 'qwen/qwen3-32b',
+        usage: { prompt_tokens: 7, completion_tokens: 3 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'qwen/qwen3-32b',
+      system: 'be brief',
+      maxTokens: 20,
+      temperature: 0.2,
+      extra: { top_p: 0.9 },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://api.atlascloud.ai/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'qwen/qwen3-32b',
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 20,
+      temperature: 0.2,
+      top_p: 0.9,
+    });
+    expect(result).toEqual({
+      text: 'hi from atlascloud',
+      model: 'qwen/qwen3-32b',
+      inputTokens: 7,
+      outputTokens: 3,
+    });
+  });
+
+  it('normalizes configured base URLs with trailing slashes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'ok' } }], model: 'deepseek-ai/DeepSeek-V3-0324' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://proxy.example.com/' });
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://proxy.example.com/v1/chat/completions');
+  });
+
+  it('includes status and redacted response body excerpt on errors', async () => {
+    const apiKey = 'test-key-crossing-truncation-boundary';
+    const prefix = 'x'.repeat(190);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: async () => `${prefix}${apiKey} invalid token`,
+    }));
+
+    let error: unknown;
+    try {
+      await adapter.generate(ctx({ ATLASCLOUD_API_KEY: apiKey }), 'hello', {}, {});
+    } catch (exc) {
+      error = exc;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('AtlasCloud 401:');
+    expect((error as Error).message).toContain('[redacted]');
+    expect((error as Error).message).not.toContain(apiKey);
+    expect((error as Error).message).not.toContain(apiKey.slice(0, 10));
+  });
+
+  it('throws when the API key is missing from the vault', async () => {
+    await expect(adapter.generate(ctx({}), 'hello', {}, {})).rejects.toThrow('ATLASCLOUD_API_KEY not in vault');
+  });
+});

--- a/packages/ai/atlascloud/src/index.ts
+++ b/packages/ai/atlascloud/src/index.ts
@@ -4,25 +4,76 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://api.atlascloud.ai';
+
+function chatCompletionsUrl(baseUrl?: string): string {
+  return `${(baseUrl ?? DEFAULT_BASE).replace(/\/+$/, '')}/v1/chat/completions`;
+}
+
+function redact(value: string, apiKey: string): string {
+  return apiKey ? value.split(apiKey).join('[redacted]') : value;
+}
+
 export default defineAi<Config>({
   id: 'ai-atlascloud',
   label: 'AtlasCloud',
-  defaultModel: 'ATLASCLOUD_API_KEY',
-  models: ['ATLASCLOUD_API_KEY'],
+  defaultModel: 'deepseek-ai/DeepSeek-V3-0324',
+  models: [
+    'deepseek-ai/DeepSeek-V3-0324',
+    'deepseek-ai/deepseek-r1-0528',
+    'deepseek-ai/DeepSeek-V3.1',
+    'qwen/qwen3-32b',
+    'Qwen/Qwen3-Coder',
+    'Qwen/Qwen3-235B-A22B-Instruct-2507',
+    'moonshotai/Kimi-K2-Instruct',
+    'moonshotai/Kimi-K2-Instruct-0905',
+  ],
 
-  async generate(ctx, prompt, _opts, _config) {
-    const apiKey = ctx.secret('https://atlascloud.ai');
-    if (!apiKey) throw new Error('https://atlascloud.ai not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-atlascloud · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-atlascloud integration not yet implemented]', model: 'ATLASCLOUD_API_KEY' };
+  async generate(ctx, prompt, opts, config) {
+    const apiKey = ctx.secret('ATLASCLOUD_API_KEY');
+    if (!apiKey) throw new Error('ATLASCLOUD_API_KEY not in vault');
+    const model = opts.model ?? 'deepseek-ai/DeepSeek-V3-0324';
+    ctx.log(`atlascloud · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(chatCompletionsUrl(config.baseUrl), {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`AtlasCloud ${res.status}: ${redact(await res.text(), apiKey).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
-    secretKey: 'https://atlascloud.ai',
+    secretKey: 'ATLASCLOUD_API_KEY',
     label: 'AtlasCloud',
-    vendorDocUrl: '',
+    vendorDocUrl: 'https://docs.atlascloud.ai',
     steps: [
-      'Sign in at  and create an API key',
+      'Sign in at https://www.atlascloud.ai and create an API key',
       'Copy the key — usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],


### PR DESCRIPTION
## Summary
- Replaces the `packages/ai/atlascloud` stub, which had bugs beyond just being a placeholder: `secretKey` was a bare URL string instead of an env var name, and `defaultModel`/`models` were literally the string `'ATLASCLOUD_API_KEY'`
- New implementation follows the OpenAI-compatible chat-completions pattern used by `groq`: `defineAi` config with `baseUrl` override, redacted error messages, `usage` token mapping to `inputTokens`/`outputTokens`
- Base URL `https://api.atlascloud.ai/v1/chat/completions` confirmed live (unauthenticated POST returns `{"code":401,"msg":"invalid token"}`)
- Model list pulled directly from the live, unauthenticated `GET /v1/models` response (not guessed) — includes DeepSeek-V3, DeepSeek-R1, Qwen3 variants, and Kimi-K2

## Test plan
- [x] Added unit tests mirroring `packages/ai/groq/src/index.test.ts` (dry-run short-circuit, request shape, base URL override, error redaction, missing-key throw)
- [ ] CI: `pnpm --filter @profullstack/sh1pt-ai-atlascloud typecheck && pnpm vitest run packages/ai/atlascloud/src/index.test.ts`