### PR TITLE
fix(iterate): require decimal interval values

### DIFF
--- a/packages/cli/src/commands/iterate-options.ts
+++ b/packages/cli/src/commands/iterate-options.ts
@@ -1,6 +1,9 @@
 import { InvalidArgumentError } from 'commander';
 
 export function parsePositiveSafeInteger(value: string): number {
+  if (!/^\d+$/.test(value.trim())) {
+    throw new InvalidArgumentError('must be a positive safe integer');
+  }
   const parsed = Number(value);
   if (!Number.isSafeInteger(parsed) || parsed < 1) {
     throw new InvalidArgumentError('must be a positive safe integer');

--- a/packages/cli/src/commands/iterate.test.ts
+++ b/packages/cli/src/commands/iterate.test.ts
@@ -6,7 +6,7 @@ describe('parsePositiveSafeInteger', () => {
     expect(parsePositiveSafeInteger('60')).toBe(60);
   });
 
-  it.each(['nope', '0', '-1', '1.5', 'Infinity', '9007199254740992'])(
+  it.each(['nope', '0', '-1', '1.5', '1e2', '0x10', 'Infinity', '9007199254740992'])(
     'rejects invalid interval %s',
     (value) => {
       expect(() => parsePositiveSafeInteger(value)).toThrow('positive safe integer');


### PR DESCRIPTION
## Summary
- Rejects non-decimal JavaScript numeric forms such as `1e2` and `0x10` for iterate interval values
- Keeps positive safe integer interval parsing for plain decimal inputs
- Adds regression coverage to the existing iterate option parser tests

## Verification
- `node_modules/.bin/vitest.CMD run packages/cli/src/commands/iterate.test.ts`
- `node_modules/.bin/tsc.CMD -p packages/cli/tsconfig.json --noEmit`
- `git diff --check`