### PR TITLE
fix(social-mastodon): tolerate invalid created_at values

### DIFF
--- a/packages/social/mastodon/src/index.test.ts
+++ b/packages/social/mastodon/src/index.test.ts
@@ -72,6 +72,34 @@ describe('social-mastodon posting', () => {
     }, { instance: 'mastodon.social' })).rejects.toThrow('Text character limit');
   });
 
+  it('falls back to the current timestamp when Mastodon returns an invalid created_at', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: '109246',
+        url: 'https://mastodon.social/@sh1pt/109246',
+        created_at: 'not-a-date',
+      }),
+    } as Response);
+
+    const ctx = {
+      ...fakeConnectContext({ MASTODON_TOKEN_MASTODON_SOCIAL: 'mastodon-token' }),
+      dryRun: false,
+    };
+
+    const result = await adapter.post(ctx as any, {
+      body: 'Release notes',
+    }, { instance: 'mastodon.social' });
+
+    expect(result).toMatchObject({
+      id: '109246',
+      url: 'https://mastodon.social/@sh1pt/109246',
+      platform: 'mastodon',
+      publishedAt: expect.any(String),
+    });
+  });
+
   it('does not silently drop media attachments', async () => {
     const ctx = {
       ...fakeConnectContext({ MASTODON_TOKEN_MASTODON_SOCIAL: 'mastodon-token' }),

--- a/packages/social/mastodon/src/index.ts
+++ b/packages/social/mastodon/src/index.ts
@@ -53,7 +53,7 @@ export default defineSocial<Config>({
       id: data.id,
       url: data.url ?? data.uri ?? `https://${instance}/`,
       platform: 'mastodon',
-      publishedAt: new Date(data.created_at ?? Date.now()).toISOString(),
+      publishedAt: mastodonTimestamp(data.created_at),
     };
   },
 
@@ -97,4 +97,11 @@ async function readMastodonError(res: Response): Promise<string> {
   } catch {
     return text;
   }
+}
+
+function mastodonTimestamp(value: string | undefined): string {
+  if (!value) return new Date().toISOString();
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.getTime())) return new Date().toISOString();
+  return timestamp.toISOString();
 }


### PR DESCRIPTION
## Summary
- avoid throwing after successful Mastodon status creation when `created_at` is malformed
- fall back to the current timestamp for `publishedAt`
- add focused regression coverage for invalid Mastodon timestamps

## Tests
- `vitest run packages/social/mastodon/src/index.test.ts`
- `tsc -p packages/social/mastodon/tsconfig.json --noEmit`