### PR TITLE
fix(cloud-runpod): reject non-decimal sizing options

### DIFF
--- a/packages/cloud/runpod/src/index.test.ts
+++ b/packages/cloud/runpod/src/index.test.ts
@@ -229,6 +229,28 @@ describe('RunPod cloud adapter', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('rejects non-decimal sizing strings before provisioning', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(adapter.provision(
+      provisionCtx(),
+      { kind: 'gpu', gpu: { model: 'NVIDIA RTX A6000', count: 1 } },
+      { hourlyPrice: 0.5, imageName: 'runpod/pytorch', volumeInGb: '1e2' },
+    )).rejects.toThrow('RunPod volumeInGb must be a plain decimal number');
+    await expect(adapter.provision(
+      provisionCtx(),
+      { kind: 'gpu', gpu: { model: 'NVIDIA RTX A6000', count: 1 } },
+      { hourlyPrice: 0.5, imageName: 'runpod/pytorch', containerDiskInGb: '0x10' },
+    )).rejects.toThrow('RunPod containerDiskInGb must be a plain decimal number');
+    await expect(adapter.provision(
+      provisionCtx(),
+      { kind: 'gpu', gpu: { model: 'NVIDIA RTX A6000', count: 1 }, cpu: '-1' as any },
+      { hourlyPrice: 0.5, imageName: 'runpod/pytorch' },
+    )).rejects.toThrow('RunPod minVcpuCount must be a plain decimal number');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('does not call RunPod for dry-run provisioning without hourlyPrice', async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);

--- a/packages/cloud/runpod/src/index.ts
+++ b/packages/cloud/runpod/src/index.ts
@@ -428,15 +428,24 @@ function safeName(value: string): string {
 
 function optionalPositiveNumber(value: Numberish | undefined, label: string): number | undefined {
   if (value === undefined) return undefined;
-  const number = Number(value);
+  const number = plainDecimalNumber(value, label);
   if (!Number.isFinite(number) || number <= 0) throw new Error(`RunPod ${label} must be a positive number`);
   return number;
 }
 
 function nonNegativeNumber(value: Numberish, label: string): number {
-  const number = Number(value);
+  const number = plainDecimalNumber(value, label);
   if (!Number.isFinite(number) || number < 0) throw new Error(`RunPod ${label} must be a non-negative number`);
   return number;
+}
+
+function plainDecimalNumber(value: Numberish, label: string): number {
+  if (typeof value === 'number') return value;
+  const text = value.trim();
+  if (!/^(?:0|[1-9]\d*|0?\.\d+|[1-9]\d*\.\d+)$/.test(text)) {
+    throw new Error(`RunPod ${label} must be a plain decimal number`);
+  }
+  return Number(text);
 }
 
 function graphqlError(payload: RunpodGraphqlResponse<unknown>): string {


### PR DESCRIPTION
## Summary
- reject non-decimal RunPod sizing strings before provisioning
- prevent surprising Number() inputs like 1e2 and 0x10 for volume, disk, CPU, and memory controls
- add focused RunPod adapter coverage to ensure invalid values fail before the API call

## Verification
- vitest run packages/cloud/runpod/src/index.test.ts (25 passed)
- tsc -p packages/cloud/runpod/tsconfig.json --noEmit
- git diff --check

Note: running through pnpm in this workspace currently triggers an unrelated lockfile policy failure for @profullstack/autoblog@0.4.0 missing tarball integrity, so I ran the local Vitest and TypeScript binaries directly.