### PR TITLE
Ignore negative Atlantic plan prices

### DIFF
--- a/packages/cloud/atlantic/src/index.test.ts
+++ b/packages/cloud/atlantic/src/index.test.ts
@@ -55,6 +55,34 @@ describe('Atlantic.Net cloud adapter', () => {
     });
   });
 
+  it('ignores malformed negative plan prices when choosing a quote', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (_url: string, init: RequestInit) => {
+      if (requestParam(init, 'Action') !== 'describe-plan') {
+        return jsonResponse({ error: 'unexpected action' }, { ok: false, status: 400, statusText: 'Bad Request' });
+      }
+      const response = describePlanResponse();
+      response['describe-planresponse'].plans['0item'] = {
+        plan_name: 'Negative.4GB',
+        display_ram: '4096MB',
+        display_disk: '100GB',
+        num_cpu: '2',
+        rate_per_hr: '-0.001',
+        rate_per_month: '-1.00',
+        platform: 'linux',
+      };
+      return jsonResponse(response);
+    }));
+
+    const quote = await adapter.quote(secret, {
+      kind: 'cpu-vps',
+      cpu: 2,
+      memory: 4,
+    }, {});
+
+    expect(quote.sku).toBe('G2.4GB');
+    expect(quote.hourly).toBe(0.0547);
+  });
+
   it('rejects missing plan matches instead of returning a fake zero dollar quote', async () => {
     await expect(adapter.quote(secret, {
       kind: 'cpu-vps',

--- a/packages/cloud/atlantic/src/index.ts
+++ b/packages/cloud/atlantic/src/index.ts
@@ -316,8 +316,10 @@ function isBareMetal(plan: Pick<AtlanticPlan, 'plan_name' | 'name' | 'display_na
 
 function parseMoney(value: string | undefined): number {
   if (!value) return 0;
-  const numeric = Number(value.replace(/[^0-9.]/g, ''));
-  return Number.isFinite(numeric) ? numeric : 0;
+  const normalized = value.trim().replace(/[$,\s]/g, '');
+  const match = normalized.match(/^[-+]?\d+(?:\.\d+)?/);
+  const numeric = match ? Number(match[0]) : Number.NaN;
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : 0;
 }
 
 function parseSizeGb(value: string | undefined): number {


### PR DESCRIPTION
## Summary
- reject negative Atlantic.Net plan prices while parsing money values
- keep malformed/negative prices from being selected as the cheapest valid quote
- add a regression test covering a negative price row ahead of a valid matching plan

## Test
- .\node_modules\.bin\vitest.CMD run packages\cloud\atlantic\src\index.test.ts