### PR TITLE
fix(iterate): reject non-decimal numeric interval values

### DIFF
--- a/packages/cli/src/commands/iterate-options.ts
+++ b/packages/cli/src/commands/iterate-options.ts
@@ -1,6 +1,12 @@
 import { InvalidArgumentError } from 'commander';
 
 export function parsePositiveSafeInteger(value: string): number {
+  // Only accept plain decimal digit strings. Number() would otherwise coerce
+  // scientific ("1e2"), hexadecimal ("0x10"), binary/octal, signed ("+60"), and
+  // whitespace-padded values into numbers, which are not valid interval inputs.
+  if (!/^\d+$/.test(value)) {
+    throw new InvalidArgumentError('must be a positive safe integer');
+  }
   const parsed = Number(value);
   if (!Number.isSafeInteger(parsed) || parsed < 1) {
     throw new InvalidArgumentError('must be a positive safe integer');

--- a/packages/cli/src/commands/iterate.test.ts
+++ b/packages/cli/src/commands/iterate.test.ts
@@ -12,6 +12,13 @@ describe('parsePositiveSafeInteger', () => {
       expect(() => parsePositiveSafeInteger(value)).toThrow('positive safe integer');
     },
   );
+
+  it.each(['1e2', '0x10', '0b10', '0o10', '+60', ' 60', '60 ', '1_000'])(
+    'rejects non-decimal numeric interval %s',
+    (value) => {
+      expect(() => parsePositiveSafeInteger(value)).toThrow('positive safe integer');
+    },
+  );
 });
 
 describe('parseQuietHours', () => {


### PR DESCRIPTION
## Summary
- `parsePositiveSafeInteger` used `Number(value)`, which coerces scientific (`1e2` -> 100), hexadecimal (`0x10` -> 16), binary/octal, signed (`+60`), and whitespace-padded strings into numbers. Those were incorrectly accepted as `--interval` values.
- Added a strict `^\d+$` decimal guard before `Number()`, keeping plain positive safe-integer parsing unchanged.
- Added regression coverage for the non-decimal forms (`1e2`, `0x10`, `0b10`, `0o10`, `+60`, ` 60`, `60 `, `1_000`).

## Verification
- `vitest run packages/cli/src/commands/iterate.test.ts` -> 26 passed (8 new)
- `tsc -p packages/cli/tsconfig.json --noEmit` -> no new errors in the cli package
- `git diff --check` -> clean

Closes #803