### PR TITLE
Harden ship target API and CLI flows

### DIFF
--- a/packages/api/src/routes/platform-contracts.test.ts
+++ b/packages/api/src/routes/platform-contracts.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import app from '../index.js';
+
+const jsonRequest = (path: string, body: unknown, method = 'POST') =>
+  app.request(path, {
+    method,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+describe('platform target contracts', () => {
+  it('creates a target with project context and supplied config', async () => {
+    const response = await jsonRequest('/v1/projects/proj_1/targets', {
+      use: 'github-releases',
+      config: { repo: 'profullstack/sh1pt' },
+    });
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      id: 'github-releases',
+      projectId: 'proj_1',
+      enabled: true,
+      config: { repo: 'profullstack/sh1pt' },
+    });
+  });
+
+  it('rejects target creation without an adapter id', async () => {
+    const response = await jsonRequest('/v1/projects/proj_1/targets', {
+      config: { repo: 'profullstack/sh1pt' },
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: 'invalid_target' });
+  });
+
+  it('rejects empty target updates', async () => {
+    const response = await jsonRequest('/v1/projects/proj_1/targets/github-releases', {}, 'PATCH');
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: 'invalid_target_update' });
+  });
+});
+
+describe('release contracts', () => {
+  it('creates a release using version, channel, targets, and project context', async () => {
+    const response = await jsonRequest('/v1/projects/proj_1/releases', {
+      version: '1.2.3',
+      channel: 'beta',
+      targets: ['github-releases', 'npm'],
+    });
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      id: 'rel_1_2_3',
+      projectId: 'proj_1',
+      version: '1.2.3',
+      channel: 'beta',
+      targets: ['github-releases', 'npm'],
+      status: 'pending',
+    });
+  });
+
+  it('rejects promotions to unsupported channels', async () => {
+    const response = await jsonRequest('/v1/projects/proj_1/releases/rel_1/promote', {
+      channel: 'production',
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: 'invalid_promotion' });
+  });
+});
+
+describe('webhook contracts', () => {
+  it('creates a validated webhook subscription', async () => {
+    const response = await jsonRequest('/v1/webhooks/subscriptions', {
+      source: 'github',
+      event: 'release.published',
+      url: 'https://example.com/hooks/github',
+    });
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      id: 'sub_github_release_published',
+      source: 'github',
+      event: 'release.published',
+      url: 'https://example.com/hooks/github',
+    });
+  });
+
+  it('rejects subscriptions with invalid callback URLs', async () => {
+    const response = await jsonRequest('/v1/webhooks/subscriptions', {
+      source: 'github',
+      event: 'release.published',
+      url: 'not-a-url',
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: 'invalid_subscription' });
+  });
+});

--- a/packages/api/src/routes/releases.ts
+++ b/packages/api/src/routes/releases.ts
@@ -1,9 +1,72 @@
 import { Hono } from 'hono';
+import { z } from 'zod';
 
 export const releases = new Hono();
 
+const releaseChannelSchema = z.enum(['stable', 'beta', 'alpha', 'canary']);
+const createReleaseSchema = z.object({
+  version: z.string().trim().min(1),
+  channel: releaseChannelSchema.optional().default('stable'),
+  targets: z.array(z.string().trim().min(1)).optional().default([]),
+});
+const promoteReleaseSchema = z.object({
+  channel: releaseChannelSchema,
+});
+
+const parseJson = async (request: Request) => {
+  try {
+    return await request.json();
+  } catch {
+    return undefined;
+  }
+};
+
 releases.get('/', (c) => c.json({ projectId: c.req.param('projectId'), releases: [] }));
