### PR TITLE
Match Micropub rel tokens case-insensitively

### DIFF
--- a/packages/w3c/micropub/src/index.test.ts
+++ b/packages/w3c/micropub/src/index.test.ts
@@ -66,6 +66,25 @@ describe('w3c-micropub namespace', () => {
     });
   });
 
+  it('matches Micropub rel tokens case-insensitively', () => {
+    expect(parseMicropubLinkHeader(
+      '<https://api.example/micropub>; rel="Micropub", '
+        + '<https://id.example/token>; rel="TOKEN_ENDPOINT"',
+      'https://example.test/profile',
+    )).toEqual({
+      micropubEndpoint: 'https://api.example/micropub',
+      tokenEndpoint: 'https://id.example/token',
+    });
+
+    expect(parseEmbeddedMicropubLinks(
+      '<link rel="Authorization_Endpoint" href="/auth"><a rel="MICROPUB" href="/micropub"></a>',
+      'https://example.test/profile',
+    )).toEqual({
+      authorizationEndpoint: 'https://example.test/auth',
+      micropubEndpoint: 'https://example.test/micropub',
+    });
+  });
+
   it('builds JSON create, update, delete, and config query requests', () => {
     const create = buildMicropubCreateRequest({
       endpointUrl: 'https://example.test/micropub',

--- a/packages/w3c/micropub/src/index.ts
+++ b/packages/w3c/micropub/src/index.ts
@@ -305,7 +305,7 @@ function assignRel(
   const resolved = resolveHref(href, baseUrl);
   if (!resolved) return;
 
-  const rels = rel.split(/\s+/).filter(Boolean);
+  const rels = rel.toLowerCase().split(/\s+/).filter(Boolean);
   if (rels.includes('micropub')) discovery.micropubEndpoint = resolved;
   if (rels.includes('authorization_endpoint')) discovery.authorizationEndpoint = resolved;
   if (rels.includes('token_endpoint')) discovery.tokenEndpoint = resolved;


### PR DESCRIPTION
## Summary
- normalize Micropub discovery rel tokens before matching them
- allow Link headers and embedded HTML rel values like `Micropub`, `MICROPUB`, or `TOKEN_ENDPOINT`
- add regression coverage for case-insensitive Link header and embedded discovery

## Test
- .\node_modules\.bin\vitest.CMD run packages\w3c\micropub\src\index.test.ts