### PR TITLE
fix(chat-whatsapp): require clean graph api origin

### DIFF
--- a/packages/targets/chat-whatsapp/src/index.test.ts
+++ b/packages/targets/chat-whatsapp/src/index.test.ts
@@ -93,6 +93,11 @@ describe('WhatsApp Business Cloud API target', () => {
       ...baseConfig,
       graphApiBaseUrl: 'http://graph.facebook.com',
     })).rejects.toThrow('graphApiBaseUrl must use HTTPS');
+
+    await expect(adapter.build(fakeBuildContext() as any, {
+      ...baseConfig,
+      graphApiBaseUrl: 'https://graph.facebook.com/api?token=leak',
+    })).rejects.toThrow('graphApiBaseUrl must be an HTTPS origin');
   });
 
   it('keeps dry-run shipping side-effect free', async () => {

--- a/packages/targets/chat-whatsapp/src/index.ts
+++ b/packages/targets/chat-whatsapp/src/index.ts
@@ -98,7 +98,10 @@ function graphApiBaseUrl(config: Config): string {
     throw new Error('chat-whatsapp graphApiBaseUrl must be a valid HTTPS URL');
   }
   if (parsed.protocol !== 'https:') throw new Error('chat-whatsapp graphApiBaseUrl must use HTTPS');
-  return baseUrl.replace(/\/+$/, '');
+  if (parsed.username || parsed.password || parsed.pathname !== '/' || parsed.search || parsed.hash) {
+    throw new Error('chat-whatsapp graphApiBaseUrl must be an HTTPS origin');
+  }
+  return parsed.origin;
 }
 
 function graphUrl(config: Config, path: string): string {


### PR DESCRIPTION
## Summary
- require chat-whatsapp graphApiBaseUrl to be a clean HTTPS origin
- reject base URLs with credentials, path, query, or hash before endpoint construction
- keep the default Graph API endpoint behavior unchanged

## Verification
- vitest run packages/targets/chat-whatsapp/src/index.test.ts (10 passed)
- tsc -p packages/targets/chat-whatsapp/tsconfig.json --noEmit
- git diff --check

Note: running through pnpm in this workspace currently triggers an unrelated lockfile policy failure for @profullstack/autoblog@0.4.0 missing tarball integrity, so I ran the local Vitest and TypeScript binaries directly.