### PR TITLE
fix(social-devto): tolerate invalid article timestamps

### DIFF
--- a/packages/social/devto/src/index.test.ts
+++ b/packages/social/devto/src/index.test.ts
@@ -78,6 +78,32 @@ describe('social-devto posting', () => {
       .rejects.toThrow('Title has already been taken');
   });
 
+  it('falls back to the current timestamp when DEV returns an invalid published_at', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        id: 251,
+        url: 'https://dev.to/sh1pt/release-shipped',
+        published_at: 'not-a-date',
+      }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ DEVTO_API_KEY: 'dev-key' }),
+      dryRun: false,
+    };
+
+    const result = await adapter.post(ctx as any, { title: 'Release shipped', body: 'Article body' }, {});
+
+    expect(result).toMatchObject({
+      id: '251',
+      url: 'https://dev.to/sh1pt/release-shipped',
+      platform: 'devto',
+      publishedAt: expect.any(String),
+    });
+  });
+
   it('throws when DEV omits the article id from a successful response', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: true,

--- a/packages/social/devto/src/index.ts
+++ b/packages/social/devto/src/index.ts
@@ -42,7 +42,7 @@ export default defineSocial<Config>({
       id: String(article.id),
       url: article.url ?? 'https://dev.to/',
       platform: 'devto',
-      publishedAt: new Date(article.published_at ?? article.created_at ?? Date.now()).toISOString(),
+      publishedAt: devtoTimestamp(article.published_at ?? article.created_at),
     };
   },
 
@@ -86,4 +86,11 @@ async function readDevtoError(res: Response): Promise<string> {
   } catch {
     return text;
   }
+}
+
+function devtoTimestamp(value: string | null | undefined): string {
+  if (!value) return new Date().toISOString();
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.getTime())) return new Date().toISOString();
+  return timestamp.toISOString();
 }

--- a/packages/social/forem/src/index.test.ts
+++ b/packages/social/forem/src/index.test.ts
@@ -84,4 +84,33 @@ describe('social-forem posting', () => {
       body: 'Article body',
     }, { host: 'community.codenewbie.org' })).rejects.toThrow('Title has already been taken');
   });
+
+  it('falls back to the current timestamp when Forem returns an invalid published_at', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        id: 313,
+        url: 'https://community.codenewbie.org/sh1pt/release-notes',
+        published_at: 'not-a-date',
+      }),
+    } as Response);
+
+    const ctx = {
+      ...fakeConnectContext({ FOREM_API_KEY_COMMUNITY_CODENEWBIE_ORG: 'forem-key' }),
+      dryRun: false,
+    };
+
+    const result = await adapter.post(ctx as any, {
+      title: 'Release notes',
+      body: 'Article body',
+    }, { host: 'community.codenewbie.org' });
+
+    expect(result).toMatchObject({
+      id: '313',
+      url: 'https://community.codenewbie.org/sh1pt/release-notes',
+      platform: 'forem',
+      publishedAt: expect.any(String),
+    });
+  });
 });

--- a/packages/social/forem/src/index.ts
+++ b/packages/social/forem/src/index.ts
@@ -45,7 +45,7 @@ export default defineSocial<Config>({
       id: String(article.id),
       url: article.url ?? `https://${host}/`,
       platform: 'forem',
-      publishedAt: new Date(article.published_at ?? article.created_at ?? Date.now()).toISOString(),
+      publishedAt: foremTimestamp(article.published_at ?? article.created_at),
     };
   },
 
@@ -97,4 +97,11 @@ async function readForemError(res: Response): Promise<string> {
   } catch {
     return text;
   }
+}
+
+function foremTimestamp(value: string | null | undefined): string {
+  if (!value) return new Date().toISOString();
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.getTime())) return new Date().toISOString();
+  return timestamp.toISOString();
 }


### PR DESCRIPTION
## Summary
- avoid throwing after successful DEV article creation when `published_at` or `created_at` is malformed
- apply the same timestamp fallback to the compatible Forem adapter
- add focused regression coverage for invalid article timestamps in both adapters

## Tests
- `vitest run packages/social/devto/src/index.test.ts packages/social/forem/src/index.test.ts`
- `tsc -p packages/social/devto/tsconfig.json --noEmit`
- `tsc -p packages/social/forem/tsconfig.json --noEmit`