### PR TITLE
fix(ai-clarifai): require clean api base urls

### DIFF
--- a/packages/ai/clarifai/src/index.test.ts
+++ b/packages/ai/clarifai/src/index.test.ts
@@ -115,6 +115,12 @@ describe('Clarifai generation', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'clarifai.test/v2/ext/openai/v1' }),
+    ).rejects.toThrow('valid URL');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'ftp://clarifai.test/v2/ext/openai/v1' }),
+    ).rejects.toThrow('http or https');
+    await expect(
       adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://user:pass@clarifai.test/v2/ext/openai/v1' }),
     ).rejects.toThrow('clean API base');
     await expect(

--- a/packages/ai/clarifai/src/index.test.ts
+++ b/packages/ai/clarifai/src/index.test.ts
@@ -88,24 +88,43 @@ describe('Clarifai generation', () => {
   });
 
   it('supports compatible text-style choices and custom base URLs', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
         choices: [{ text: 'legacy text response' }],
       }),
-    }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
 
     const result = await adapter.generate(
       ctx(),
       'hello',
       { model: 'anthropic/completion/models/claude-sonnet-4' },
-      { baseUrl: 'https://clarifai.test/v2/ext/openai/v1' },
+      { baseUrl: 'https://clarifai.test/v2/ext/openai/v1/' },
     );
 
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://clarifai.test/v2/ext/openai/v1/chat/completions');
     expect(result).toEqual({
       text: 'legacy text response',
       model: 'anthropic/completion/models/claude-sonnet-4',
     });
+  });
+
+  it('rejects base URLs with credentials, query, or hash', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://user:pass@clarifai.test/v2/ext/openai/v1' }),
+    ).rejects.toThrow('clean API base');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://clarifai.test/v2/ext/openai/v1?target=chat' }),
+    ).rejects.toThrow('clean API base');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://clarifai.test/v2/ext/openai/v1#chat' }),
+    ).rejects.toThrow('clean API base');
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('includes status and response body excerpt on errors', async () => {

--- a/packages/ai/clarifai/src/index.ts
+++ b/packages/ai/clarifai/src/index.ts
@@ -70,7 +70,12 @@ export default defineAi<Config>({
 });
 
 function cleanBaseUrl(value: string): string {
-  const url = new URL(value);
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('Clarifai baseUrl must be a valid URL');
+  }
   if (url.protocol !== 'https:' && url.protocol !== 'http:') {
     throw new Error('Clarifai baseUrl must use http or https');
   }

--- a/packages/ai/clarifai/src/index.ts
+++ b/packages/ai/clarifai/src/index.ts
@@ -29,7 +29,8 @@ export default defineAi<Config>({
     if (opts.system) messages.push({ role: 'system', content: opts.system });
     messages.push({ role: 'user', content: prompt });
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+    const baseUrl = cleanBaseUrl(config.baseUrl ?? DEFAULT_BASE);
+    const res = await fetch(`${baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         authorization: `Key ${apiKey}`,
@@ -67,6 +68,17 @@ export default defineAi<Config>({
     ],
   }),
 });
+
+function cleanBaseUrl(value: string): string {
+  const url = new URL(value);
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error('Clarifai baseUrl must use http or https');
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error('Clarifai baseUrl must be a clean API base without credentials, query, or hash');
+  }
+  return url.toString().replace(/\/+$/, '');
+}
 
 type ClarifaiRole = 'system' | 'user' | 'assistant' | 'developer' | 'tool';
 


### PR DESCRIPTION
## Summary
- normalize the Clarifai OpenAI-compatible API base URL before building the chat completions endpoint
- strip trailing slashes so custom `/v1/` bases do not produce double-slash request paths
- reject base URLs containing credentials, query strings, or fragments before any network call

## Why
The adapter previously concatenated `config.baseUrl` directly with `/chat/completions`. A custom base URL ending in `/` produced a `//chat/completions` path, and URLs with credentials/query/hash could create surprising request targets. This keeps Clarifai endpoint construction explicit and predictable.

## Validation
- `vitest run packages/ai/clarifai/src/index.test.ts` (7 passed)
- `tsc -p packages/ai/clarifai/tsconfig.json --noEmit`
- `git diff --check`