### PR TITLE
fix(ai-akashml): require clean api base urls

### DIFF
--- a/packages/ai/akashml/src/index.test.ts
+++ b/packages/ai/akashml/src/index.test.ts
@@ -85,24 +85,49 @@ describe('Akash ML generation', () => {
   });
 
   it('supports text-style choices from compatible responses', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
         choices: [{ text: 'legacy text response' }],
       }),
-    }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
 
     const result = await adapter.generate(
       ctx(),
       'hello',
       { model: 'Qwen/Qwen3.6-35B-A3B' },
-      { baseUrl: 'https://akash.test/api/v1' },
+      { baseUrl: 'https://akash.test/api/v1/' },
     );
 
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://akash.test/api/v1/chat/completions');
     expect(result).toEqual({
       text: 'legacy text response',
       model: 'Qwen/Qwen3.6-35B-A3B',
     });
+  });
+
+  it('rejects invalid or unclean custom base URLs before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'akash.test/api/v1' }),
+    ).rejects.toThrow('valid URL');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'ftp://akash.test/api/v1' }),
+    ).rejects.toThrow('http or https');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://user:pass@akash.test/api/v1' }),
+    ).rejects.toThrow('clean API base');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://akash.test/api/v1?target=chat' }),
+    ).rejects.toThrow('clean API base');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://akash.test/api/v1#chat' }),
+    ).rejects.toThrow('clean API base');
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('includes status and response body excerpt on errors', async () => {

--- a/packages/ai/akashml/src/index.ts
+++ b/packages/ai/akashml/src/index.ts
@@ -30,7 +30,8 @@ export default defineAi<Config>({
     if (opts.system) messages.push({ role: 'system', content: opts.system });
     messages.push({ role: 'user', content: prompt });
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+    const baseUrl = cleanBaseUrl(config.baseUrl ?? DEFAULT_BASE);
+    const res = await fetch(`${baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         authorization: `Bearer ${apiKey}`,
@@ -68,6 +69,22 @@ export default defineAi<Config>({
     ],
   }),
 });
+
+function cleanBaseUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('Akash ML baseUrl must be a valid URL');
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error('Akash ML baseUrl must use http or https');
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error('Akash ML baseUrl must be a clean API base without credentials, query, or hash');
+  }
+  return url.toString().replace(/\/+$/, '');
+}
 
 type AkashRole = 'system' | 'user' | 'assistant' | 'tool';
 


### PR DESCRIPTION
## Summary
- normalize Akash ML custom `baseUrl` values before appending `/chat/completions`
- reject invalid URLs, non-http(s) schemes, credentials, query strings, and fragments before any network request
- extend tests for trailing slash normalization and invalid/unclean custom base URLs

## Why
The adapter currently concatenates user-provided `baseUrl` directly into the request target. That can produce malformed URLs and surprising destinations. This change makes the adapter fail early with Akash-specific configuration errors.

## Validation
- `vitest run packages/ai/akashml/src/index.test.ts`
- `tsc -p packages/ai/akashml/tsconfig.json --noEmit`
- `git diff --check`