### PR TITLE
fix(dns-googledns): match trailing-dot upserts

### DIFF
--- a/packages/dns/googledns/src/index.test.ts
+++ b/packages/dns/googledns/src/index.test.ts
@@ -1,7 +1,73 @@
 import { contractTestDns } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import dns from './index.js';
 
 contractTestDns(dns, {
   sampleConfig: {},
   requiredSecrets: ['GOOGLE_ACCESS_TOKEN', 'GOOGLE_PROJECT_ID'],
+});
+
+const ctx = (secrets: Record<string, string> = {
+  GOOGLE_ACCESS_TOKEN: 'google-token',
+  GOOGLE_PROJECT_ID: 'demo-project',
+}) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+});
+
+const jsonResponse = (body: unknown, ok = true, status = ok ? 200 : 400) => ({
+  ok,
+  status,
+  json: async () => body,
+});
+
+describe('Google Cloud DNS adapter', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('matches existing records when upserting a trailing-dot FQDN', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({
+        rrsets: [{
+          name: 'www.example.com.',
+          type: 'A',
+          ttl: 300,
+          rrdatas: ['1.1.1.1'],
+        }],
+      }))
+      .mockResolvedValueOnce(jsonResponse({ id: 'change-1' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await dns.connect(ctx(), {});
+    const record = await dns.upsertRecord('example-zone', {
+      zone: 'example-zone',
+      name: 'www.example.com.',
+      type: 'A',
+      value: '2.2.2.2',
+      ttl: 600,
+    }, {});
+
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('https://dns.googleapis.com/dns/v1/projects/demo-project/managedZones/example-zone/changes');
+    expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1].body))).toEqual({
+      kind: 'dns#change',
+      deletions: [{
+        name: 'www.example.com.',
+        type: 'A',
+        ttl: 600,
+        rrdatas: ['1.1.1.1'],
+      }],
+      additions: [{
+        name: 'www.example.com.',
+        type: 'A',
+        ttl: 600,
+        rrdatas: ['2.2.2.2'],
+      }],
+    });
+    expect(record).toMatchObject({
+      id: 'A/www.example.com.',
+      name: 'www.example.com.',
+      value: '2.2.2.2',
+    });
+  });
 });

--- a/packages/dns/googledns/src/index.test.ts
+++ b/packages/dns/googledns/src/index.test.ts
@@ -54,7 +54,7 @@ describe('Google Cloud DNS adapter', () => {
       deletions: [{
         name: 'www.example.com.',
         type: 'A',
-        ttl: 600,
+        ttl: 300,
         rrdatas: ['1.1.1.1'],
       }],
       additions: [{

--- a/packages/dns/googledns/src/index.ts
+++ b/packages/dns/googledns/src/index.ts
@@ -17,6 +17,14 @@ interface Config {
 const API = 'https://dns.googleapis.com/dns/v1';
 let _secret: (k: string) => string | undefined = () => undefined;
 
+function trimTrailingDot(name: string): string {
+  return name.replace(/\.$/, '');
+}
+
+function ensureTrailingDot(name: string): string {
+  return name.endsWith('.') ? name : `${name}.`;
+}
+
 async function getAccessToken(): Promise<string> {
   // Prefer GOOGLE_ACCESS_TOKEN (pre-fetched by caller or CI) for simplicity.
   // For service-account flow, use GOOGLE_APPLICATION_CREDENTIALS path.
@@ -78,7 +86,7 @@ export default defineDns<Config>({
     };
     const records: DnsRecord[] = [];
     for (const rs of rrsets ?? []) {
-      const name = rs.name.replace(/\.$/, '');
+      const name = trimTrailingDot(rs.name);
       for (const val of rs.rrdatas) {
         records.push({
           id: `${rs.type}/${rs.name}`,
@@ -98,11 +106,12 @@ export default defineDns<Config>({
     const project = config.projectId ?? _secret('GOOGLE_PROJECT_ID');
     if (!project) throw new Error('GOOGLE_PROJECT_ID not set');
     const ttl = record.ttl ?? config.defaultTtl ?? 300;
-    const name = record.name.endsWith('.') ? record.name : `${record.name}.`;
+    const name = ensureTrailingDot(record.name);
+    const normalizedName = trimTrailingDot(record.name);
 
     // Google Cloud DNS changes are atomic: DELETE old + ADD new in one call.
     const existing = (await this.listRecords(zoneId, config)).filter(
-      r => r.name === record.name && r.type === record.type,
+      r => trimTrailingDot(r.name) === normalizedName && r.type === record.type,
     );
     const deletions = existing.length > 0
       ? [{ name, type: record.type, ttl, rrdatas: existing.map(r => r.value) }]

--- a/packages/dns/googledns/src/index.ts
+++ b/packages/dns/googledns/src/index.ts
@@ -113,8 +113,9 @@ export default defineDns<Config>({
     const existing = (await this.listRecords(zoneId, config)).filter(
       r => trimTrailingDot(r.name) === normalizedName && r.type === record.type,
     );
+    const existingTtl = existing[0]?.ttl ?? ttl;
     const deletions = existing.length > 0
-      ? [{ name, type: record.type, ttl, rrdatas: existing.map(r => r.value) }]
+      ? [{ name, type: record.type, ttl: existingTtl, rrdatas: existing.map(r => r.value) }]
       : [];
     const additions = [{ name, type: record.type, ttl, rrdatas: [record.value] }];
 


### PR DESCRIPTION
## Summary
- normalize Google Cloud DNS names consistently when matching existing records
- make `upsertRecord` detect an existing rrset even when the requested record name includes a trailing dot
- keep the submitted change payload using Google DNS FQDNs with trailing dots

## Tests
- `./node_modules/.bin/vitest.CMD run packages/dns/googledns/src/index.test.ts`
- `./node_modules/.bin/tsc.CMD -p packages/dns/googledns/tsconfig.json --noEmit`