### PR TITLE
fix(ai-aionlabs): require clean api base urls

### DIFF
--- a/packages/ai/aionlabs/src/index.test.ts
+++ b/packages/ai/aionlabs/src/index.test.ts
@@ -81,6 +81,53 @@ describe('AionLabs OpenAI-compatible generation', () => {
     });
   });
 
+  it('normalizes custom base URLs before building request URLs', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'custom gateway' } }],
+        model: 'aion-1.0-mini',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await adapter.generate(
+      ctx(),
+      'hello',
+      {},
+      { baseUrl: 'https://aionlabs.test/v1/' },
+    );
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://aionlabs.test/v1/chat/completions');
+    expect(result).toEqual({
+      text: 'custom gateway',
+      model: 'aion-1.0-mini',
+    });
+  });
+
+  it('rejects unclean or invalid custom base URLs before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'aionlabs.test/v1' }),
+    ).rejects.toThrow('valid URL');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'ftp://aionlabs.test/v1' }),
+    ).rejects.toThrow('http or https');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://user:pass@aionlabs.test/v1' }),
+    ).rejects.toThrow('clean API base');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://aionlabs.test/v1?target=chat' }),
+    ).rejects.toThrow('clean API base');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://aionlabs.test/v1#chat' }),
+    ).rejects.toThrow('clean API base');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('includes status and response body excerpt on errors', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: false,

--- a/packages/ai/aionlabs/src/index.ts
+++ b/packages/ai/aionlabs/src/index.ts
@@ -24,7 +24,8 @@ export default defineAi<Config>({
     if (opts.system) messages.push({ role: 'system', content: opts.system });
     messages.push({ role: 'user', content: prompt });
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+    const baseUrl = cleanBaseUrl(config.baseUrl ?? DEFAULT_BASE);
+    const res = await fetch(`${baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         authorization: `Bearer ${apiKey}`,
@@ -60,6 +61,22 @@ export default defineAi<Config>({
     ],
   }),
 });
+
+function cleanBaseUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('AionLabs baseUrl must be a valid URL');
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error('AionLabs baseUrl must use http or https');
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error('AionLabs baseUrl must be a clean API base without credentials, query, or hash');
+  }
+  return url.toString().replace(/\/+$/, '');
+}
 
 type AionLabsRole = 'system' | 'user' | 'assistant' | 'tool';
 


### PR DESCRIPTION
## Summary
- normalize the AionLabs `baseUrl` before constructing `/chat/completions`
- reject malformed URLs, non-http(s) protocols, credentials, query strings, and fragments before making a network request
- add focused Vitest coverage for custom URL normalization and invalid/unclean URL rejection

## Why
A custom `baseUrl` currently gets concatenated directly into the request URL. Trailing slashes can produce malformed paths, and unclean URLs can hide credentials or surprising request targets. This makes AionLabs match the safer behavior being added across the OpenAI-compatible adapters.

## Validation
- `vitest run packages/ai/aionlabs/src/index.test.ts`
- `tsc -p packages/ai/aionlabs/tsconfig.json --noEmit`
- `git diff --check`