### PR TITLE
fix(slack): reject malformed event timestamps

### DIFF
--- a/packages/bridges/slack/src/index.test.ts
+++ b/packages/bridges/slack/src/index.test.ts
@@ -214,6 +214,40 @@ describe('bridge-slack adapter', () => {
     expect(socket.closed).toBe(true);
   });
 
+  it('falls back to the current time for malformed Slack timestamps', async () => {
+    vi.useFakeTimers().setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      ok: true,
+      url: 'wss://slack.example/socket',
+    }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('WebSocket', FakeSocket);
+
+    const onMessage = vi.fn();
+    await adapter.subscribe(subscribeCtx(), ['C-allowed'], onMessage, {});
+
+    await FakeSocket.instances[0]?.onmessage?.({
+      data: JSON.stringify({
+        envelope_id: 'env-bad-ts',
+        type: 'events_api',
+        payload: {
+          event: {
+            type: 'message',
+            channel: 'C-allowed',
+            user: 'U123',
+            text: 'bad timestamp',
+            event_ts: '.000200',
+            ts: '.000200',
+          },
+        },
+      }),
+    });
+
+    expect(onMessage).toHaveBeenCalledWith(expect.objectContaining({
+      timestamp: '2026-05-22T12:00:00.000Z',
+    }));
+  });
+
   it('redacts Slack tokens from API errors', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
       ok: false,

--- a/packages/bridges/slack/src/index.ts
+++ b/packages/bridges/slack/src/index.ts
@@ -193,9 +193,10 @@ function renderUsername(msg: BridgeMessage): string {
 }
 
 function slackTimestamp(value: string): string {
+  if (!/^\d+(?:\.\d+)?$/.test(value)) return new Date().toISOString();
   const seconds = Number(value.split('.')[0]);
-  if (!Number.isFinite(seconds)) return new Date().toISOString();
-  return new Date(seconds * 1000).toISOString();
+  const date = new Date(seconds * 1000);
+  return Number.isNaN(date.getTime()) ? new Date().toISOString() : date.toISOString();
 }
 
 function websocketConstructor(): SlackWebSocketConstructor {


### PR DESCRIPTION
## Summary
- Tightens Slack event timestamp parsing so malformed values like `.000200` do not become Unix epoch timestamps
- Falls back to the current time for malformed or invalid Slack timestamp values
- Adds Socket Mode regression coverage for malformed event timestamps

## Verification
- `node_modules/.bin/vitest.CMD run packages/bridges/slack/src/index.test.ts`
- `node_modules/.bin/tsc.CMD -p packages/bridges/slack/tsconfig.json --noEmit`
- `git diff --check`