### PR TITLE
fix(social-discord): set wait query parameter

### DIFF
--- a/packages/social/discord/src/index.test.ts
+++ b/packages/social/discord/src/index.test.ts
@@ -63,4 +63,27 @@ describe('social-discord posting', () => {
     await expect(adapter.post(ctx as any, { body: 'Release shipped' }, {}))
       .rejects.toThrow('Invalid Form Body');
   });
+
+  it('replaces an existing wait query parameter while preserving thread routing', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: '123456789',
+        channel_id: '222',
+        guild_id: '111',
+        timestamp: '2026-05-11T20:00:00.000000+00:00',
+      }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ DISCORD_WEBHOOK_URL: 'https://discord.com/api/webhooks/1/token?thread_id=333&wait=false' }),
+      dryRun: false,
+    };
+
+    await adapter.post(ctx as any, { body: 'Release shipped' }, {});
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://discord.com/api/webhooks/1/token?thread_id=333&wait=true');
+  });
 });

--- a/packages/social/discord/src/index.ts
+++ b/packages/social/discord/src/index.ts
@@ -73,8 +73,9 @@ function formatDiscordPost(post: SocialPost, config: Config): unknown {
 }
 
 function withWait(webhookUrl: string): string {
-  const separator = webhookUrl.includes('?') ? '&' : '?';
-  return `${webhookUrl}${separator}wait=true`;
+  const url = new URL(webhookUrl);
+  url.searchParams.set('wait', 'true');
+  return url.toString();
 }
 
 async function readDiscordError(res: Response): Promise<string> {


### PR DESCRIPTION
## Summary
- build Discord webhook URLs with `URLSearchParams` instead of string-appending `wait=true`
- replace an existing `wait=false` value with `wait=true`
- preserve thread routing and any other existing webhook query parameters

## Tests
- `./node_modules/.bin/vitest.CMD run packages/social/discord/src/index.test.ts`
- `./node_modules/.bin/tsc.CMD -p packages/social/discord/tsconfig.json --noEmit`