### PR TITLE
fix(social-x): trim custom API base URL

### DIFF
--- a/packages/social/x/src/index.test.ts
+++ b/packages/social/x/src/index.test.ts
@@ -83,6 +83,28 @@ describe('social-x API posting', () => {
     });
   });
 
+  it('normalizes custom API base URLs before composing tweet paths', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ data: { id: '1445880548472328194', text: 'Custom base' } }),
+    } as Response);
+
+    const ctx = {
+      ...fakeConnectContext({ X_BEARER_TOKEN: 'x-token' }),
+      dryRun: false,
+    };
+
+    await adapter.post(ctx as any, {
+      body: 'Custom base',
+    }, {
+      mode: 'api',
+      apiBaseUrl: 'https://api.x.example/',
+    });
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://api.x.example/2/tweets');
+  });
+
   it('rejects media attachments without pre-uploaded media ids', async () => {
     const ctx = {
       ...fakeConnectContext({ X_BEARER_TOKEN: 'x-token' }),

--- a/packages/social/x/src/index.ts
+++ b/packages/social/x/src/index.ts
@@ -56,7 +56,8 @@ export default defineSocial<Config>({
       throw new Error('X media posts require pre-uploaded media IDs in config.mediaIds');
     }
 
-    const res = await fetch(`${config.apiBaseUrl ?? 'https://api.x.com'}/2/tweets`, {
+    const apiBaseUrl = (config.apiBaseUrl ?? 'https://api.x.com').replace(/\/+$/, '');
+    const res = await fetch(`${apiBaseUrl}/2/tweets`, {
       method: 'POST',
       headers: {
         authorization: `Bearer ${token}`,


### PR DESCRIPTION
## Summary
- trim trailing slashes from custom X API base URLs before composing `/2/tweets`
- avoid malformed request URLs like `https://api.x.example//2/tweets`
- add focused coverage for custom API base URL normalization

## Tests
- `vitest run packages/social/x/src/index.test.ts`
- `tsc -p packages/social/x/tsconfig.json --noEmit`