### PR TITLE
feat(actions): add coinpay-invoice Fleet pack (submit-a-PR for coinpaybot)

### DIFF
--- a/packages/actions/coinpay-invoice/README.md
+++ b/packages/actions/coinpay-invoice/README.md
@@ -1,0 +1,27 @@
+# CoinPayPortal Invoice Bot
+
+Installs the [`coinpaybot`](https://github.com/profullstack/coinpaybot) GitHub Action so maintainers can create CoinPayPortal crypto invoices and payment links straight from issue and PR comments:
+
+```
+/coinpay invoice 250 USD --crypto usdc_pol --for "Milestone 1"
+```
+
+The bot replies with a payable `…/pay/{id}` link. Owners/members/collaborators create invoices directly; other contributors create a pending request a maintainer approves with `/coinpay approve`.
+
+## Requirements
+
+Add two repository secrets before use:
+
+- `COINPAY_API_KEY` — a CoinPayPortal API key (`cp_live_...`).
+- `COINPAY_BUSINESS_ID` — the CoinPayPortal business that owns the receiving wallet.
+
+The business must have a receiving wallet configured for the crypto you invoice in (e.g. `usdc_pol`), or payment creation fails.
+
+## Inputs
+
+- `actionRef` (default `profullstack/coinpaybot@v0`) — the action reference to run.
+- `coinpayBaseUrl` (default `https://coinpayportal.com`) — CoinPayPortal base URL.
+
+## Output
+
+`coinpay-invoice` writes `.github/workflows/coinpay.yml` through a pull request.

--- a/packages/actions/coinpay-invoice/action.yml
+++ b/packages/actions/coinpay-invoice/action.yml
@@ -1,0 +1,17 @@
+id: coinpay-invoice
+name: CoinPayPortal Invoice Bot
+version: 1.0.0
+category: agent
+description: Create CoinPayPortal crypto invoices and payment links from GitHub issue and PR comments via /coinpay commands.
+provider: github
+public: true
+destination: .github/workflows/coinpay.yml
+installMode: pull-request
+supports:
+  - issue_comment
+requiredSecrets:
+  - COINPAY_API_KEY
+  - COINPAY_BUSINESS_ID
+permissions:
+  issues: write
+  pull-requests: write

--- a/packages/actions/coinpay-invoice/schema.json
+++ b/packages/actions/coinpay-invoice/schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CoinPayPortal Invoice Bot inputs",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "actionRef": {
+      "type": "string",
+      "default": "profullstack/coinpaybot@v0",
+      "description": "The coinpaybot action reference (owner/repo@ref) to run."
+    },
+    "coinpayBaseUrl": {
+      "type": "string",
+      "default": "https://coinpayportal.com",
+      "description": "CoinPayPortal base URL."
+    }
+  }
+}

--- a/packages/actions/coinpay-invoice/sh1pt.actionpack.yaml
+++ b/packages/actions/coinpay-invoice/sh1pt.actionpack.yaml
@@ -1,0 +1,45 @@
+schemaVersion: 1
+id: coinpay-invoice
+name: CoinPayPortal Invoice Bot
+description: Create CoinPayPortal crypto invoices and payment links from GitHub issue and PR comments via /coinpay commands.
+version: 1.0.0
+publisher: profullstack
+visibility: public
+license: MIT
+categories:
+  - agent
+compatibility:
+  providers:
+    - github
+pricing:
+  type: free
+inputs:
+  actionRef:
+    type: string
+    default: profullstack/coinpaybot@v0
+    description: The coinpaybot action reference (owner/repo@ref) to run.
+  coinpayBaseUrl:
+    type: string
+    default: https://coinpayportal.com
+    description: CoinPayPortal base URL.
+secrets:
+  - name: COINPAY_API_KEY
+    description: CoinPayPortal API key (cp_live_...). Store as a repository secret.
+    required: true
+  - name: COINPAY_BUSINESS_ID
+    description: CoinPayPortal business id that owns the receiving wallet.
+    required: true
+repoVariables: []
+files:
+  - source: workflow.yml
+    destination: .github/workflows/coinpay.yml
+    mergeStrategy: replace-managed
+policies:
+  installMode: pull-request
+  managedComment: true
+  requiresReview: true
+security:
+  leastPrivilegePermissions: true
+  pinThirdPartyActions: optional
+  allowPullRequestTarget: false
+  defaultTimeoutMinutes: 15

