### PR TITLE
fix(social-pinterest): tolerate invalid created_at values

### DIFF
--- a/packages/social/pinterest/src/index.test.ts
+++ b/packages/social/pinterest/src/index.test.ts
@@ -103,6 +103,37 @@ describe('social-pinterest posting', () => {
     });
   });
 
+  it('falls back to the current timestamp when Pinterest returns an invalid created_at', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        id: '654321654321654321',
+        created_at: 'not-a-date',
+      }),
+    } as Response);
+
+    const ctx = {
+      ...fakeConnectContext({ PINTEREST_ACCESS_TOKEN: 'pinterest-token' }),
+      dryRun: false,
+    };
+
+    const result = await adapter.post(ctx as any, {
+      title: 'Launch visual',
+      body: 'Launch screenshot',
+      media: [{ file: 'https://cdn.example.com/launch.jpg', kind: 'image' }],
+    }, {
+      boardId: 'board_123',
+    });
+
+    expect(result).toMatchObject({
+      id: '654321654321654321',
+      url: 'https://www.pinterest.com/pin/654321654321654321/',
+      platform: 'pinterest',
+      publishedAt: expect.any(String),
+    });
+  });
+
   it('rejects local image paths because Pinterest image_url requires a URL', async () => {
     const ctx = {
       ...fakeConnectContext({ PINTEREST_ACCESS_TOKEN: 'pinterest-token' }),

--- a/packages/social/pinterest/src/index.ts
+++ b/packages/social/pinterest/src/index.ts
@@ -139,5 +139,7 @@ async function readPinterestResponse(res: Response): Promise<PinterestPinRespons
 function pinterestTimestamp(value: string | undefined): string {
   if (!value) return new Date().toISOString();
   const hasTimezone = /(?:Z|[+-]\d{2}:\d{2})$/.test(value);
-  return new Date(hasTimezone ? value : `${value}Z`).toISOString();
+  const timestamp = new Date(hasTimezone ? value : `${value}Z`);
+  if (Number.isNaN(timestamp.getTime())) return new Date().toISOString();
+  return timestamp.toISOString();
 }


### PR DESCRIPTION
## Summary
- avoid throwing after a successful Pinterest Pin create when `created_at` is malformed
- fall back to the current timestamp for invalid Pinterest timestamps
- add a focused regression test for invalid `created_at` responses

## Tests
- `vitest run packages/social/pinterest/src/index.test.ts`
- `tsc -p packages/social/pinterest/tsconfig.json --noEmit`