### PR TITLE
Use real home directory for global installer paths

### DIFF
--- a/packages/cli/src/installer.test.ts
+++ b/packages/cli/src/installer.test.ts
@@ -1,0 +1,24 @@
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { globalNodeModulesDir } from './installer.js';
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_USERPROFILE = process.env.USERPROFILE;
+
+describe('globalNodeModulesDir', () => {
+  afterEach(() => {
+    if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+    else process.env.HOME = ORIGINAL_HOME;
+
+    if (ORIGINAL_USERPROFILE === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = ORIGINAL_USERPROFILE;
+  });
+
+  it('uses USERPROFILE for global package paths when HOME is not set', () => {
+    delete process.env.HOME;
+    process.env.USERPROFILE = join('tmp', 'windows-home');
+
+    expect(globalNodeModulesDir('bun')).toBe(join('tmp', 'windows-home', '.bun/install/global/node_modules'));
+    expect(globalNodeModulesDir('aube')).toBe(join('tmp', 'windows-home', '.aube/install/global/node_modules'));
+  });
+});

--- a/packages/cli/src/installer.ts
+++ b/packages/cli/src/installer.ts
@@ -23,6 +23,7 @@
 
 import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import kleur from 'kleur';
@@ -50,7 +51,7 @@ export function detectPackageManager(): PM {
 // Where the PM keeps globally-installed packages. Returns null if we
 // can't determine the path (e.g. deno; or a PM we couldn't probe).
 export function globalNodeModulesDir(pm: PM): string | null {
-  const home = process.env.HOME ?? '~';
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
   try {
     switch (pm) {
       case 'pnpm': {


### PR DESCRIPTION
## Summary
- use `USERPROFILE` / `os.homedir()` instead of the literal `~` for global adapter install paths when `HOME` is unset
- add a regression test for bun/aube global node_modules path resolution

## Why
Node does not expand `~` in paths. In Windows or HOME-less CI/container environments, the previous fallback caused sh1pt to check a literal `~/.bun` or `~/.aube` directory and miss already-installed global adapter packages.

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter @profullstack/sh1pt-core --filter @profullstack/sh1pt-policy --filter @profullstack/sh1pt-action-packs --filter @profullstack/sh1pt-actions-fleet-core --filter @profullstack/sh1pt-openapi build`
- `corepack pnpm exec vitest run packages/cli/src/installer.test.ts`
- `corepack pnpm --filter @profullstack/sh1pt typecheck`
- `git diff --check`