### PR TITLE
fix(ai-baidu): require clean api base urls

### DIFF
--- a/packages/ai/baidu/src/index.test.ts
+++ b/packages/ai/baidu/src/index.test.ts
@@ -89,24 +89,49 @@ describe('Baidu Qianfan chat completions generation', () => {
   });
 
   it('supports compatible text-style choices and custom base URLs', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
         choices: [{ text: 'legacy text response' }],
       }),
-    }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
 
     const result = await adapter.generate(
       ctx(),
       'hello',
       { model: 'deepseek-v3.1-250821' },
-      { baseUrl: 'https://qianfan.test/v2' },
+      { baseUrl: 'https://qianfan.test/v2/' },
     );
 
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://qianfan.test/v2/chat/completions');
     expect(result).toEqual({
       text: 'legacy text response',
       model: 'deepseek-v3.1-250821',
     });
+  });
+
+  it('rejects invalid or unclean custom base URLs before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'qianfan.test/v2' }),
+    ).rejects.toThrow('valid URL');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'ftp://qianfan.test/v2' }),
+    ).rejects.toThrow('http or https');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://user:pass@qianfan.test/v2' }),
+    ).rejects.toThrow('clean API base');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://qianfan.test/v2?target=chat' }),
+    ).rejects.toThrow('clean API base');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://qianfan.test/v2#chat' }),
+    ).rejects.toThrow('clean API base');
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('includes status and response body excerpt on errors', async () => {

--- a/packages/ai/baidu/src/index.ts
+++ b/packages/ai/baidu/src/index.ts
@@ -37,7 +37,8 @@ export default defineAi<Config>({
     };
     if (config.appId) headers.appid = config.appId;
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+    const baseUrl = cleanBaseUrl(config.baseUrl ?? DEFAULT_BASE);
+    const res = await fetch(`${baseUrl}/chat/completions`, {
       method: 'POST',
       headers,
       body: JSON.stringify({
@@ -72,6 +73,22 @@ export default defineAi<Config>({
     ],
   }),
 });
+
+function cleanBaseUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('Baidu Qianfan baseUrl must be a valid URL');
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error('Baidu Qianfan baseUrl must use http or https');
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error('Baidu Qianfan baseUrl must be a clean API base without credentials, query, or hash');
+  }
+  return url.toString().replace(/\/+$/, '');
+}
 
 type QianfanRole = 'system' | 'user' | 'assistant' | 'tool';
 


### PR DESCRIPTION
## Summary
- normalize the Baidu Qianfan `baseUrl` before appending `/chat/completions`
- reject invalid URLs, non-http(s) schemes, credentials, query strings, and fragments before making network calls
- extend tests to cover trailing slash normalization and unsafe custom base URLs

## Why
The adapter currently concatenates user-supplied `baseUrl` directly into the request URL. That allows malformed paths and surprising request targets. This makes the Baidu adapter fail early with adapter-specific configuration errors.

## Validation
- `vitest run packages/ai/baidu/src/index.test.ts`
- `tsc -p packages/ai/baidu/tsconfig.json --noEmit`
- `git diff --check`