### PR TITLE
fix(social-spotify): trim custom API base URL

### DIFF
--- a/packages/social/spotify/src/index.test.ts
+++ b/packages/social/spotify/src/index.test.ts
@@ -88,6 +88,31 @@ describe('social-spotify playlist publishing', () => {
     });
   });
 
+  it('normalizes custom API base URLs before composing Spotify paths', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      text: async () => JSON.stringify({
+        id: 'playlist_base_url',
+        external_urls: { spotify: 'https://open.spotify.com/playlist/playlist_base_url' },
+      }),
+    } as Response);
+
+    const ctx = {
+      ...fakeConnectContext({ SPOTIFY_ACCESS_TOKEN: 'spotify-token' }),
+      dryRun: false,
+    };
+
+    await adapter.post(ctx as any, {
+      title: 'Base URL',
+      body: 'Check custom base URL handling',
+    }, {
+      baseUrl: 'https://api.spotify.example/v1/',
+    });
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://api.spotify.example/v1/me/playlists');
+  });
+
   it('updates an existing playlist and replaces its items', async () => {
     const fetchMock = vi.spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce({

--- a/packages/social/spotify/src/index.ts
+++ b/packages/social/spotify/src/index.ts
@@ -179,7 +179,8 @@ async function spotifyFetch<T>(
   options: SpotifyFetchOptions = {},
 ): Promise<T> {
   const { allowEmpty, ...init } = options;
-  const res = await fetch(`${config.baseUrl ?? 'https://api.spotify.com/v1'}${path}`, {
+  const baseUrl = (config.baseUrl ?? 'https://api.spotify.com/v1').replace(/\/+$/, '');
+  const res = await fetch(`${baseUrl}${path}`, {
     ...init,
     headers: {
       authorization: `Bearer ${token}`,


### PR DESCRIPTION
## Summary
- trim trailing slashes from custom Spotify API base URLs before composing endpoint paths
- add coverage so `baseUrl: "https://api.spotify.example/v1/"` calls `/me/playlists` without a double slash

## Tests
- `vitest run packages/social/spotify/src/index.test.ts`
- `tsc -p packages/social/spotify/tsconfig.json --noEmit`