### PR TITLE
fix(social-stackernews): tolerate invalid createdAt values

### DIFF
--- a/packages/social/stackernews/src/index.test.ts
+++ b/packages/social/stackernews/src/index.test.ts
@@ -128,4 +128,37 @@ describe('social-stackernews GraphQL posting', () => {
       link: 'https://sh1pt.com',
     }, { apiUrl: 'https://stacker.test/api/graphql' })).rejects.toThrow('insufficient sats');
   });
+
+  it('falls back when Stacker News returns an invalid createdAt value', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: {
+          upsertDiscussion: {
+            id: 57,
+            createdAt: 'not-a-date',
+            item: { id: 125, title: 'Ask SN', createdAt: 'not-a-date' },
+          },
+        },
+      }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ STACKERNEWS_COOKIE: 'next-auth.session-token=test' }),
+      dryRun: false,
+    };
+
+    const result = await adapter.post(ctx as any, {
+      title: 'Ask SN',
+      body: 'What should sh1pt support next?',
+    }, { territory: 'meta', apiUrl: 'https://stacker.test/api/graphql' });
+
+    expect(result).toMatchObject({
+      id: '125',
+      url: 'https://stacker.news/items/125',
+      platform: 'stackernews',
+    });
+    expect(new Date(result.publishedAt).toString()).not.toBe('Invalid Date');
+  });
 });

--- a/packages/social/stackernews/src/index.ts
+++ b/packages/social/stackernews/src/index.ts
@@ -42,7 +42,7 @@ export default defineSocial<Config>({
       id,
       url: item?.id ? `https://stacker.news/items/${item.id}` : 'https://stacker.news/',
       platform: 'stackernews',
-      publishedAt: new Date(item?.createdAt ?? payIn.createdAt ?? Date.now()).toISOString(),
+      publishedAt: stackerTimestamp(item?.createdAt ?? payIn.createdAt),
     };
   },
 
@@ -143,6 +143,11 @@ async function readStackerResponse<T>(res: Response): Promise<StackerGraphqlResp
 function formatText(post: SocialPost): string {
   const tags = (post.hashtags ?? []).slice(0, 3).map((tag) => `#${tag}`).join(' ');
   return [post.body, tags].filter(Boolean).join('\n\n').slice(0, 20_000);
+}
+
+function stackerTimestamp(value: string | undefined): string {
+  const date = value ? new Date(value) : new Date();
+  return Number.isNaN(date.getTime()) ? new Date().toISOString() : date.toISOString();
 }
 
 interface StackerGraphqlResponse<T> {


### PR DESCRIPTION
## Summary
- avoid throwing when Stacker News returns a successful item with an invalid `createdAt` value
- fall back to the current timestamp while preserving the submitted item id and URL
- add focused coverage for invalid `createdAt` handling

## Tests
- `vitest run packages/social/stackernews/src/index.test.ts`
- `tsc -p packages/social/stackernews/tsconfig.json --noEmit`