### PR TITLE
fix(cli): reject invalid bare Bluesky actors

### DIFF
--- a/packages/cli/src/social-follow.test.ts
+++ b/packages/cli/src/social-follow.test.ts
@@ -39,6 +39,12 @@ describe('social follow target parsing', () => {
     expect(() => parseSocialFollowTarget('https://example.com/alice')).toThrow('only supports bsky.app URLs');
   });
 
+  it('rejects invalid bare actors even when Bluesky is explicit', () => {
+    expect(() => parseSocialFollowTarget('not a valid handle', 'bluesky')).toThrow(
+      'Expected a social account URL',
+    );
+  });
+
   it('rejects malformed Bluesky profile URLs with a useful error', () => {
     expect(() => parseSocialFollowTarget('https://bsky.app/profile/%E0%A4%A')).toThrow(
       'Could not parse Bluesky profile URL',

--- a/packages/cli/src/social-follow.ts
+++ b/packages/cli/src/social-follow.ts
@@ -84,7 +84,7 @@ export function parseSocialFollowTarget(input: string, explicitPlatform?: string
   try {
     url = new URL(input);
   } catch {
-    if (platform === 'bluesky' || looksLikeBlueskyActor(input)) {
+    if (looksLikeBlueskyActor(input)) {
       return { platform: 'bluesky', actor: input.replace(/^@/, ''), source: 'profile' };
     }
     throw new Error(`Expected a social account URL; got "${input}"`);


### PR DESCRIPTION
## Summary
- reject invalid bare Bluesky actor strings even when --platform bluesky is explicit
- keep valid bare handles/DIDs and bsky.app profile URLs working
- add regression coverage for malformed bare actor input

## Tests
- corepack pnpm exec vitest run packages/cli/src/social-follow.test.ts
- git diff --check

## Note
- corepack pnpm --filter @profullstack/sh1pt typecheck currently fails on pre-existing workspace/type declaration errors unrelated to this change.