### PR TITLE
fix(social-codenewbie): tolerate invalid article timestamps

### DIFF
--- a/packages/social/codenewbie/src/index.test.ts
+++ b/packages/social/codenewbie/src/index.test.ts
@@ -78,4 +78,33 @@ describe('social-codenewbie posting', () => {
       body: 'Short',
     }, {})).rejects.toThrow('Body markdown is too short');
   });
+
+  it('falls back to the current timestamp when CodeNewbie returns an invalid published_at', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        id: 414,
+        url: 'https://community.codenewbie.org/sh1pt/release-notes',
+        published_at: 'not-a-date',
+      }),
+    } as Response);
+
+    const ctx = {
+      ...fakeConnectContext({ CODENEWBIE_API_KEY: 'codenewbie-key' }),
+      dryRun: false,
+    };
+
+    const result = await adapter.post(ctx as any, {
+      title: 'Release notes',
+      body: 'Article body',
+    }, {});
+
+    expect(result).toMatchObject({
+      id: '414',
+      url: 'https://community.codenewbie.org/sh1pt/release-notes',
+      platform: 'codenewbie',
+      publishedAt: expect.any(String),
+    });
+  });
 });

--- a/packages/social/codenewbie/src/index.ts
+++ b/packages/social/codenewbie/src/index.ts
@@ -42,7 +42,7 @@ export default defineSocial<Config>({
       id: String(article.id),
       url: article.url ?? CODENEWBIE_HOME,
       platform: 'codenewbie',
-      publishedAt: new Date(article.published_at ?? article.created_at ?? Date.now()).toISOString(),
+      publishedAt: codeNewbieTimestamp(article.published_at ?? article.created_at),
     };
   },
 
@@ -84,4 +84,11 @@ async function readCodeNewbieError(res: Response): Promise<string> {
   } catch {
     return text;
   }
+}
+
+function codeNewbieTimestamp(value: string | null | undefined): string {
+  if (!value) return new Date().toISOString();
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.getTime())) return new Date().toISOString();
+  return timestamp.toISOString();
 }


### PR DESCRIPTION
## Summary
- avoid throwing after successful CodeNewbie article creation when `published_at` or `created_at` is malformed
- fall back to the current timestamp for `publishedAt`
- add focused regression coverage for invalid CodeNewbie article timestamps

## Tests
- `vitest run packages/social/codenewbie/src/index.test.ts`
- `tsc -p packages/social/codenewbie/tsconfig.json --noEmit`