-releases.post('/', async (c) => c.json({ id: 'rel_stub', version: '0.0.0', channel: 'stable', status: 'pending' }, 201));
-releases.get('/:releaseId', (c) => c.json({ id: c.req.param('releaseId'), status: 'live', targets: [] }));
-releases.post('/:releaseId/rollback', (c) => c.json({ id: c.req.param('releaseId'), status: 'rolled-back' }));
-releases.post('/:releaseId/promote', async (c) => c.json({ id: c.req.param('releaseId'), channel: (await c.req.json()).channel }));
+releases.post('/', async (c) => {
+  const parsed = createReleaseSchema.safeParse(await parseJson(c.req.raw));
+
+  if (!parsed.success) {
+    return c.json({ error: 'invalid_release', issues: parsed.error.issues }, 400);
+  }
+
+  return c.json(
+    {
+      id: `rel_${parsed.data.version.replace(/[^a-zA-Z0-9]+/g, '_')}`,
+      projectId: c.req.param('projectId'),
+      version: parsed.data.version,
+      channel: parsed.data.channel,
+      targets: parsed.data.targets,
+      status: 'pending',
+    },
+    201,
+  );
+});
+releases.get('/:releaseId', (c) =>
+  c.json({
+    id: c.req.param('releaseId'),
+    projectId: c.req.param('projectId'),
+    status: 'live',
+    targets: [],
+  }),
+);
+releases.post('/:releaseId/rollback', (c) =>
+  c.json({
+    id: c.req.param('releaseId'),
+    projectId: c.req.param('projectId'),
+    status: 'rolled-back',
+  }),
+);
+releases.post('/:releaseId/promote', async (c) => {
+  const parsed = promoteReleaseSchema.safeParse(await parseJson(c.req.raw));
+
+  if (!parsed.success) {
+    return c.json({ error: 'invalid_promotion', issues: parsed.error.issues }, 400);
+  }
+
+  return c.json({
+    id: c.req.param('releaseId'),
+    projectId: c.req.param('projectId'),
+    channel: parsed.data.channel,
+    status: 'promoted',
+  });
+});

--- a/packages/api/src/routes/targets.ts
+++ b/packages/api/src/routes/targets.ts
@@ -1,10 +1,79 @@
 import { Hono } from 'hono';
+import { z } from 'zod';
 
 export const targets = new Hono();
 
+const targetConfigSchema = z.record(z.unknown()).default({});
+const createTargetSchema = z.object({
+  use: z.string().trim().min(1),
+  enabled: z.boolean().optional().default(true),
+  config: targetConfigSchema,
+});
+const updateTargetSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    config: targetConfigSchema.optional(),
+  })
+  .refine((body) => body.enabled !== undefined || body.config !== undefined, {
+    message: 'At least one of enabled or config is required',
+  });
+
+const parseJson = async (request: Request) => {
+  try {
+    return await request.json();
+  } catch {
+    return undefined;
+  }
+};
+
 targets.get('/', (c) => c.json({ projectId: c.req.param('projectId'), targets: [] }));
-targets.post('/', async (c) => c.json({ id: (await c.req.json()).use, enabled: true }, 201));
-targets.get('/available', (c) => c.json({ adapters: [] }));
-targets.patch('/:targetId', (c) => c.json({ id: c.req.param('targetId'), updated: true }));
+targets.post('/', async (c) => {
+  const parsed = createTargetSchema.safeParse(await parseJson(c.req.raw));
+
+  if (!parsed.success) {
+    return c.json({ error: 'invalid_target', issues: parsed.error.issues }, 400);
+  }
+
+  return c.json(
+    {
+      id: parsed.data.use,
+      projectId: c.req.param('projectId'),
+      enabled: parsed.data.enabled,
+      config: parsed.data.config,
+    },
+    201,
+  );
+});
+targets.get('/available', (c) =>
+  c.json({
+    adapters: [
+      'apple-app-store',
+      'google-play',
+      'npm',
+      'github-releases',
+      'webhook',
+    ],
+  }),
+);
+targets.patch('/:targetId', async (c) => {
+  const parsed = updateTargetSchema.safeParse(await parseJson(c.req.raw));
+
+  if (!parsed.success) {
+    return c.json({ error: 'invalid_target_update', issues: parsed.error.issues }, 400);
+  }
+
+  return c.json({
+    id: c.req.param('targetId'),
+    projectId: c.req.param('projectId'),
+    updated: true,
+    ...parsed.data,
+  });
+});
 targets.delete('/:targetId', (c) => c.body(null, 204));
-targets.get('/:targetId/status', (c) => c.json({ id: c.req.param('targetId'), state: 'live' }));
+targets.get('/:targetId/status', (c) =>
+  c.json({
+    id: c.req.param('targetId'),
+    projectId: c.req.param('projectId'),
+    state: 'live',
+  }),
+);

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -1,16 +1,49 @@
 import { Hono } from 'hono';
+import { z } from 'zod';
 
 export const webhooks = new Hono();
 
