### PR TITLE
fix(ai-mancer): require clean api base urls

### DIFF
--- a/packages/ai/mancer/src/index.test.ts
+++ b/packages/ai/mancer/src/index.test.ts
@@ -96,7 +96,7 @@ describe('Mancer generation', () => {
       ctx(),
       'hello',
       { model: 'mancer/weaver' },
-      { baseUrl: 'https://gateway.example.test/v1' },
+      { baseUrl: 'https://gateway.example.test/v1/' },
     );
 
     expect(fetchMock.mock.calls[0]?.[0]).toBe('https://gateway.example.test/v1/chat/completions');
@@ -104,6 +104,23 @@ describe('Mancer generation', () => {
       text: 'legacy text response',
       model: 'mancer/weaver',
     });
+  });
+
+  it('rejects base URLs with credentials, query, or hash', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://user:pass@gateway.example.test/v1' }),
+    ).rejects.toThrow('clean API base');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://gateway.example.test/v1?target=chat' }),
+    ).rejects.toThrow('clean API base');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://gateway.example.test/v1#chat' }),
+    ).rejects.toThrow('clean API base');
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('includes status and response body excerpt on errors', async () => {

--- a/packages/ai/mancer/src/index.test.ts
+++ b/packages/ai/mancer/src/index.test.ts
@@ -111,6 +111,12 @@ describe('Mancer generation', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'gateway.example.test/v1' }),
+    ).rejects.toThrow('valid URL');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'ftp://gateway.example.test/v1' }),
+    ).rejects.toThrow('http or https');
+    await expect(
       adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://user:pass@gateway.example.test/v1' }),
     ).rejects.toThrow('clean API base');
     await expect(

--- a/packages/ai/mancer/src/index.ts
+++ b/packages/ai/mancer/src/index.ts
@@ -65,7 +65,12 @@ export default defineAi<Config>({
 });
 
 function cleanBaseUrl(value: string): string {
-  const url = new URL(value);
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('Mancer baseUrl must be a valid URL');
+  }
   if (url.protocol !== 'https:' && url.protocol !== 'http:') {
     throw new Error('Mancer baseUrl must use http or https');
   }

--- a/packages/ai/mancer/src/index.ts
+++ b/packages/ai/mancer/src/index.ts
@@ -24,7 +24,8 @@ export default defineAi<Config>({
     if (opts.system) messages.push({ role: 'system', content: opts.system });
     messages.push({ role: 'user', content: prompt });
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+    const baseUrl = cleanBaseUrl(config.baseUrl ?? DEFAULT_BASE);
+    const res = await fetch(`${baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         authorization: `Bearer ${apiKey}`,
@@ -62,6 +63,17 @@ export default defineAi<Config>({
     ],
   }),
 });
+
+function cleanBaseUrl(value: string): string {
+  const url = new URL(value);
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error('Mancer baseUrl must use http or https');
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error('Mancer baseUrl must be a clean API base without credentials, query, or hash');
+  }
+  return url.toString().replace(/\/+$/, '');
+}
 
 type MancerRole = 'system' | 'user' | 'assistant' | 'tool';
 


### PR DESCRIPTION
## Summary
- normalize the Mancer API base URL before building the chat completions endpoint
- strip trailing slashes so custom bases like `/v1/` do not produce double-slash request paths
- reject base URLs containing credentials, query strings, or fragments before any network call

## Why
The adapter previously concatenated `config.baseUrl` directly with `/chat/completions`. A custom base URL with a trailing slash produced `//chat/completions`, and URLs with credentials/query/hash could create surprising request targets. This keeps the endpoint construction explicit and avoids leaking or accepting malformed API bases.

## Validation
- `vitest run packages/ai/mancer/src/index.test.ts` (8 passed)
- `tsc -p packages/ai/mancer/tsconfig.json --noEmit`
- `git diff --check`