### PR TITLE
fix(ai-alibaba-cloud): require clean api base urls

### DIFF
--- a/packages/ai/alibaba-cloud/src/index.test.ts
+++ b/packages/ai/alibaba-cloud/src/index.test.ts
@@ -92,13 +92,36 @@ describe('Alibaba Cloud OpenAI-compatible generation', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     await adapter.generate(ctx(), 'hello', { model: 'qwen-flash' }, {
-      baseUrl: 'https://dashscope-us.aliyuncs.com/compatible-mode/v1',
+      baseUrl: 'https://dashscope-us.aliyuncs.com/compatible-mode/v1/',
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
       'https://dashscope-us.aliyuncs.com/compatible-mode/v1/chat/completions',
       expect.any(Object)
     );
+  });
+
+  it('rejects invalid or unclean custom base URLs before network calls', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'dashscope-us.aliyuncs.com/compatible-mode/v1' }),
+    ).rejects.toThrow('valid URL');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'ftp://dashscope-us.aliyuncs.com/compatible-mode/v1' }),
+    ).rejects.toThrow('http or https');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://user:pass@dashscope-us.aliyuncs.com/compatible-mode/v1' }),
+    ).rejects.toThrow('clean API base');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://dashscope-us.aliyuncs.com/compatible-mode/v1?target=chat' }),
+    ).rejects.toThrow('clean API base');
+    await expect(
+      adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://dashscope-us.aliyuncs.com/compatible-mode/v1#chat' }),
+    ).rejects.toThrow('clean API base');
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('includes status and response body excerpt on errors', async () => {

--- a/packages/ai/alibaba-cloud/src/index.ts
+++ b/packages/ai/alibaba-cloud/src/index.ts
@@ -30,7 +30,8 @@ export default defineAi<Config>({
     if (opts.system) messages.push({ role: 'system', content: opts.system });
     messages.push({ role: 'user', content: prompt });
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+    const baseUrl = cleanBaseUrl(config.baseUrl ?? DEFAULT_BASE);
+    const res = await fetch(`${baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         authorization: `Bearer ${apiKey}`,
@@ -69,6 +70,22 @@ export default defineAi<Config>({
     ],
   }),
 });
+
+function cleanBaseUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('Alibaba Cloud baseUrl must be a valid URL');
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error('Alibaba Cloud baseUrl must use http or https');
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error('Alibaba Cloud baseUrl must be a clean API base without credentials, query, or hash');
+  }
+  return url.toString().replace(/\/+$/, '');
+}
 
 type AlibabaCloudRole = 'system' | 'user' | 'assistant' | 'tool';
 


### PR DESCRIPTION
## Summary
- normalize Alibaba Cloud Model Studio custom `baseUrl` values before appending `/chat/completions`
- reject invalid URLs, non-http(s) schemes, credentials, query strings, and fragments before any network request
- add focused test coverage for trailing slash normalization and unsafe custom base URLs

## Why
The adapter currently concatenates user-provided `baseUrl` directly into the request URL. That can create malformed paths or surprising request targets. This change makes misconfiguration fail early with Alibaba Cloud-specific errors.

## Validation
- `vitest run packages/ai/alibaba-cloud/src/index.test.ts`
- `tsc -p packages/ai/alibaba-cloud/tsconfig.json --noEmit`
- `git diff --check`