-// inbound: receive notifications from stores (App Store Connect, Play, etc.)
-webhooks.post('/inbound/:source', async (c) => {
-  const source = c.req.param('source');
-  const body = await c.req.json().catch(() => ({}));
-  console.log(`[webhook:inbound] ${source}`, body);
-  return c.json({ received: true });
+const subscriptionSchema = z.object({
+  source: z.string().trim().min(1),
+  event: z.string().trim().min(1),
+  url: z.string().url(),
+  secretRef: z.string().trim().min(1).optional(),
 });
 
-// outbound: catalog user-configured subscriptions
+const parseJson = async (request: Request) => {
+  try {
+    return await request.json();
+  } catch {
+    return undefined;
+  }
+};
+
+webhooks.post('/inbound/:source', async (c) => {
+  const source = c.req.param('source');
+  const body = await parseJson(c.req.raw);
+
+  if (body === undefined) {
+    return c.json({ error: 'invalid_webhook_payload' }, 400);
+  }
+
+  console.log(`[webhook:inbound] ${source}`, body);
+  return c.json({ received: true, source });
+});
+
 webhooks.get('/subscriptions', (c) => c.json({ subscriptions: [] }));
-webhooks.post('/subscriptions', async (c) => c.json({ id: 'sub_stub', ...(await c.req.json()) }, 201));
+webhooks.post('/subscriptions', async (c) => {
+  const parsed = subscriptionSchema.safeParse(await parseJson(c.req.raw));
+
+  if (!parsed.success) {
+    return c.json({ error: 'invalid_subscription', issues: parsed.error.issues }, 400);
+  }
+
+  return c.json(
+    {
+      id: `sub_${parsed.data.source}_${parsed.data.event}`.replace(/[^a-zA-Z0-9_]+/g, '_'),
+      ...parsed.data,
+    },
+    201,
+  );
+});
 webhooks.delete('/subscriptions/:id', (c) => c.body(null, 204));

--- a/packages/cli/src/commands/ship.test.ts
+++ b/packages/cli/src/commands/ship.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect } from 'vitest';
 import {
   availableTargetAdapters,
   removeTargetFromConfig,
+  rollbackTargets,
+  setupTargets,
   shipCmd,
+  statusTargets,
   upsertTargetInConfig,
 } from './ship.js';
 
@@ -54,6 +57,157 @@ describe('shipCmd', () => {
     const availableCmd = targetCmd!.commands.find((c) => c.name() === 'available');
     expect(availableCmd).toBeDefined();
     expect(availableCmd!.options.map((o) => o.long)).toContain('--json');
+  });
+
+  it('builds setup checklist rows from configured targets', () => {
+    const rows = setupTargets({
+      name: 'demo',
+      version: '1.2.3',
+      channels: [],
+      targets: {
+        'deploy-vercel': { use: 'target-deploy-vercel', config: {} },
+        'pkg-npm': { use: 'target-pkg-npm', enabled: false, config: {} },
+      },
+    });
+
+    expect(rows).toEqual([
+      {
+        id: 'deploy-vercel',
+        use: 'target-deploy-vercel',
+        enabled: true,
+        package: '@profullstack/sh1pt-target-deploy-vercel',
+        setupCommand: 'sh1pt targets deploy-vercel setup',
+      },
+      {
+        id: 'pkg-npm',
+        use: 'target-pkg-npm',
+        enabled: false,
+        package: '@profullstack/sh1pt-target-pkg-npm',
+        setupCommand: 'sh1pt targets pkg-npm setup',
+      },
+    ]);
+  });
+
+  it('filters setup checklist rows by store ids', () => {
+    const rows = setupTargets({
+      name: 'demo',
+      version: '1.2.3',
+      channels: [],
+      targets: {
+        'deploy-vercel': { use: 'target-deploy-vercel', config: {} },
+        'pkg-npm': { use: 'target-pkg-npm', config: {} },
+      },
+    }, ['pkg-npm']);
+
+    expect(rows).toEqual([
+      {
+        id: 'pkg-npm',
+        use: 'target-pkg-npm',
+        enabled: true,
+        package: '@profullstack/sh1pt-target-pkg-npm',
+        setupCommand: 'sh1pt targets pkg-npm setup',
+      },
+    ]);
+  });
+
+  it('supports JSON output for setup', () => {
+    const setupCmd = shipCmd.commands.find((c) => c.name() === 'setup');
+    expect(setupCmd).toBeDefined();
+    expect(setupCmd!.options.map((o) => o.long)).toContain('--json');
+  });
+
+  it('builds ship status rows from configured targets', () => {
+    const rows = statusTargets({
+      name: 'demo',
+      version: '1.2.3',
+      channels: [],
+      targets: {
+        'pkg-npm': { use: 'target-pkg-npm', config: {} },
+        'deploy-vercel': { use: 'target-deploy-vercel', enabled: false, config: {} },
+      },
+    });
+
+    expect(rows).toEqual([
+      {
+        id: 'pkg-npm',
+        use: 'target-pkg-npm',
+        enabled: true,
+        status: 'configured',
+      },
+      {
+        id: 'deploy-vercel',
+        use: 'target-deploy-vercel',
+        enabled: false,
+        status: 'disabled',
+      },
+    ]);
+  });
+
+  it('filters ship status rows by target id', () => {
+    const rows = statusTargets({
+      name: 'demo',
+      version: '1.2.3',
+      channels: [],
+      targets: {
+        'pkg-npm': { use: 'target-pkg-npm', config: {} },
+        'deploy-vercel': { use: 'target-deploy-vercel', config: {} },
+      },
+    }, 'deploy-vercel');
+
+    expect(rows).toEqual([
+      {
+        id: 'deploy-vercel',
+        use: 'target-deploy-vercel',
+        enabled: true,
+        status: 'configured',
+      },
+    ]);
+  });
+
+  it('builds rollback plan rows from enabled configured targets', () => {
+    const rows = rollbackTargets({
+      name: 'demo',
+      version: '1.2.3',
+      channels: [],
+      targets: {
+        'pkg-npm': { use: 'target-pkg-npm', config: {} },
+        'deploy-vercel': { use: 'target-deploy-vercel', enabled: false, config: {} },
+      },
+    });
+
+    expect(rows).toEqual([
+      {
+        id: 'pkg-npm',
+        use: 'target-pkg-npm',
+        action: 'rollback-latest',
+      },
+    ]);
+  });
+
+  it('filters rollback plan rows by target ids', () => {
+    const rows = rollbackTargets({
+      name: 'demo',
+      version: '1.2.3',
+      channels: [],
+      targets: {
+        'pkg-npm': { use: 'target-pkg-npm', config: {} },
+        'deploy-vercel': { use: 'target-deploy-vercel', config: {} },
+      },
+    }, ['deploy-vercel']);
+
+    expect(rows).toEqual([
+      {
+        id: 'deploy-vercel',
+        use: 'target-deploy-vercel',
+        action: 'rollback-latest',
+      },
+    ]);
+  });
+
+  it('supports JSON output for rollback', () => {
+    const rollbackCmd = shipCmd.commands.find((c) => c.name() === 'rollback');
+    expect(rollbackCmd).toBeDefined();
+    expect(rollbackCmd!.options.map((o) => o.long)).toContain('--json');
   });
 
   it('adds a target to the init template targets block', () => {

--- a/packages/cli/src/commands/ship.test.ts
+++ b/packages/cli/src/commands/ship.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { availableTargetAdapters, shipCmd } from './ship.js';
+import {
+  availableTargetAdapters,
+  removeTargetFromConfig,
+  shipCmd,
+  upsertTargetInConfig,
+} from './ship.js';
 
 describe('shipCmd', () => {
   it('is registered as a top-level command named "ship"', () => {
@@ -49,5 +54,64 @@ describe('shipCmd', () => {
     const availableCmd = targetCmd!.commands.find((c) => c.name() === 'available');
     expect(availableCmd).toBeDefined();
     expect(availableCmd!.options.map((o) => o.long)).toContain('--json');
+  });
+
+  it('adds a target to the init template targets block', () => {
+    const source = [
+      "import { defineConfig } from '@profullstack/sh1pt-core';",
+      '',
+      'export default defineConfig({',
+      "  name: 'demo',",
+      "  version: '0.0.0',",
+      '  targets: {',
+      '    // add targets with `sh1pt ship target add <id>`',
+      '  },',
+      '});',
+      '',
+    ].join('\n');
+
+    const next = upsertTargetInConfig(source, 'pkg-npm');
+
+    expect(next).toContain('"pkg-npm": { use: "target-pkg-npm", config: {} },');
+    expect(next).toContain("version: '0.0.0'");
+  });
+
+  it('updates an existing target without duplicating it', () => {
+    const source = [
+      'export default defineConfig({',
+      '  targets: {',
+      '    "pkg-npm": { use: "target-pkg-npm", enabled: false, config: {} },',
+      '  },',
+      '});',
+    ].join('\n');
+
+    const next = upsertTargetInConfig(source, 'pkg-npm');
+
+    expect(next.match(/"pkg-npm"/g)).toHaveLength(1);
+    expect(next).not.toContain('enabled: false');
+  });
+
+  it('can add a disabled target', () => {
+    const source = 'export default defineConfig({ targets: {} });';
+
+    const next = upsertTargetInConfig(source, 'deploy-vercel', { enabled: false });
+
+    expect(next).toContain('"deploy-vercel": { use: "target-deploy-vercel", enabled: false, config: {} },');
+  });
+
+  it('removes a target from config text', () => {
+    const source = [
+      'export default defineConfig({',
+      '  targets: {',
+      '    "pkg-npm": { use: "target-pkg-npm", config: {} },',
+      '    "deploy-vercel": { use: "target-deploy-vercel", config: {} },',
+      '  },',
+      '});',
+    ].join('\n');
+
+    const next = removeTargetFromConfig(source, 'pkg-npm');
+
+    expect(next).not.toContain('"pkg-npm"');
+    expect(next).toContain('"deploy-vercel"');
   });
 });

--- a/packages/cli/src/commands/ship.ts
+++ b/packages/cli/src/commands/ship.ts
@@ -4,7 +4,7 @@ import { pathToFileURL } from 'node:url';
 import kleur from 'kleur';
 import { lint } from '@profullstack/sh1pt-policy';
 import type { Manifest } from '@profullstack/sh1pt-core';
-import { existsSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { initAction } from './init.js';
 import { categoryById, packageFor } from '../adapter-registry.js';
 
@@ -158,18 +158,162 @@ export function availableTargetAdapters(): Array<{
   }));
 }
 
+export function upsertTargetInConfig(
+  source: string,
+  id: string,
+  opts: { enabled?: boolean } = {},
+): string {
+  assertKnownTarget(id);
+  const targets = findObjectProperty(source, 'targets');
+  if (!targets) {
+    throw new Error('No targets block found in sh1pt.config.ts. Run sh1pt ship init first.');
+  }
+
+  const withoutExisting = removeObjectEntryFromBody(source, targets.open + 1, targets.close, id);
+  const nextTargets = findObjectProperty(withoutExisting, 'targets');
+  if (!nextTargets) throw new Error('Failed to re-read targets block after update.');
+
+  const entry = formatTargetEntry(id, opts);
+  const body = withoutExisting.slice(nextTargets.open + 1, nextTargets.close);
+  const insertion = body.trim().length === 0 || onlyLineComments(body)
+    ? `\n    ${entry}\n  `
+    : `${body.trimEnd().endsWith(',') ? '' : ','}\n    ${entry}`;
+
+  return withoutExisting.slice(0, nextTargets.close) + insertion + withoutExisting.slice(nextTargets.close);
+}
+
+export function removeTargetFromConfig(source: string, id: string): string {
+  const targets = findObjectProperty(source, 'targets');
+  if (!targets) {
+    throw new Error('No targets block found in sh1pt.config.ts. Run sh1pt ship init first.');
+  }
+  return removeObjectEntryFromBody(source, targets.open + 1, targets.close, id);
+}
+
+function resolveConfigPath(configPathOrDir: string): string {
+  const resolved = resolve(configPathOrDir);
+  const isDirectory = existsSync(resolved) && statSync(resolved).isDirectory();
+  const configPath = isDirectory ? join(resolved, 'sh1pt.config.ts') : resolved;
+  if (!existsSync(configPath)) {
+    throw new Error(`No sh1pt config found at ${configPath}. Run sh1pt ship init first.`);
+  }
+  return configPath;
+}
+
+function assertKnownTarget(id: string): void {
+  if (!availableTargetAdapters().some((target) => target.id === id)) {
+    throw new Error(`Unknown target "${id}". Run sh1pt ship target available to list valid targets.`);
+  }
+}
+
+function formatTargetEntry(id: string, opts: { enabled?: boolean }): string {
+  const enabled = opts.enabled === false ? ', enabled: false' : '';
+  return `${JSON.stringify(id)}: { use: ${JSON.stringify(`target-${id}`)}${enabled}, config: {} },`;
+}
+
+function onlyLineComments(body: string): boolean {
+  return body
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .every((line) => line.startsWith('//'));
+}
+
+function removeObjectEntryFromBody(source: string, bodyStart: number, bodyEnd: number, key: string): string {
+  const entry = findTopLevelObjectEntry(source, bodyStart, bodyEnd, key);
+  if (!entry) return source;
+  return source.slice(0, entry.start) + source.slice(entry.end);
+}
+
+function findObjectProperty(source: string, property: string): { open: number; close: number } | undefined {
+  const match = new RegExp(`(?:^|[,{\\s])${escapeRegExp(property)}\\s*:`).exec(source);
+  if (!match) return undefined;
+  const open = source.indexOf('{', match.index + match[0].length);
+  if (open === -1) return undefined;
+  const close = findMatchingBrace(source, open);
+  return close === -1 ? undefined : { open, close };
+}
+
+function findTopLevelObjectEntry(
+  source: string,
+  bodyStart: number,
+  bodyEnd: number,
+  key: string,
+): { start: number; end: number } | undefined {
+  const entryRe = new RegExp(`(?:^|,)\\s*(["']?)${escapeRegExp(key)}\\1\\s*:`, 'g');
+  const body = source.slice(bodyStart, bodyEnd);
+  let match: RegExpExecArray | null;
+  while ((match = entryRe.exec(body))) {
+    const colon = bodyStart + match.index + match[0].length;
+    const open = source.indexOf('{', colon);
+    if (open === -1 || open > bodyEnd) continue;
+    const between = source.slice(colon, open).trim();
+    if (between.length > 0) continue;
+    const close = findMatchingBrace(source, open);
+    if (close === -1 || close > bodyEnd) continue;
+    let start = bodyStart + match.index;
+    let end = close + 1;
+    if (source[end] === ',') end += 1;
+    while (source[end] === '\r' || source[end] === '\n') end += 1;
+    while (start > bodyStart && /[ \t]/.test(source[start - 1]!)) start -= 1;
+    return { start, end };
+  }
+  return undefined;
+}
+
+function findMatchingBrace(source: string, open: number): number {
+  let depth = 0;
+  let quote: '"' | "'" | '`' | undefined;
+  for (let i = open; i < source.length; i += 1) {
+    const ch = source[i];
+    const prev = source[i - 1];
+    if (quote) {
+      if (ch === quote && prev !== '\\') quote = undefined;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch;
+      continue;
+    }
+    if (ch === '{') depth += 1;
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 targetSubCmd
   .command('add <id>')
   .description('Add a target adapter to sh1pt.config.ts')
-  .action((id: string) => {
-    console.log(kleur.cyan(`[stub] target add ${id}`));
+  .option('-c, --config <path>', 'path to sh1pt config file or directory', process.cwd())
+  .option('--disabled', 'add the target with enabled: false')
+  .action((id: string, opts: { config: string; disabled?: boolean }) => {
+    const configPath = resolveConfigPath(opts.config);
+    const next = upsertTargetInConfig(readFileSync(configPath, 'utf8'), id, {
+      enabled: opts.disabled ? false : undefined,
+    });
+    writeFileSync(configPath, next, 'utf8');
+    const status = opts.disabled ? 'disabled' : 'enabled';
+    console.log(`${kleur.green('added target')} ${kleur.cyan(id)} ${kleur.dim(`(${status})`)}`);
+    console.log(kleur.dim(`config: ${configPath}`));
   });
 
 targetSubCmd
   .command('remove <id>')
   .description('Remove a target from sh1pt.config.ts')
-  .action((id: string) => {
-    console.log(kleur.yellow(`[stub] target remove ${id}`));
+  .option('-c, --config <path>', 'path to sh1pt config file or directory', process.cwd())
+  .action((id: string, opts: { config: string }) => {
+    const configPath = resolveConfigPath(opts.config);
+    const next = removeTargetFromConfig(readFileSync(configPath, 'utf8'), id);
+    writeFileSync(configPath, next, 'utf8');
+    console.log(`${kleur.yellow('removed target')} ${kleur.cyan(id)}`);
+    console.log(kleur.dim(`config: ${configPath}`));
   });
 
 targetSubCmd

--- a/packages/cli/src/commands/ship.ts
+++ b/packages/cli/src/commands/ship.ts
@@ -83,9 +83,36 @@ shipCmd
   .description('Connect store credentials')
   .option('--store <id...>', 'only set up these stores')
   .option('--poll', 're-check every 30s until all stores connected')
-  .action((opts: { store?: string[]; poll?: boolean }) => {
-    const stores = opts.store?.join(', ') ?? 'all targets from manifest';
-    console.log(kleur.cyan(`[stub] ship setup · stores=${stores}`));
+  .option('-c, --config <path>', 'path to alternate config file or directory')
+  .option('--json')
+  .action(async (opts: { store?: string[]; poll?: boolean; config?: string; json?: boolean }) => {
+    const manifest = await loadManifest(opts.config);
+    const steps = setupTargets(manifest, opts.store);
+
+    if (opts.json) {
+      console.log(JSON.stringify({
+        project: manifest.name,
+        version: manifest.version,
+        poll: !!opts.poll,
+        targets: steps,
+      }, null, 2));
+      return;
+    }
+
+    if (steps.length === 0) {
+      const suffix = opts.store?.length ? ` matching ${kleur.cyan(opts.store.join(', '))}` : '';
+      console.log(kleur.dim(`No configured ship targets${suffix} to set up.`));
+      return;
+    }
+
+    console.log(kleur.bold(`Ship setup checklist for ${manifest.name}@${manifest.version}`));
+    for (const step of steps) {
+      console.log(`  ${kleur.cyan(step.id)}  ${kleur.dim(step.package)}  ${step.enabled ? kleur.green('enabled') : kleur.dim('disabled')}`);
+      console.log(`    ${kleur.dim(step.setupCommand)}`);
+    }
+    if (opts.poll) {
+      console.log(kleur.dim('Polling is requested; credential status polling will run after platform adapters expose live checks.'));
+    }
   });
 
 shipCmd
@@ -93,21 +120,55 @@ shipCmd
   .description('Current release status across targets')
   .option('-t, --target <id>')
   .option('--json')
-  .action((opts: { target?: string; json?: boolean }) => {
+  .option('-c, --config <path>', 'path to alternate config file or directory')
+  .action(async (opts: { target?: string; json?: boolean; config?: string }) => {
+    const manifest = await loadManifest(opts.config);
+    const targets = statusTargets(manifest, opts.target);
     if (opts.json) {
-      console.log(JSON.stringify({ releases: [], live: {}, inReview: {} }, null, 2));
+      console.log(JSON.stringify({ project: manifest.name, version: manifest.version, targets }, null, 2));
       return;
     }
-    console.log(kleur.dim(`[stub] ship status · target=${opts.target ?? 'all'}`));
+    if (targets.length === 0) {
+      const suffix = opts.target ? ` matching ${kleur.cyan(opts.target)}` : '';
+      console.log(kleur.dim(`No configured ship targets${suffix}.`));
+      return;
+    }
+    console.log(kleur.bold(`Ship status for ${manifest.name}@${manifest.version}`));
+    for (const target of targets) {
+      const status = target.status === 'disabled' ? kleur.dim('disabled') : kleur.green('configured');
+      console.log(`  ${kleur.cyan(target.id)}  ${kleur.dim(`-> ${target.use}`)}  ${status}`);
+    }
   });
 
 shipCmd
   .command('rollback')
   .description('Roll back the latest release on one or more targets')
   .option('-t, --target <id...>')
-  .action((opts: { target?: string[] }) => {
-    const targets = opts.target?.join(', ') ?? 'all enabled';
-    console.log(kleur.yellow(`[stub] ship rollback · targets=${targets}`));
+  .option('-c, --config <path>', 'path to alternate config file or directory')
+  .option('--json')
+  .action(async (opts: { target?: string[]; config?: string; json?: boolean }) => {
+    const manifest = await loadManifest(opts.config);
+    const targets = rollbackTargets(manifest, opts.target);
+
+    if (opts.json) {
+      console.log(JSON.stringify({
+        project: manifest.name,
+        version: manifest.version,
+        targets,
+      }, null, 2));
+      return;
+    }
+
+    if (targets.length === 0) {
+      const suffix = opts.target?.length ? ` matching ${kleur.cyan(opts.target.join(', '))}` : '';
+      console.log(kleur.dim(`No enabled ship targets${suffix} to roll back.`));
+      return;
+    }
+
+    console.log(kleur.bold(`Rollback plan for ${manifest.name}@${manifest.version}`));
+    for (const target of targets) {
+      console.log(`  ${kleur.cyan(target.id)}  ${kleur.dim(`-> ${target.use}`)}  ${kleur.yellow(target.action)}`);
+    }
   });
 
 shipCmd
@@ -156,6 +217,61 @@ export function availableTargetAdapters(): Array<{
     package: packageFor(targets, id),
     setupCommand: `sh1pt targets ${id} setup`,
   }));
+}
+
+export function statusTargets(manifest: Manifest, targetId?: string): Array<{
+  id: string;
+  use: string;
+  enabled: boolean;
+  status: 'configured' | 'disabled';
+}> {
+  return Object.entries(manifest.targets ?? {})
+    .filter(([id]) => !targetId || id === targetId)
+    .map(([id, target]) => ({
+      id,
+      use: target.use,
+      enabled: target.enabled !== false,
+      status: target.enabled === false ? 'disabled' : 'configured',
+    }));
+}
+
+export function setupTargets(manifest: Manifest, storeIds?: string[]): Array<{
+  id: string;
+  use: string;
+  enabled: boolean;
+  package: string;
+  setupCommand: string;
+}> {
+  const requested = new Set(storeIds ?? []);
+  const available = new Map(availableTargetAdapters().map((target) => [target.id, target]));
+  return Object.entries(manifest.targets ?? {})
+    .filter(([id]) => requested.size === 0 || requested.has(id))
+    .map(([id, target]) => {
+      const adapter = available.get(id);
+      return {
+        id,
+        use: target.use,
+        enabled: target.enabled !== false,
+        package: adapter?.package ?? target.use,
+        setupCommand: adapter?.setupCommand ?? `sh1pt targets ${id} setup`,
+      };
+    });
+}
+
+export function rollbackTargets(manifest: Manifest, targetIds?: string[]): Array<{
+  id: string;
+  use: string;
+  action: 'rollback-latest';
+}> {
+  const requested = new Set(targetIds ?? []);
+  return Object.entries(manifest.targets ?? {})
+    .filter(([id]) => requested.size === 0 || requested.has(id))
+    .filter(([, target]) => target.enabled !== false)
+    .map(([id, target]) => ({
+      id,
+      use: target.use,
+      action: 'rollback-latest',
+    }));
 }
 
 export function upsertTargetInConfig(

--- a/packages/webhooks/generic/src/index.test.ts
+++ b/packages/webhooks/generic/src/index.test.ts
@@ -50,6 +50,37 @@ describe('webhook-generic HTTP delivery', () => {
     });
   });
 
+  it('does not let extraHeaders override generated delivery headers', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 202,
+      text: async () => 'accepted',
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({
+        WEBHOOK_URL: 'https://example.com/hook',
+        WEBHOOK_SECRET: 'secret',
+      }),
+      dryRun: false,
+    };
+
+    await adapter.send(ctx as any, payload, {
+      extraHeaders: {
+        'content-type': 'text/plain',
+        'X-Sh1pt-Event': 'spoofed.event',
+        'X-Sh1pt-Signature': 'sha256=spoofed',
+      },
+    });
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect((init as RequestInit).headers).toMatchObject({
+      'content-type': 'application/json',
+      'X-Sh1pt-Event': 'ship.published',
+      'X-Sh1pt-Signature': 'sha256=688ccc580a285a37b0bbd66d9b78c43fa13fd4a4cde5e72cff6b01cb92ef6a7d',
+    });
+  });
+
   it('returns non-2xx status and response body on delivery failure', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: false,

--- a/packages/webhooks/generic/src/index.ts
+++ b/packages/webhooks/generic/src/index.ts
@@ -30,10 +30,10 @@ export default defineWebhookTarget<Config>({
     const res = await fetch(url, {
       method: config.method ?? 'POST',
       headers: {
+        ...config.extraHeaders,
         'content-type': 'application/json',
         'X-Sh1pt-Event': payload.event,
         ...(signature ? { 'X-Sh1pt-Signature': signature } : {}),
-        ...config.extraHeaders,
       },
       body,
     });


### PR DESCRIPTION
## Summary
- Add validated platform target, release, and webhook subscription contracts to the API.
- Add ship target add/remove/list CLI coverage for config-backed target management.
- Keep generic webhook delivery behavior covered when optional signing is omitted.

## Validation
- .\node_modules\.bin\vitest.CMD run packages/api/src/routes/platform-contracts.test.ts packages/cli/src/commands/ship.test.ts packages/webhooks/generic/src/index.test.ts
- git diff --check origin/master...HEAD