### PR TITLE
fix(webhook-telegram): escape MarkdownV2 code blocks

### DIFF
--- a/packages/webhooks/telegram/src/index.test.ts
+++ b/packages/webhooks/telegram/src/index.test.ts
@@ -64,6 +64,28 @@ describe('webhook-telegram HTTP delivery', () => {
     expect(body.text).toContain('*ship\\.published*');
   });
 
+  it('escapes backticks and backslashes inside MarkdownV2 code blocks', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, result: { message_id: 42 } }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ TELEGRAM_BOT_TOKEN: '123:abc' }),
+      dryRun: false,
+    };
+
+    await adapter.send(ctx as any, {
+      ...payload,
+      data: { message: 'path\\to `danger`' },
+    }, { chatId: -1001234567890 });
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const body = JSON.parse(String((init as RequestInit).body));
+    expect(body.text).toContain('"message": "path\\\\\\\\to \\`danger\\`"');
+  });
+
   it('escapes HTML content when HTML parse mode is selected', async () => {
     const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
       ok: true,

--- a/packages/webhooks/telegram/src/index.ts
+++ b/packages/webhooks/telegram/src/index.ts
@@ -81,8 +81,12 @@ function formatTelegramText(payload: WebhookPayload, parseMode: NonNullable<Conf
   }
 
   const summary = `*${escapeMarkdown(payload.event)}*`;
-  const body = '```\n' + data + '\n```';
+  const body = '```\n' + escapeMarkdownCode(data) + '\n```';
   return `${summary}\n${body}`;
+}
+
+function escapeMarkdownCode(s: string): string {
+  return s.replace(/[`\\]/g, (c) => '\\' + c);
 }
 
 async function parseTelegramResponse(res: Response): Promise<TelegramResponse> {


### PR DESCRIPTION
## Summary

- escape backticks and backslashes inside Telegram MarkdownV2 preformatted blocks
- add a regression test covering JSON data with both characters

Telegram requires every backtick and backslash inside `pre` and `code` entities to be escaped: https://core.telegram.org/bots/api#markdownv2-style

Without this, ordinary payload data such as Windows-style paths or Markdown snippets can break `sendMessage` parsing.

## Verification

- `pnpm vitest run packages/webhooks/telegram/src/index.test.ts` (9 passed)
- `pnpm --filter @profullstack/sh1pt-webhooks-telegram typecheck`
- `git diff --check`