### PR TITLE
fix(social-medium): tolerate invalid publishedAt values

### DIFF
--- a/packages/social/medium/src/index.test.ts
+++ b/packages/social/medium/src/index.test.ts
@@ -113,6 +113,36 @@ describe('social-medium legacy API posting', () => {
     });
   });
 
+  it('falls back when Medium returns an invalid publishedAt value', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      data: {
+        id: 'pub_post_invalid_date',
+        url: 'https://medium.com/developers/invalid-date-pub_post_invalid_date',
+        publishedAt: 'not-a-date',
+      },
+    }), { status: 201, headers: { 'content-type': 'application/json' } }));
+
+    const ctx = {
+      ...fakeConnectContext({ MEDIUM_INTEGRATION_TOKEN: 'medium-token' }),
+      dryRun: false,
+    };
+
+    const result = await adapter.post(ctx as any, {
+      title: 'Medium API',
+      body: 'Draft body',
+    }, {
+      mode: 'api-legacy',
+      publicationId: 'pub_123',
+    });
+
+    expect(result).toMatchObject({
+      id: 'pub_post_invalid_date',
+      url: 'https://medium.com/developers/invalid-date-pub_post_invalid_date',
+      platform: 'medium',
+    });
+    expect(new Date(result.publishedAt).toString()).not.toBe('Invalid Date');
+  });
+
   it('surfaces Medium API errors without leaking the token', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
       errors: [{ message: 'Invalid token medium-secret-token for user' }],

--- a/packages/social/medium/src/index.ts
+++ b/packages/social/medium/src/index.ts
@@ -178,7 +178,9 @@ function redactToken(message: string, token: string): string {
 
 function mediumPublishedAt(post: MediumPost): string {
   const value = post.publishedAt;
-  if (typeof value === 'number') return new Date(value).toISOString();
-  if (typeof value === 'string') return new Date(value).toISOString();
+  if (typeof value === 'number' || typeof value === 'string') {
+    const date = new Date(value);
+    if (!Number.isNaN(date.getTime())) return date.toISOString();
+  }
   return new Date().toISOString();
 }


### PR DESCRIPTION
## Summary
- avoid throwing when Medium returns a created post with an invalid `publishedAt` value
- fall back to the current timestamp instead of failing a successful publish response
- add focused coverage for invalid `publishedAt` handling

## Tests
- `vitest run packages/social/medium/src/index.test.ts`
- `tsc -p packages/social/medium/tsconfig.json --noEmit`