### PR TITLE
fix(social-youtube): reject empty video uploads

### DIFF
--- a/packages/social/youtube/src/index.test.ts
+++ b/packages/social/youtube/src/index.test.ts
@@ -203,6 +203,23 @@ describe('social-youtube upload', () => {
     }, {})).rejects.toThrow('video attachment');
   });
 
+  it('rejects empty video attachments before opening an upload session', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch');
+    const ctx = {
+      ...fakeConnectContext({ YOUTUBE_ACCESS_TOKEN: 'sekret' }),
+      dryRun: false,
+    };
+
+    await expect(adapter.post(ctx as any, {
+      body: 'Empty video',
+      media: [{ file: tempVideoFile('empty.mp4', new Uint8Array()), kind: 'video' }],
+    }, {
+      uploadBaseUrl: 'https://www.googleapis.example',
+    })).rejects.toThrow('YouTube video attachment is empty');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('redacts OAuth secrets from token refresh errors', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
       error: 'invalid_grant',

--- a/packages/social/youtube/src/index.ts
+++ b/packages/social/youtube/src/index.ts
@@ -230,6 +230,7 @@ async function loadVideo(media: MediaAttachment): Promise<LoadedVideo> {
     const res = await fetch(media.file);
     if (!res.ok) throw new Error(`Could not fetch YouTube video media: ${res.statusText}`);
     const bytes = new Uint8Array(await res.arrayBuffer());
+    ensureVideoBytes(bytes);
     return {
       bytes,
       mimeType: normalizeVideoMime(res.headers.get('content-type')) ?? guessVideoMime(media.file),
@@ -237,10 +238,15 @@ async function loadVideo(media: MediaAttachment): Promise<LoadedVideo> {
   }
 
   const bytes = readFileSync(media.file);
+  ensureVideoBytes(bytes);
   return {
     bytes,
     mimeType: guessVideoMime(media.file),
   };
+}
+
+function ensureVideoBytes(bytes: Uint8Array): void {
+  if (bytes.byteLength === 0) throw new Error('YouTube video attachment is empty');
 }
 
 function guessVideoMime(file: string): string {


### PR DESCRIPTION
## Summary
- reject empty YouTube video attachments immediately after loading media bytes
- prevent invalid resumable upload ranges like `bytes 0--1/0`
- add coverage that verifies empty local videos fail before any upload API call

## Tests
- `vitest run packages/social/youtube/src/index.test.ts`
- `tsc -p packages/social/youtube/tsconfig.json --noEmit`