### PR TITLE
fix(ai-zai): require clean api base urls

### DIFF
--- a/packages/ai/zai/src/index.test.ts
+++ b/packages/ai/zai/src/index.test.ts
@@ -93,13 +93,36 @@ describe('Z.ai chat completions generation', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     await adapter.generate(ctx(), 'hello', { model: 'glm-4.5-air' }, {
-      baseUrl: 'https://example.test/api/paas/v4',
+      baseUrl: 'https://example.test/api/paas/v4/',
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
       'https://example.test/api/paas/v4/chat/completions',
       expect.any(Object)
     );
+  });
+
+  it('rejects configured base URLs with credentials, query, or hash', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, {
+        baseUrl: 'https://user:pass@example.test/api/paas/v4',
+      }),
+    ).rejects.toThrow('clean API base');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, {
+        baseUrl: 'https://example.test/api/paas/v4?target=chat',
+      }),
+    ).rejects.toThrow('clean API base');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, {
+        baseUrl: 'https://example.test/api/paas/v4#chat',
+      }),
+    ).rejects.toThrow('clean API base');
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('includes status and response body excerpt on errors', async () => {

--- a/packages/ai/zai/src/index.test.ts
+++ b/packages/ai/zai/src/index.test.ts
@@ -108,6 +108,16 @@ describe('Z.ai chat completions generation', () => {
 
     await expect(
       adapter.generate(ctx(), 'hello', {}, {
+        baseUrl: 'example.test/api/paas/v4',
+      }),
+    ).rejects.toThrow('valid URL');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, {
+        baseUrl: 'ftp://example.test/api/paas/v4',
+      }),
+    ).rejects.toThrow('http or https');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, {
         baseUrl: 'https://user:pass@example.test/api/paas/v4',
       }),
     ).rejects.toThrow('clean API base');

--- a/packages/ai/zai/src/index.ts
+++ b/packages/ai/zai/src/index.ts
@@ -35,7 +35,8 @@ export default defineAi<Config>({
     if (opts.system) messages.push({ role: 'system', content: opts.system });
     messages.push({ role: 'user', content: prompt });
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+    const baseUrl = cleanBaseUrl(config.baseUrl ?? DEFAULT_BASE);
+    const res = await fetch(`${baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         authorization: `Bearer ${apiKey}`,
@@ -72,6 +73,17 @@ export default defineAi<Config>({
     ],
   }),
 });
+
+function cleanBaseUrl(value: string): string {
+  const url = new URL(value);
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error('Z.ai baseUrl must use http or https');
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error('Z.ai baseUrl must be a clean API base without credentials, query, or hash');
+  }
+  return url.toString().replace(/\/+$/, '');
+}
 
 type ZaiRole = 'system' | 'user' | 'assistant' | 'tool';
 

--- a/packages/ai/zai/src/index.ts
+++ b/packages/ai/zai/src/index.ts
@@ -75,7 +75,12 @@ export default defineAi<Config>({
 });
 
 function cleanBaseUrl(value: string): string {
-  const url = new URL(value);
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('Z.ai baseUrl must be a valid URL');
+  }
   if (url.protocol !== 'https:' && url.protocol !== 'http:') {
     throw new Error('Z.ai baseUrl must use http or https');
   }


### PR DESCRIPTION
## Summary
- normalize the Z.ai API base URL before building the chat completions endpoint
- strip trailing slashes so custom `/api/paas/v4/` bases do not produce double-slash request paths
- reject base URLs containing credentials, query strings, or fragments before any network call

## Why
The adapter previously concatenated `config.baseUrl` directly with `/chat/completions`. A custom base URL ending in `/` produced a `//chat/completions` path, and URLs with credentials/query/hash could create surprising request targets. This keeps Z.ai endpoint construction explicit and predictable.

## Validation
- `vitest run packages/ai/zai/src/index.test.ts` (7 passed)
- `tsc -p packages/ai/zai/tsconfig.json --noEmit`
- `git diff --check`