### PR TITLE
fix(scale): reject non-decimal numeric options

### DIFF
--- a/packages/cli/src/commands/scale.test.ts
+++ b/packages/cli/src/commands/scale.test.ts
@@ -74,21 +74,21 @@ describe('scale numeric option parsers', () => {
     expect(parsePercentage('100')).toBe(100);
   });
 
-  it.each(['nope', '1.5', '0', '-1', 'Infinity', 'NaN', ''])(
+  it.each(['nope', '1.5', '1e2', '0x10', '0', '-1', 'Infinity', 'NaN', ''])(
     'rejects invalid positive integers: %s',
     (value) => {
       expect(() => parsePositiveInteger(value)).toThrow();
     },
   );
 
-  it.each(['nope', '1.5', '-1', 'Infinity', 'NaN', ''])(
+  it.each(['nope', '1.5', '1e2', '0x10', '-1', 'Infinity', 'NaN', ''])(
     'rejects invalid non-negative integers: %s',
     (value) => {
       expect(() => parseNonNegativeInteger(value)).toThrow();
     },
   );
 
-  it.each(['nope', '0', '-1', 'Infinity', 'NaN', ''])(
+  it.each(['nope', '1e2', '0x10', '0', '-1', 'Infinity', 'NaN', ''])(
     'rejects invalid positive finite numbers: %s',
     (value) => {
       expect(() => parsePositiveNumber(value)).toThrow();

--- a/packages/cli/src/commands/scale.ts
+++ b/packages/cli/src/commands/scale.ts
@@ -122,27 +122,39 @@ export function getNextId(instances: FleetEntry[]): string {
 }
 
 export function parsePositiveInteger(value: string): number {
-  const parsed = Number(value);
-  if (value.trim() === '' || !Number.isSafeInteger(parsed) || parsed < 1) {
+  const parsed = parseDecimalInteger(value);
+  if (parsed === null || parsed < 1) {
     throw new InvalidArgumentError('must be a positive integer');
   }
   return parsed;
 }
 
 export function parseNonNegativeInteger(value: string): number {
-  const parsed = Number(value);
-  if (value.trim() === '' || !Number.isSafeInteger(parsed) || parsed < 0) {
+  const parsed = parseDecimalInteger(value);
+  if (parsed === null || parsed < 0) {
     throw new InvalidArgumentError('must be zero or a positive integer');
   }
   return parsed;
 }
 
 export function parsePositiveNumber(value: string): number {
-  const parsed = Number(value);
-  if (value.trim() === '' || !Number.isFinite(parsed) || parsed <= 0) {
+  const parsed = parseDecimalNumber(value);
+  if (parsed === null || parsed <= 0) {
     throw new InvalidArgumentError('must be a positive finite number');
   }
   return parsed;
+}
+
+function parseDecimalInteger(value: string): number | null {
+  if (!/^\d+$/.test(value.trim())) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function parseDecimalNumber(value: string): number | null {
+  if (!/^\d+(?:\.\d+)?$/.test(value.trim())) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
 export function parsePercentage(value: string): number {


### PR DESCRIPTION
## Summary
- Rejects non-decimal JavaScript numeric forms such as `1e2` and `0x10` in scale CLI numeric options
- Keeps plain decimal integers for counts/percentages and plain decimal finite values for prices
- Extends scale parser tests for integer, non-negative integer, and positive finite number options

## Verification
- `node_modules/.bin/vitest.CMD run packages/cli/src/commands/scale.test.ts`
- `node_modules/.bin/tsc.CMD -p packages/cli/tsconfig.json --noEmit`
- `git diff --check`