### PR TITLE
Validate WebSub lease seconds

### DIFF
--- a/packages/w3c/websub/src/index.test.ts
+++ b/packages/w3c/websub/src/index.test.ts
@@ -120,6 +120,24 @@ describe('WebSub helpers', () => {
     })).toThrow('hub.secret must be less than 200 bytes');
   });
 
+  it('rejects invalid lease seconds when building subscription requests', () => {
+    expect(() => buildSubscriptionRequest({
+      hubUrl: 'https://hub.example/',
+      callbackUrl: 'https://subscriber.example/callback',
+      topicUrl: 'https://publisher.example/feed',
+      mode: 'subscribe',
+      leaseSeconds: -1,
+    })).toThrow('hub.lease_seconds must be a non-negative integer');
+
+    expect(() => buildSubscriptionRequest({
+      hubUrl: 'https://hub.example/',
+      callbackUrl: 'https://subscriber.example/callback',
+      topicUrl: 'https://publisher.example/feed',
+      mode: 'subscribe',
+      leaseSeconds: 1.5,
+    })).toThrow('hub.lease_seconds must be a non-negative integer');
+  });
+
   it('verifies callback intent requests and returns the challenge to echo', () => {
     const intent = verifyIntentRequest(new URLSearchParams({
       'hub.mode': 'subscribe',
@@ -134,6 +152,15 @@ describe('WebSub helpers', () => {
       challenge: 'challenge-token',
       leaseSeconds: 600,
     });
+  });
+
+  it('rejects invalid callback intent lease seconds', () => {
+    expect(() => verifyIntentRequest(new URLSearchParams({
+      'hub.mode': 'subscribe',
+      'hub.topic': 'https://publisher.example/feed',
+      'hub.challenge': 'challenge-token',
+      'hub.lease_seconds': '600s',
+    }))).toThrow('invalid hub.lease_seconds');
   });
 
   it('validates distribution signatures with a timing-safe HMAC comparison', () => {

--- a/packages/w3c/websub/src/index.ts
+++ b/packages/w3c/websub/src/index.ts
@@ -159,7 +159,7 @@ export function buildSubscriptionRequest(request: WebSubSubscriptionRequest): We
     'hub.topic': request.topicUrl,
   });
 
-  if (request.leaseSeconds !== undefined) body.set('hub.lease_seconds', String(request.leaseSeconds));
+  if (request.leaseSeconds !== undefined) body.set('hub.lease_seconds', String(validLeaseSeconds(request.leaseSeconds)));
   if (request.secret) body.set('hub.secret', request.secret);
   for (const [key, value] of Object.entries(request.extraParams ?? {})) {
     if (value !== undefined) body.set(key, String(value));
@@ -191,7 +191,7 @@ export function verifyIntentRequest(
     mode,
     topic,
     challenge,
-    leaseSeconds: lease ? Number.parseInt(lease, 10) : undefined,
+    leaseSeconds: lease ? parseLeaseSeconds(lease) : undefined,
   };
 }
 
@@ -259,6 +259,18 @@ function absolutize(value: string, baseUrl: string): string {
 
 function unique(values: string[]): string[] {
   return [...new Set(values)];
+}
+
+function validLeaseSeconds(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error('hub.lease_seconds must be a non-negative integer');
+  }
+  return value;
+}
+
+function parseLeaseSeconds(value: string): number {
+  if (!/^\d+$/.test(value)) throw new Error('invalid hub.lease_seconds');
+  return validLeaseSeconds(Number(value));
 }
 
 function valueOf(params: URLSearchParams | Record<string, string | undefined>, key: string): string | undefined {


### PR DESCRIPTION
## Summary
- validate WebSub `hub.lease_seconds` before building subscription requests
- reject malformed callback lease values instead of returning `NaN` or partially parsed values
- add regression coverage for invalid request and callback lease values

## Test
- .\node_modules\.bin\vitest.CMD run packages\w3c\websub\src\index.test.ts