### PR TITLE
fix(cloud-exe-dev): reject non-decimal numeric options

### DIFF
--- a/packages/cloud/exe-dev/src/index.test.ts
+++ b/packages/cloud/exe-dev/src/index.test.ts
@@ -1,0 +1,48 @@
+import { contractTestCloud } from '@profullstack/sh1pt-core/testing';
+import { describe, expect, it, vi } from 'vitest';
+import adapter from './index.js';
+
+const ctx = {
+  secret: (key: string) => key === 'EXE_DEV_TOKEN' ? 'test-token' : undefined,
+  log: vi.fn(),
+  dryRun: true,
+};
+
+describe('exe.dev numeric options', () => {
+  it('quotes positive decimal CPU, memory, and disk values', async () => {
+    const quote = await adapter.quote(ctx as any, {
+      kind: 'cpu-vps',
+      cpu: '2',
+      memory: '4.5',
+      storage: '20',
+    } as any, {});
+
+    expect(quote.sku).toBe('2cpu-4.5gb-20gb');
+  });
+
+  it('rejects non-decimal CPU, memory, and disk strings instead of falling back', async () => {
+    await expect(adapter.quote(ctx as any, { kind: 'cpu-vps', cpu: '1e2' } as any, {}))
+      .rejects.toThrow('exe.dev cpu must be a positive decimal number');
+    await expect(adapter.quote(ctx as any, { kind: 'cpu-vps', memory: '0x10' } as any, {}))
+      .rejects.toThrow('exe.dev memory must be a positive decimal number');
+    await expect(adapter.quote(ctx as any, { kind: 'cpu-vps', storage: '-1' } as any, {}))
+      .rejects.toThrow('exe.dev disk must be a positive decimal number');
+  });
+
+  it('keeps dry-run provision args decimal and deterministic', async () => {
+    const instance = await adapter.provision(ctx as any, {
+      kind: 'cpu-vps',
+      cpu: '2',
+      memory: '4',
+      storage: '20',
+    } as any, {});
+
+    expect(instance.sku).toBe('2cpu-4gb-20gb');
+  });
+});
+
+contractTestCloud(adapter, {
+  sampleConfig: {},
+  sampleSpec: { kind: 'cpu-vps', cpu: 2, memory: 4, storage: 20 },
+  requiredSecrets: ['EXE_DEV_TOKEN'],
+});

--- a/packages/cloud/exe-dev/src/index.ts
+++ b/packages/cloud/exe-dev/src/index.ts
@@ -52,9 +52,9 @@ export default defineCloud<Config>({
   },
 
   async quote(ctx, spec, config) {
-    const cpu = positiveNumber(spec.cpu ?? config.defaultCpu, 2);
-    const memory = positiveNumber(spec.memory ?? config.defaultMemoryGb, 4);
-    const disk = positiveNumber(spec.storage ?? config.defaultDiskGb, 20);
+    const cpu = positiveNumber(spec.cpu ?? config.defaultCpu, 2, 'cpu');
+    const memory = positiveNumber(spec.memory ?? config.defaultMemoryGb, 4, 'memory');
+    const disk = positiveNumber(spec.storage ?? config.defaultDiskGb, 20, 'disk');
 
     ctx.log(`exe.dev quote - cpu=${cpu} memory=${memory}GB disk=${disk}GB`);
     return {
@@ -73,9 +73,9 @@ export default defineCloud<Config>({
     }
 
     const name = safeName(`sh1pt-${Date.now()}`);
-    const cpu = positiveNumber(spec.cpu ?? config.defaultCpu, 2);
-    const memory = positiveNumber(spec.memory ?? config.defaultMemoryGb, 4);
-    const disk = positiveNumber(spec.storage ?? config.defaultDiskGb, 20);
+    const cpu = positiveNumber(spec.cpu ?? config.defaultCpu, 2, 'cpu');
+    const memory = positiveNumber(spec.memory ?? config.defaultMemoryGb, 4, 'memory');
+    const disk = positiveNumber(spec.storage ?? config.defaultDiskGb, 20, 'disk');
 
     if (spec.region) {
       ctx.log(`exe.dev region is account-level; ignoring per-VM region ${spec.region}`, 'warn');
@@ -234,8 +234,17 @@ function quoteArg(value: string): string {
   return JSON.stringify(value);
 }
 
-function positiveNumber(value: Numberish | undefined, fallback: number): number {
+function positiveNumber(value: Numberish | undefined, fallback: number, label = 'value'): number {
   if (value === undefined || value === '') return fallback;
-  const n = typeof value === 'number' ? value : Number(value);
-  return Number.isFinite(n) && n > 0 ? n : fallback;
+  if (typeof value === 'number') {
+    if (Number.isFinite(value) && value > 0) return value;
+    throw new Error(`exe.dev ${label} must be a positive number`);
+  }
+  const text = value.trim();
+  if (!/^(?:[1-9]\d*|0?\.\d+|[1-9]\d*\.\d+)$/.test(text)) {
+    throw new Error(`exe.dev ${label} must be a positive decimal number`);
+  }
+  const n = Number(text);
+  if (!Number.isFinite(n) || n <= 0) throw new Error(`exe.dev ${label} must be a positive number`);
+  return n;
 }


### PR DESCRIPTION
## Summary
- reject non-decimal exe.dev CPU, memory, and disk option strings instead of silently falling back
- keep positive decimal numeric strings accepted for quote/provision sizing
- add focused exe.dev adapter tests for accepted and rejected numeric inputs

## Verification
- vitest run packages/cloud/exe-dev/src/index.test.ts (7 passed)
- tsc -p packages/cloud/exe-dev/tsconfig.json --noEmit
- git diff --check

Note: running through pnpm in this workspace currently triggers an unrelated lockfile policy failure for @profullstack/autoblog@0.4.0 missing tarball integrity, so I ran the local Vitest and TypeScript binaries directly.