### PR TITLE
fix(ai-parasail): require clean api base urls

### DIFF
--- a/packages/ai/parasail/src/index.test.ts
+++ b/packages/ai/parasail/src/index.test.ts
@@ -62,6 +62,12 @@ describe('Parasail generation', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'gateway.example.test/v1' }),
+    ).rejects.toThrow('valid URL');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'ftp://gateway.example.test/v1' }),
+    ).rejects.toThrow('http or https');
+    await expect(
       adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://user:pass@gateway.example.test/v1' }),
     ).rejects.toThrow('clean API base');
     await expect(

--- a/packages/ai/parasail/src/index.test.ts
+++ b/packages/ai/parasail/src/index.test.ts
@@ -1,4 +1,76 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'ai' });
+
+const ctx = (
+  secrets: Record<string, string> = { PARASAIL_API_KEY: 'test-key' },
+  dryRun = false,
+) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+  dryRun,
+});
+
+describe('Parasail generation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('normalizes custom base URLs before posting chat completions', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'hello from parasail' } }],
+        model: 'llama-3.1-8b',
+        usage: { prompt_tokens: 8, completion_tokens: 3 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx(),
+      'hello',
+      { system: 'be concise', maxTokens: 32, temperature: 0.2 },
+      { baseUrl: 'https://gateway.example.test/v1/' },
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, request] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://gateway.example.test/v1/chat/completions');
+    expect(request.headers.authorization).toBe('Bearer test-key');
+    expect(JSON.parse(request.body)).toEqual({
+      model: 'llama-3.1-8b',
+      messages: [
+        { role: 'system', content: 'be concise' },
+        { role: 'user', content: 'hello' },
+      ],
+      max_tokens: 32,
+      temperature: 0.2,
+    });
+    expect(result).toEqual({
+      text: 'hello from parasail',
+      model: 'llama-3.1-8b',
+      inputTokens: 8,
+      outputTokens: 3,
+    });
+  });
+
+  it('rejects base URLs with credentials, query, or hash', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://user:pass@gateway.example.test/v1' }),
+    ).rejects.toThrow('clean API base');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://gateway.example.test/v1?target=chat' }),
+    ).rejects.toThrow('clean API base');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://gateway.example.test/v1#chat' }),
+    ).rejects.toThrow('clean API base');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ai/parasail/src/index.ts
+++ b/packages/ai/parasail/src/index.ts
@@ -27,7 +27,8 @@ export default defineAi<Config>({
     if (opts.system) messages.push({ role: 'system', content: opts.system });
     messages.push({ role: 'user', content: prompt });
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+    const baseUrl = cleanBaseUrl(config.baseUrl ?? DEFAULT_BASE);
+    const res = await fetch(`${baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         authorization: `Bearer ${apiKey}`,
@@ -69,3 +70,14 @@ export default defineAi<Config>({
     ],
   }),
 });
+
+function cleanBaseUrl(value: string): string {
+  const url = new URL(value);
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error('Parasail baseUrl must use http or https');
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error('Parasail baseUrl must be a clean API base without credentials, query, or hash');
+  }
+  return url.toString().replace(/\/+$/, '');
+}

--- a/packages/ai/parasail/src/index.ts
+++ b/packages/ai/parasail/src/index.ts
@@ -72,7 +72,12 @@ export default defineAi<Config>({
 });
 
 function cleanBaseUrl(value: string): string {
-  const url = new URL(value);
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('Parasail baseUrl must be a valid URL');
+  }
   if (url.protocol !== 'https:' && url.protocol !== 'http:') {
     throw new Error('Parasail baseUrl must use http or https');
   }


### PR DESCRIPTION
## Summary
- normalize the Parasail API base URL before building the chat completions endpoint
- strip trailing slashes so custom `/v1/` bases do not produce double-slash request paths
- reject base URLs containing credentials, query strings, or fragments before any network call
- add focused generation tests around request construction and malformed base URLs

## Why
The adapter previously concatenated `config.baseUrl` directly with `/chat/completions`. A custom base URL ending in `/` created a `//chat/completions` path, and URLs with credentials/query/hash could create surprising request targets. This keeps Parasail endpoint construction explicit and predictable.

## Validation
- `vitest run packages/ai/parasail/src/index.test.ts` (4 passed)
- `tsc -p packages/ai/parasail/tsconfig.json --noEmit`
- `git diff --check`