### PR TITLE
fix(deploy): reject non-decimal numeric options

### DIFF
--- a/packages/cli/src/commands/deploy.test.ts
+++ b/packages/cli/src/commands/deploy.test.ts
@@ -6,7 +6,7 @@ describe('deploy numeric option parsers', () => {
     expect(parsePositiveSafeInteger('4')).toBe(4);
   });
 
-  it.each(['nope', '0', '-1', '1.5', 'Infinity', '9007199254740992'])(
+  it.each(['nope', '0', '-1', '1.5', '1e2', '0x10', 'Infinity', '9007199254740992'])(
     'rejects invalid resource count %s',
     (value) => {
       expect(() => parsePositiveSafeInteger(value)).toThrow('positive safe integer');
@@ -18,7 +18,7 @@ describe('deploy numeric option parsers', () => {
     expect(parsePositiveFiniteNumber('12.75')).toBe(12.75);
   });
 
-  it.each(['nope', '0', '-1', 'NaN', 'Infinity', '-Infinity'])(
+  it.each(['nope', '0', '-1', '1e2', '0x10', 'NaN', 'Infinity', '-Infinity'])(
     'rejects invalid finite value %s',
     (value) => {
       expect(() => parsePositiveFiniteNumber(value)).toThrow('positive finite number');

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -2,6 +2,9 @@ import { Command, InvalidArgumentError } from 'commander';
 import kleur from 'kleur';
 
 export function parsePositiveSafeInteger(value: string): number {
+  if (!/^\d+$/.test(value)) {
+    throw new InvalidArgumentError('must be a positive safe integer');
+  }
   const parsed = Number(value);
   if (!Number.isSafeInteger(parsed) || parsed < 1) {
     throw new InvalidArgumentError('must be a positive safe integer');
@@ -10,6 +13,9 @@ export function parsePositiveSafeInteger(value: string): number {
 }
 
 export function parsePositiveFiniteNumber(value: string): number {
+  if (!/^\d+(?:\.\d+)?$/.test(value)) {
+    throw new InvalidArgumentError('must be a positive finite number');
+  }
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed <= 0) {
     throw new InvalidArgumentError('must be a positive finite number');


### PR DESCRIPTION
## Summary
- require plain decimal integers for deploy resource counts
- require plain positive decimal values for memory and hourly price guardrails
- add regression coverage for scientific and hexadecimal numeric strings

## Tests
- node_modules/.bin/vitest.CMD run packages/cli/src/commands/deploy.test.ts
- node_modules/.bin/tsc.CMD -p packages/cli/tsconfig.json --noEmit
- git diff --check