### PR TITLE
fix(webhook-telegram): format HTML parse mode correctly

### DIFF
--- a/packages/webhooks/telegram/src/index.test.ts
+++ b/packages/webhooks/telegram/src/index.test.ts
@@ -41,7 +41,52 @@ describe('webhook-telegram HTTP delivery', () => {
     const body = JSON.parse(String((init as RequestInit).body));
     expect(body.chat_id).toBe(-1001234567890);
     expect(body.parse_mode).toBe('HTML');
-    expect(body.text).toContain('ship\\.published');
+    expect(body.text).toContain('<b>ship.published</b>');
+  });
+
+  it('keeps MarkdownV2 formatting as the default parse mode', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, result: { message_id: 42 } }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ TELEGRAM_BOT_TOKEN: '123:abc' }),
+      dryRun: false,
+    };
+
+    await adapter.send(ctx as any, payload, { chatId: -1001234567890 });
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const body = JSON.parse(String((init as RequestInit).body));
+    expect(body.parse_mode).toBe('MarkdownV2');
+    expect(body.text).toContain('*ship\\.published*');
+  });
+
+  it('escapes HTML content when HTML parse mode is selected', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, result: { message_id: 42 } }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ TELEGRAM_BOT_TOKEN: '123:abc' }),
+      dryRun: false,
+    };
+
+    await adapter.send(ctx as any, {
+      ...payload,
+      event: 'ship<deploy>&done',
+      data: { target: '<script>', message: 'a & b' },
+    }, { chatId: -1001234567890, parseMode: 'HTML' });
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const body = JSON.parse(String((init as RequestInit).body));
+    expect(body.text).toContain('<b>ship&lt;deploy&gt;&amp;done</b>');
+    expect(body.text).toContain('&lt;script&gt;');
+    expect(body.text).toContain('a &amp; b');
   });
 
   it('returns Telegram error descriptions when sendMessage is rejected', async () => {

--- a/packages/webhooks/telegram/src/index.ts
+++ b/packages/webhooks/telegram/src/index.ts
@@ -65,14 +65,24 @@ interface TelegramResponse {
 }
 
 function formatTelegramPayload(payload: WebhookPayload, config: Config): unknown {
-  const summary = `*${escape(payload.event)}*`;
-  const body = '```\n' + JSON.stringify(payload.data, null, 2).slice(0, 3500) + '\n```';
+  const parseMode = config.parseMode ?? 'MarkdownV2';
   return {
     chat_id: config.chatId,
-    text: `${summary}\n${body}`,
-    parse_mode: config.parseMode ?? 'MarkdownV2',
+    text: formatTelegramText(payload, parseMode),
+    parse_mode: parseMode,
     disable_notification: config.disableNotification,
   };
+}
+
+function formatTelegramText(payload: WebhookPayload, parseMode: NonNullable<Config['parseMode']>): string {
+  const data = JSON.stringify(payload.data, null, 2).slice(0, 3500);
+  if (parseMode === 'HTML') {
+    return `<b>${escapeHtml(payload.event)}</b>\n<pre>${escapeHtml(data)}</pre>`;
+  }
+
+  const summary = `*${escapeMarkdown(payload.event)}*`;
+  const body = '```\n' + data + '\n```';
+  return `${summary}\n${body}`;
 }
 
 async function parseTelegramResponse(res: Response): Promise<TelegramResponse> {
@@ -83,6 +93,17 @@ async function parseTelegramResponse(res: Response): Promise<TelegramResponse> {
   }
 }
 
-function escape(s: string): string {
+function escapeMarkdown(s: string): string {
   return s.replace(/[_*[\]()~`>#+\-=|{}.!\\]/g, (c) => '\\' + c);
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"]/g, (c) => {
+    switch (c) {
+      case '&': return '&amp;';
+      case '<': return '&lt;';
+      case '>': return '&gt;';
+      default: return '&quot;';
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- format Telegram messages according to the selected parse mode instead of always emitting MarkdownV2 text
- emit valid Telegram HTML with escaped event/data content when `parseMode: "HTML"` is configured
- keep MarkdownV2 as the default behavior

## Tests
- `./node_modules/.bin/vitest.CMD run packages/webhooks/telegram/src/index.test.ts`
- `./node_modules/.bin/tsc.CMD -p packages/webhooks/telegram/tsconfig.json --noEmit`