### PR TITLE
Implement Phala AI adapter

### DIFF
--- a/packages/ai/phala/src/index.test.ts
+++ b/packages/ai/phala/src/index.test.ts
@@ -1,4 +1,109 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (secrets: Record<string, string> = { PHALA_API_KEY: 'test-key' }, dryRun = false) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Phala OpenAI-compatible generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('short-circuits dry-run before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx({ PHALA_API_KEY: 'test-key' }, true), 'hello', {}, {});
+
+    expect(result).toEqual({ text: '[dry-run]', model: 'phala/qwen3.5-27b' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts chat completions requests and maps usage tokens', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hi from phala' } }],
+        model: 'z-ai/glm-5',
+        usage: { prompt_tokens: 7, completion_tokens: 3 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(ctx(), 'hello', {
+      model: 'z-ai/glm-5',
+      system: 'be brief',
+      maxTokens: 20,
+      temperature: 0.2,
+      extra: { top_p: 0.9 },
+    }, {});
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const call = fetchMock.mock.calls[0];
+    expect(call).toBeDefined();
+    const [url, request] = call!;
+    expect(url).toBe('https://inference.phala.com/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'z-ai/glm-5',
+      messages: [
+        { role: 'system', content: 'be brief' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 20,
+      temperature: 0.2,
+      top_p: 0.9,
+    });
+    expect(result).toEqual({
+      text: 'hi from phala',
+      model: 'z-ai/glm-5',
+      inputTokens: 7,
+      outputTokens: 3,
+    });
+  });
+
+  it('normalizes configured base URLs with trailing slashes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'ok' } }], model: 'phala/qwen3.5-27b' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://proxy.example.com/' });
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://proxy.example.com/v1/chat/completions');
+  });
+
+  it('includes status and redacted response body excerpt on errors', async () => {
+    const apiKey = 'test-key-crossing-truncation-boundary';
+    const prefix = 'x'.repeat(190);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => `${prefix}${apiKey} rate limited`,
+    }));
+
+    let error: unknown;
+    try {
+      await adapter.generate(ctx({ PHALA_API_KEY: apiKey }), 'hello', {}, {});
+    } catch (exc) {
+      error = exc;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain('Phala 429:');
+    expect((error as Error).message).toContain('[redacted]');
+    expect((error as Error).message).not.toContain(apiKey);
+    expect((error as Error).message).not.toContain(apiKey.slice(0, 10));
+  });
+
+  it('throws when the API key is missing from the vault', async () => {
+    await expect(adapter.generate(ctx({}), 'hello', {}, {})).rejects.toThrow('PHALA_API_KEY not in vault');
+  });
+});

--- a/packages/ai/phala/src/index.ts
+++ b/packages/ai/phala/src/index.ts
@@ -4,25 +4,67 @@ interface Config {
   baseUrl?: string;
 }
 
+const DEFAULT_BASE = 'https://inference.phala.com';
+
+function chatCompletionsUrl(baseUrl?: string): string {
+  return `${(baseUrl ?? DEFAULT_BASE).replace(/\/+$/, '')}/v1/chat/completions`;
+}
+
+function redact(value: string, apiKey: string): string {
+  return apiKey ? value.split(apiKey).join('[redacted]') : value;
+}
+
 export default defineAi<Config>({
   id: 'ai-phala',
   label: 'Phala',
-  defaultModel: 'PHALA_API_KEY',
-  models: ['PHALA_API_KEY'],
+  defaultModel: 'phala/qwen3.5-27b',
+  models: ['phala/qwen3.5-27b', 'phala/gemma-3-27b-it', 'z-ai/glm-5', 'openai/gpt-oss-120b'],
 
-  async generate(ctx, prompt, _opts, _config) {
-    const apiKey = ctx.secret('https://phala.network');
-    if (!apiKey) throw new Error('https://phala.network not in vault — run `sh1pt promote ai setup`');
-    ctx.log(`[stub] ai-phala · ${prompt.length} chars in — integration pending`);
-    return { text: '[stub — ai-phala integration not yet implemented]', model: 'PHALA_API_KEY' };
+  async generate(ctx, prompt, opts, config) {
+    const apiKey = ctx.secret('PHALA_API_KEY');
+    if (!apiKey) throw new Error('PHALA_API_KEY not in vault');
+    const model = opts.model ?? 'phala/qwen3.5-27b';
+    ctx.log(`phala · model=${model} · ${prompt.length} chars in`);
+    if (ctx.dryRun) return { text: '[dry-run]', model };
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (opts.system) messages.push({ role: 'system', content: opts.system });
+    messages.push({ role: 'user', content: prompt });
+
+    const res = await fetch(chatCompletionsUrl(config.baseUrl), {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+        ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        ...opts.extra,
+      }),
+    });
+    if (!res.ok) throw new Error(`Phala ${res.status}: ${redact(await res.text(), apiKey).slice(0, 200)}`);
+    const data = (await res.json()) as {
+      choices: Array<{ message?: { content?: string } }>;
+      model: string;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
+    return {
+      text: data.choices[0]?.message?.content ?? '',
+      model: data.model,
+      inputTokens: data.usage?.prompt_tokens,
+      outputTokens: data.usage?.completion_tokens,
+    };
   },
 
   setup: tokenSetup<Config>({
-    secretKey: 'https://phala.network',
+    secretKey: 'PHALA_API_KEY',
     label: 'Phala',
-    vendorDocUrl: '',
+    vendorDocUrl: 'https://docs.phala.com/phala-cloud/confidential-ai/confidential-model/api-reference/chat-completions',
     steps: [
-      'Sign in at  and create an API key',
+      'Sign in at https://phala.com and create an API key',
       'Copy the key — usually shown once',
       'Paste below; sh1pt encrypts it in the vault',
     ],


### PR DESCRIPTION
## Summary
- Replaces the `packages/ai/phala` stub, which had the same class of bug as atlascloud (`secretKey` was a bare URL instead of an env var name, `defaultModel`/`models` were the string `'PHALA_API_KEY'`)
- New implementation targets Phala's confidential-AI (GPU TEE) chat completions API, documented at `docs.phala.com/phala-cloud/confidential-ai/confidential-model/api-reference/chat-completions`
- Base URL `https://inference.phala.com/v1/chat/completions` confirmed live (unauthenticated POST returns `{"error":{"message":"Model parameter is required",...}}`)
- Model IDs (`phala/qwen3.5-27b`, `phala/gemma-3-27b-it`, `z-ai/glm-5`, `openai/gpt-oss-120b`) taken directly from the documented request examples, not guessed

## Test plan
- [x] Added unit tests mirroring `packages/ai/groq/src/index.test.ts` (dry-run short-circuit, request shape, base URL override, error redaction, missing-key throw)
- [ ] CI: `pnpm --filter @profullstack/sh1pt-ai-phala typecheck && pnpm vitest run packages/ai/phala/src/index.test.ts`