--- a/packages/actions/coinpay-invoice/workflow.yml
+++ b/packages/actions/coinpay-invoice/workflow.yml
@@ -1,0 +1,27 @@
+name: CoinPayPortal invoice command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: coinpay-${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  coinpay:
+    # Only spin up when a comment actually invokes the bot.
+    if: startsWith(github.event.comment.body, '/coinpay')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: {{actionRef}}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          coinpay-api-key: ${{ secrets.COINPAY_API_KEY }}
+          coinpay-business-id: ${{ secrets.COINPAY_BUSINESS_ID }}
+          coinpay-base-url: {{coinpayBaseUrl}}

--- a/packages/actions/src/index.test.ts
+++ b/packages/actions/src/index.test.ts
@@ -28,6 +28,48 @@ describe('built-in packs', () => {
     expect(entry?.manifest.secrets[0]?.name).toBe('ENV_FILE');
   });
 
+  it('loads the coinpay-invoice pack', async () => {
+    const catalog = await loadBuiltinPacks();
+    const entry = catalog.get('coinpay-invoice');
+    expect(entry).toBeDefined();
+    expect(entry?.manifest.name).toBe('CoinPayPortal Invoice Bot');
+    expect(entry?.manifest.files[0]?.destination).toBe('.github/workflows/coinpay.yml');
+    expect(entry?.manifest.policies.installMode).toBe('pull-request');
+    expect(entry?.manifest.secrets.map((s) => s.name)).toEqual(['COINPAY_API_KEY', 'COINPAY_BUSINESS_ID']);
+  });
+
+  it('renders coinpay-invoice with default inputs', async () => {
+    const catalog = await loadBuiltinPacks();
+    const entry = catalog.get('coinpay-invoice');
+    if (!entry) throw new Error('coinpay-invoice not in catalog');
+    const result = await renderPack({
+      packDir: entry.packDir,
+      manifest: entry.manifest,
+      inputs: {},
+    });
+    const file = result.files[0];
+    expect(file?.destination).toBe('.github/workflows/coinpay.yml');
+    // Input placeholders substituted...
+    expect(file?.content).toContain('uses: profullstack/coinpaybot@v0');
+    expect(file?.content).toContain('coinpay-base-url: https://coinpayportal.com');
+    // ...while GitHub expressions and secret refs survive untouched.
+    expect(file?.content).toContain('${{ secrets.COINPAY_API_KEY }}');
+    expect(file?.content).toContain("startsWith(github.event.comment.body, '/coinpay')");
+    expect(file?.content).toContain('# Managed by sh1pt Actions Fleet');
+  });
+
+  it('honors an overridden action ref', async () => {
+    const catalog = await loadBuiltinPacks();
+    const entry = catalog.get('coinpay-invoice');
+    if (!entry) throw new Error('coinpay-invoice not in catalog');
+    const result = await renderPack({
+      packDir: entry.packDir,
+      manifest: entry.manifest,
+      inputs: { actionRef: 'profullstack/coinpaybot@v0.1.0' },
+    });
+    expect(result.files[0]?.content).toContain('uses: profullstack/coinpaybot@v0.1.0');
+  });
+
   it('renders node-pnpm-ci with default inputs', async () => {
     const catalog = await loadBuiltinPacks();
     const entry = catalog.get('node-pnpm-ci');


### PR DESCRIPTION
## What

Adds a **sh1pt Actions Fleet pack** `coinpay-invoice` that the GitHub App submits into a connected repo **as a reviewable pull request** (`installMode: pull-request`). The PR'd workflow wires up the [`coinpaybot`](https://github.com/profullstack/coinpaybot) Action, so maintainers can create CoinPayPortal crypto invoices and payment links from issue/PR comments:

```
/coinpay invoice 250 USD --crypto usdc_pol --for "Milestone 1"
```

This is the "submit a PR" distribution path for coinpaybot that wasn't part of the original CoinPayPortal-for-GitHub PRD (that PRD only covered the Action itself).

## Contents

`packages/actions/coinpay-invoice/`
- `sh1pt.actionpack.yaml` — manifest. Category `agent`, `installMode: pull-request`, declares repo secrets `COINPAY_API_KEY` + `COINPAY_BUSINESS_ID`, writes `.github/workflows/coinpay.yml`.
- `workflow.yml` — `on: issue_comment`, least-privilege perms, `uses: {{actionRef}}` (default `profullstack/coinpaybot@v0`).
- `schema.json`, `action.yml`, `README.md`.

Pack dir is **data inside the existing `@profullstack/sh1pt-action-packs` package** — auto-discovered by `loadCatalog`, so no workspace or Dockerfile changes are needed.

## Tests

`packages/actions/src/index.test.ts` — 3 new cases (10 pass total): loads the pack, renders it through the real `renderPack` (verifies input substitution, `${{ secrets.* }}` / GitHub-expression passthrough, managed-comment header), and honors an overridden `actionRef`.

## Dependency / prerequisite

- `profullstack/coinpaybot` is now **public** and tagged **`v0`** / `v0.1.0`, so the PR'd `uses: profullstack/coinpaybot@v0` resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)