### PR TITLE
fix(dns-porkbun): reject non-decimal ttl strings

### DIFF
--- a/packages/dns/porkbun/src/index.test.ts
+++ b/packages/dns/porkbun/src/index.test.ts
@@ -55,6 +55,32 @@ describe('Porkbun DNS API adapter', () => {
     ]);
   });
 
+  it('falls back for non-decimal Porkbun TTL strings', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({
+        status: 'SUCCESS',
+        records: [
+          { id: 'sci', name: 'sci.example.com', type: 'A', content: '1.2.3.4', ttl: '1e2' },
+          { id: 'hex', name: 'hex.example.com', type: 'A', content: '1.2.3.5', ttl: '0x10' },
+          { id: 'decimal', name: 'decimal.example.com', type: 'A', content: '1.2.3.6', ttl: '600.5' },
+          { id: 'normal', name: 'normal.example.com', type: 'A', content: '1.2.3.7', ttl: '600' },
+        ],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await dns.connect(ctx(), {});
+    const records = await dns.listRecords('example.com', { defaultTtl: 900 });
+
+    expect(records.map((record) => [record.id, record.ttl])).toEqual([
+      ['sci', 900],
+      ['hex', 900],
+      ['decimal', 900],
+      ['normal', 600],
+    ]);
+  });
+
   it('lists API-enabled domains as zones', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/packages/dns/porkbun/src/index.ts
+++ b/packages/dns/porkbun/src/index.ts
@@ -70,15 +70,26 @@ function ttlValue(ttl: number | undefined, config: Config): number {
   return ttl ?? config.defaultTtl ?? 600;
 }
 
+function parsePorkbunTtl(ttl: PorkbunRecord['ttl']): number | undefined {
+  if (typeof ttl === 'number') {
+    return Number.isInteger(ttl) && ttl > 0 ? ttl : undefined;
+  }
+  if (typeof ttl !== 'string' || !/^[1-9]\d*$/.test(ttl)) {
+    return undefined;
+  }
+  const parsed = Number(ttl);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
 function mapRecord(zoneId: string, record: PorkbunRecord, config: Config): DnsRecord {
-  const ttl = Number(record.ttl);
+  const ttl = parsePorkbunTtl(record.ttl);
   return {
     id: String(record.id),
     zone: zoneId,
     name: normalizeRecordName(zoneId, record.name),
     type: record.type as DnsRecord['type'],
     value: record.content,
-    ttl: Number.isFinite(ttl) && ttl > 0 ? ttl : ttlValue(undefined, config),
+    ttl: ttl ?? ttlValue(undefined, config),
   };
 }
 


### PR DESCRIPTION
## Summary
- parse Porkbun record TTLs only when they are positive decimal integers
- fall back to the configured/default TTL for malformed strings like `1e2`, `0x10`, or decimal fractions
- add regression coverage for non-decimal TTL strings while preserving normal decimal TTLs

## Verification
- `node_modules/.bin/vitest.cmd run packages/dns/porkbun/src/index.test.ts`
- `node_modules/.bin/tsc.cmd -p packages/dns/porkbun/tsconfig.json --noEmit`
- `git diff --check`