### PR TITLE
fix(social-vimeo): tolerate invalid creation timestamps

### DIFF
--- a/packages/social/vimeo/src/index.test.ts
+++ b/packages/social/vimeo/src/index.test.ts
@@ -104,6 +104,30 @@ describe('social-vimeo', () => {
     });
   });
 
+  it('falls back when Vimeo returns an invalid creation timestamp', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-05-21T10:00:00Z'));
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(jsonResponse({
+        uri: '/videos/24680',
+        link: 'https://vimeo.com/24680',
+        created_time: 'not-a-date',
+      }, 201));
+
+      await expect(adapter.post({
+        ...ctx({ VIMEO_ACCESS_TOKEN: 'mock-vimeo-token' }),
+        dryRun: false,
+      }, samplePost, {
+        baseUrl: 'https://vimeo.test',
+      })).resolves.toMatchObject({
+        id: '24680',
+        publishedAt: '2026-05-21T10:00:00.000Z',
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('rejects local video paths because pull uploads need public URLs', async () => {
     await expect(adapter.post({
       ...ctx({ VIMEO_ACCESS_TOKEN: 'mock-vimeo-token' }),

--- a/packages/social/vimeo/src/index.ts
+++ b/packages/social/vimeo/src/index.ts
@@ -79,7 +79,7 @@ export default defineSocial<Config>({
       id,
       url: video.link ?? `https://vimeo.com/${id}`,
       platform: 'vimeo',
-      publishedAt: video.created_time ?? new Date().toISOString(),
+      publishedAt: vimeoTimestamp(video.created_time),
     };
   },
 
@@ -193,6 +193,13 @@ function vimeoErrorMessage(data: VimeoErrorResponse | unknown, fallback: string,
     .filter(Boolean)
     .join('; ');
   return redact([err.developer_message, err.message, err.error, invalid, fallback].find(Boolean) ?? 'unknown error', token);
+}
+
+function vimeoTimestamp(value: string | undefined): string {
+  if (!value) return new Date().toISOString();
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.getTime())) return new Date().toISOString();
+  return value;
 }
 
 function redact(value: string, token: string): string {


### PR DESCRIPTION
## Summary
- fall back to the current timestamp when Vimeo returns an invalid `created_time`
- keep valid Vimeo timestamps unchanged
- add regression coverage for an invalid creation timestamp response

## Tests
- `vitest run packages/social/vimeo/src/index.test.ts`
- `tsc -p packages/social/vimeo/tsconfig.json --noEmit`