### PR TITLE
fix(payment-coinpay): normalize webhook status case

### DIFF
--- a/packages/payments/coinpay/src/index.test.ts
+++ b/packages/payments/coinpay/src/index.test.ts
@@ -137,10 +137,10 @@ describe('payment-coinpay', () => {
   it('verifies CoinPay webhook signatures and normalizes payment events', async () => {
     const raw = JSON.stringify({
       id: 'evt_pay_123',
-      type: 'payment.confirmed',
+      type: 'Payment.Confirmed',
       data: {
         payment_id: 'pay_123',
-        status: 'confirmed',
+        status: 'PAID',
         amount_usd: '24.40',
         currency: 'USDC',
         metadata: { customer_email: 'buyer@example.com' },
@@ -160,7 +160,7 @@ describe('payment-coinpay', () => {
     );
 
     expect(webhook).toMatchObject({
-      type: 'payment.confirmed',
+      type: 'Payment.Confirmed',
       paymentId: 'pay_123',
       status: 'succeeded',
       amount: 2440,

--- a/packages/payments/coinpay/src/index.ts
+++ b/packages/payments/coinpay/src/index.ts
@@ -247,13 +247,14 @@ function normalizeWebhook(event: CoinPayWebhookEvent): Webhook {
 
 function normalizeStatus(status: string | undefined): Webhook['status'] | undefined {
   if (!status) return undefined;
-  if (['confirmed', 'forwarded', 'succeeded', 'paid', 'payment.confirmed', 'payment.forwarded'].includes(status)) {
+  const normalized = status.trim().toLowerCase();
+  if (['confirmed', 'forwarded', 'succeeded', 'paid', 'payment.confirmed', 'payment.forwarded'].includes(normalized)) {
     return 'succeeded';
   }
-  if (['pending', 'awaiting_payment', 'processing', 'created'].includes(status)) return 'pending';
-  if (['expired', 'failed', 'cancelled', 'canceled', 'payment.expired'].includes(status)) return 'failed';
-  if (status === 'refunded') return 'refunded';
-  if (status === 'disputed') return 'disputed';
+  if (['pending', 'awaiting_payment', 'processing', 'created'].includes(normalized)) return 'pending';
+  if (['expired', 'failed', 'cancelled', 'canceled', 'payment.expired'].includes(normalized)) return 'failed';
+  if (normalized === 'refunded') return 'refunded';
+  if (normalized === 'disputed') return 'disputed';
   return undefined;
 }
 


### PR DESCRIPTION
## Summary
- normalize CoinPay webhook status values before mapping them to sh1pt payment states
- accept provider casing variants such as `PAID` and `Payment.Confirmed`
- keep the original webhook event type in the returned payload/type

## Tests
- `./node_modules/.bin/vitest.CMD run packages/payments/coinpay/src/index.test.ts`
- `./node_modules/.bin/tsc.CMD -p packages/payments/coinpay/tsconfig.json --noEmit`