### PR TITLE
fix(promote): reject non-decimal numeric limits

### DIFF
--- a/packages/cli/src/commands/promote.test.ts
+++ b/packages/cli/src/commands/promote.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { parseNonNegativeInteger, parsePositiveInteger } from './promote.js';
+
+describe('promote numeric option parsers', () => {
+  it('accepts decimal positive integers', () => {
+    expect(parsePositiveInteger('25')).toBe(25);
+  });
+
+  it.each(['0', '-1', '1.5', '1e2', '0x10', 'Infinity', 'NaN', 'abc'])(
+    'rejects invalid positive integer %s',
+    (value) => {
+      expect(() => parsePositiveInteger(value)).toThrow('positive integer');
+    },
+  );
+
+  it('accepts decimal non-negative integers', () => {
+    expect(parseNonNegativeInteger('0')).toBe(0);
+    expect(parseNonNegativeInteger('2000')).toBe(2000);
+  });
+
+  it.each(['-1', '1.5', '1e2', '0x10', 'Infinity', 'NaN', 'abc'])(
+    'rejects invalid non-negative integer %s',
+    (value) => {
+      expect(() => parseNonNegativeInteger(value)).toThrow('zero or a positive integer');
+    },
+  );
+});

--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -866,13 +866,15 @@ function stripAiPrefix(p: string): string {
   return p.replace(/^ai-/, '').toLowerCase();
 }
 
-function parsePositiveInteger(value: string): number {
+export function parsePositiveInteger(value: string): number {
+  if (!/^\d+$/.test(value)) throw new InvalidArgumentError('must be a positive integer');
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed < 1) throw new InvalidArgumentError('must be a positive integer');
   return parsed;
 }
 
-function parseNonNegativeInteger(value: string): number {
+export function parseNonNegativeInteger(value: string): number {
+  if (!/^\d+$/.test(value)) throw new InvalidArgumentError('must be zero or a positive integer');
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed < 0) throw new InvalidArgumentError('must be zero or a positive integer');
   return parsed;


### PR DESCRIPTION
## Summary
- require plain decimal input for promote integer limit parsers
- reject scientific and hexadecimal numeric strings for max/delay style options
- add direct regression coverage for promote numeric parsers

## Tests
- node_modules/.bin/vitest.CMD run packages/cli/src/commands/promote.test.ts
- node_modules/.bin/tsc.CMD -p packages/cli/tsconfig.json --noEmit
- git diff --check