### PR TITLE
Report broken ship config imports

### DIFF
--- a/packages/cli/src/commands/ship.test.ts
+++ b/packages/cli/src/commands/ship.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { availableTargetAdapters, shipCmd } from './ship.js';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { availableTargetAdapters, loadManifest, shipCmd } from './ship.js';
 
 describe('shipCmd', () => {
   it('is registered as a top-level command named "ship"', () => {
@@ -49,5 +52,13 @@ describe('shipCmd', () => {
     const availableCmd = targetCmd!.commands.find((c) => c.name() === 'available');
     expect(availableCmd).toBeDefined();
     expect(availableCmd!.options.map((o) => o.long)).toContain('--json');
+  });
+
+  it('reports broken config files instead of silently using an empty manifest', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'sh1pt-bad-config-'));
+    const file = join(dir, 'sh1pt.config.mjs');
+    await writeFile(file, 'throw new Error("boom");\nexport default {};\n');
+
+    await expect(loadManifest(file)).rejects.toThrow(/cannot load config file .*boom/);
   });
 });

--- a/packages/cli/src/commands/ship.ts
+++ b/packages/cli/src/commands/ship.ts
@@ -16,7 +16,7 @@ import { categoryById, packageFor } from '../adapter-registry.js';
  * @param configPathOrDir  Path to a config file, or a directory (appends sh1pt.config.ts).
  *                         Defaults to process.cwd().
  */
-async function loadManifest(configPathOrDir?: string): Promise<Manifest> {
+export async function loadManifest(configPathOrDir?: string): Promise<Manifest> {
   const input = configPathOrDir ?? process.cwd();
   const resolved = resolve(input);
 
@@ -48,11 +48,8 @@ async function loadManifest(configPathOrDir?: string): Promise<Manifest> {
 
     return candidate as unknown as Manifest;
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ERR_MODULE_NOT_FOUND') {
-      console.error(kleur.red(`error: cannot load config file "${configPath}"`));
-      process.exit(1);
-    }
-    return { name: 'unknown', version: '0.0.0', channels: [], targets: {} };
+    const message = (err as Error).message || String(err);
+    throw new Error(`cannot load config file "${configPath}": ${message}`);
   }
 }
 


### PR DESCRIPTION
## Summary
- make ship manifest loading report config import failures instead of silently falling back to an empty manifest
- export loadManifest for focused coverage
- add regression coverage for a config file that throws during import

## Tests
- .\\node_modules\\.bin\\vitest.CMD run packages\\cli\\src\\commands\\ship.test.ts