### PR TITLE
fix(payment-square): validate refund amount money

### DIFF
--- a/packages/targets/payment-square/src/index.test.ts
+++ b/packages/targets/payment-square/src/index.test.ts
@@ -119,4 +119,43 @@ describe('payment-square target adapter', () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it('refunds payments with validated amount money', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ refund: { id: 'refund_123' } }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await target.build(fakeBuildContext({
+      secret: makeVault({ SQUARE_ACCESS_TOKEN: 'square-token' }),
+    }) as any, {
+      command: 'refund',
+      args: { paymentId: 'pay_123', amount: 500, currency: 'usd', reason: 'duplicate' },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('https://connect.squareup.com/v2/refunds', expect.objectContaining({
+      method: 'POST',
+    }));
+    const body = JSON.parse(String(fetchMock.mock.calls[0]![1].body));
+    expect(body).toMatchObject({
+      payment_id: 'pay_123',
+      amount_money: { amount: 500, currency: 'USD' },
+      reason: 'duplicate',
+    });
+  });
+
+  it('rejects invalid refund amounts before calling Square', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(target.build(fakeBuildContext({
+      secret: makeVault({ SQUARE_ACCESS_TOKEN: 'square-token' }),
+    }) as any, {
+      command: 'refund',
+      args: { paymentId: 'pay_123', amount: 1.5, currency: 'USD' },
+    })).rejects.toThrow('amount must be a positive integer');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/packages/targets/payment-square/src/index.ts
+++ b/packages/targets/payment-square/src/index.ts
@@ -93,13 +93,15 @@ export default defineTarget<Config>({
       }
       case 'refund': {
         const id = requireText(config.args?.paymentId, 'paymentId');
+        const amount = requirePositiveInteger(config.args?.amount, 'amount');
+        const currency = requireCurrency(config.args?.currency);
         ctx.log(`square: refunding payment ${id}`);
         const data = await sq('/refunds', {
           method: 'POST',
           body: JSON.stringify({
             idempotency_key: `sh1pt-${Date.now()}`,
             payment_id: id,
-            amount_money: config.args?.amount,
+            amount_money: { amount, currency },
             reason: (config.args?.reason as string) || 'requested_by_customer',
           }),
         });


### PR DESCRIPTION
## Summary
- validate Square refund amounts and currencies before calling the API
- send refund amount_money as a normalized { amount, currency } object instead of passing raw config
- add coverage for valid refund payloads and invalid refund amounts

## Verification
- vitest run packages/targets/payment-square/src/index.test.ts (8 passed)
- tsc -p packages/targets/payment-square/tsconfig.json --noEmit
- git diff --check

Note: running through pnpm in this workspace currently triggers an unrelated lockfile policy failure for @profullstack/autoblog@0.4.0 missing tarball integrity, so I ran the local Vitest and TypeScript binaries directly.