### PR TITLE
Reject unsafe remote plan destinations

### DIFF
--- a/packages/actions-fleet-core/src/diff/plan.test.ts
+++ b/packages/actions-fleet-core/src/diff/plan.test.ts
@@ -168,6 +168,30 @@ describe('planDiff', () => {
       await rm(repoDir, { recursive: true, force: true });
     }
   });
+
+  it('rejects nested traversal that normalizes outside the repo', async () => {
+    const repoDir = await mkdtemp(join(tmpdir(), 'sh1pt-diff-'));
+    try {
+      const render: RenderResult = {
+        packId: 'test-pack',
+        packVersion: '1.0.0',
+        files: [
+          {
+            source: 'x.hbs',
+            destination: '.github/workflows/../../../outside.yml',
+            mergeStrategy: 'replace-managed',
+            content: 'x',
+            hash: 'a',
+          },
+        ],
+      };
+      await expect(
+        planDiff({ repoDir, render, readExisting: async () => null }),
+      ).rejects.toThrow(UnsafeRepoPathError);
+    } finally {
+      await rm(repoDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('summarizeDiff + hasConflicts', () => {

--- a/packages/actions-fleet-core/src/diff/plan.ts
+++ b/packages/actions-fleet-core/src/diff/plan.ts
@@ -50,14 +50,23 @@ function resolveSafeRepoPath(repoDir: string, destination: string): string {
   if (!isAbsolute(repoDir)) {
     throw new Error(`repoDir must be absolute, got "${repoDir}"`);
   }
-  if (destination.startsWith('/')) throw new UnsafeRepoPathError(destination);
-  if (destination.includes('\0')) throw new UnsafeRepoPathError(destination);
+  assertSafeDestination(destination);
   const absolute = normalize(join(repoDir, destination));
   const repoWithSep = repoDir.endsWith(sep) ? repoDir : `${repoDir}${sep}`;
   if (!absolute.startsWith(repoWithSep) && absolute !== repoDir) {
     throw new UnsafeRepoPathError(destination);
   }
   return absolute;
+}
+
+function assertSafeDestination(destination: string): void {
+  if (isAbsolute(destination)) throw new UnsafeRepoPathError(destination);
+  if (destination.startsWith('/')) throw new UnsafeRepoPathError(destination);
+  if (destination.includes('\0')) throw new UnsafeRepoPathError(destination);
+  const normalized = normalize(destination);
+  if (normalized === '..' || normalized.startsWith(`..${sep}`) || normalized.includes(`${sep}..${sep}`)) {
+    throw new UnsafeRepoPathError(destination);
+  }
 }
 
 async function defaultReadExisting(absolutePath: string): Promise<string | null> {
@@ -269,6 +278,7 @@ export async function planRemoteDiff(options: PlanRemoteDiffOptions): Promise<Re
   const files: RemotePlannedFileDiff[] = [];
 
   for (const file of render.files) {
+    assertSafeDestination(file.destination);
     const existing = await options.readExisting(file.destination);
     let status: DiffStatus;
     if (existing === null) {

--- a/packages/actions-fleet-core/src/remote/plan-remote.test.ts
+++ b/packages/actions-fleet-core/src/remote/plan-remote.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createHash } from 'node:crypto';
-import { planRemoteDiff, summarizeRemoteDiff, hasRemoteConflicts } from '../diff/plan.js';
+import { planRemoteDiff, summarizeRemoteDiff, hasRemoteConflicts, UnsafeRepoPathError } from '../diff/plan.js';
 import type { RenderResult } from '../action-pack/render.js';
 
 function bodyHash(body: string): string {
@@ -144,5 +144,28 @@ describe('planRemoteDiff', () => {
     expect(s.create).toBe(1);
     expect(s.conflict).toBe(1);
     expect(hasRemoteConflicts(plan)).toBe(true);
+  });
+
+  it('rejects remote file destinations that escape the repo', async () => {
+    await expect(
+      planRemoteDiff({
+        owner: 'acme',
+        repo: 'app',
+        baseRef: 'main',
+        render: {
+          ...singleFileRender(hash),
+          files: [
+            {
+              source: 'escape.hbs',
+              destination: '../outside.yml',
+              mergeStrategy: 'replace-managed',
+              content: 'x',
+              hash: 'h1',
+            },
+          ],
+        },
+        readExisting: async () => null,
+      }),
+    ).rejects.toThrow(UnsafeRepoPathError);
   });
 });


### PR DESCRIPTION
## Summary
- reuse destination safety checks before planning remote Actions Fleet file updates
- reject remote render destinations that would normalize outside the repository before reading or writing through the GitHub Contents API
- add local and remote regression coverage for unsafe traversal destinations

## Validation
- `node_modules/.bin/vitest.CMD run packages/actions-fleet-core/src/diff/plan.test.ts packages/actions-fleet-core/src/remote/plan-remote.test.ts` (18 tests passed)