### PR TITLE
fix(social-telegram): tolerate missing message date

### DIFF
--- a/packages/social/telegram/src/index.test.ts
+++ b/packages/social/telegram/src/index.test.ts
@@ -63,4 +63,29 @@ describe('social-telegram posting', () => {
     await expect(adapter.post(ctx as any, { body: 'Release shipped' }, { chatId: '@missing' }))
       .rejects.toThrow('Bad Request: chat not found');
   });
+
+  it('falls back to the current timestamp when Telegram omits the message date', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        result: { message_id: 42, chat: { username: 'sh1pt' } },
+      }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ TELEGRAM_BOT_TOKEN: '123:abc' }),
+      dryRun: false,
+    };
+
+    const result = await adapter.post(ctx as any, { body: 'Release shipped' }, { chatId: '@sh1pt' });
+
+    expect(result).toMatchObject({
+      id: '42',
+      url: 'https://t.me/sh1pt/42',
+      platform: 'telegram',
+      publishedAt: expect.any(String),
+    });
+  });
 });

--- a/packages/social/telegram/src/index.ts
+++ b/packages/social/telegram/src/index.ts
@@ -40,7 +40,7 @@ export default defineSocial<Config>({
       id: String(data.result.message_id),
       url: messageUrl(data.result, config),
       platform: 'telegram',
-      publishedAt: new Date(data.result.date * 1000).toISOString(),
+      publishedAt: telegramTimestamp(data.result.date),
     };
   },
 
@@ -65,7 +65,7 @@ interface TelegramResponse {
   description?: string;
   result?: {
     message_id: number;
-    date: number;
+    date?: number;
     chat?: {
       username?: string;
     };
@@ -93,4 +93,9 @@ async function parseTelegramResponse(res: Response): Promise<TelegramResponse> {
 function messageUrl(result: NonNullable<TelegramResponse['result']>, config: Config): string {
   const username = result.chat?.username ?? (config.chatId.startsWith('@') ? config.chatId.slice(1) : undefined);
   return username ? `https://t.me/${username}/${result.message_id}` : 'https://t.me/';
+}
+
+function telegramTimestamp(date: number | undefined): string {
+  if (typeof date !== 'number' || !Number.isFinite(date)) return new Date().toISOString();
+  return new Date(date * 1000).toISOString();
 }


### PR DESCRIPTION
## Summary
- avoid throwing after a successful Telegram sendMessage response when the message date is missing or unusable
- fall back to the current timestamp for `publishedAt`
- add regression coverage for successful responses without a `date`

## Tests
- `vitest run packages/social/telegram/src/index.test.ts`
- `tsc -p packages/social/telegram/tsconfig.json --noEmit`