### PR TITLE
fix(ai-together): require clean api base urls

### DIFF
--- a/packages/ai/together/src/index.test.ts
+++ b/packages/ai/together/src/index.test.ts
@@ -84,24 +84,43 @@ describe('Together AI generation', () => {
   });
 
   it('supports text-style choices from compatible responses', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
         choices: [{ text: 'legacy text response' }],
       }),
-    }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
 
     const result = await adapter.generate(
       ctx(),
       'hello',
       { model: 'Qwen/Qwen3.5-9B' },
-      { baseUrl: 'https://together.test/v1' },
+      { baseUrl: 'https://together.test/v1/' },
     );
 
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://together.test/v1/chat/completions');
     expect(result).toEqual({
       text: 'legacy text response',
       model: 'Qwen/Qwen3.5-9B',
     });
+  });
+
+  it.each([
+    ['missing scheme', 'together.test/v1'],
+    ['ftp scheme', 'ftp://together.test/v1'],
+    ['credentials', 'https://user:pass@together.test/v1'],
+    ['query string', 'https://together.test/v1?token=secret'],
+    ['fragment', 'https://together.test/v1#chat'],
+  ])('rejects unclean custom baseUrl values: %s', async (_label, baseUrl) => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(adapter.generate(ctx(), 'hello', {}, { baseUrl })).rejects.toThrow(
+      /Together AI baseUrl/,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('includes status and response body excerpt on errors', async () => {

--- a/packages/ai/together/src/index.ts
+++ b/packages/ai/together/src/index.ts
@@ -28,7 +28,8 @@ export default defineAi<Config>({
     if (opts.system) messages.push({ role: 'system', content: opts.system });
     messages.push({ role: 'user', content: prompt });
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+    const baseUrl = cleanBaseUrl(config.baseUrl ?? DEFAULT_BASE);
+    const res = await fetch(`${baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         authorization: `Bearer ${apiKey}`,
@@ -86,4 +87,23 @@ interface TogetherChatResponse {
     prompt_tokens?: number;
     completion_tokens?: number;
   };
+}
+
+function cleanBaseUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('Together AI baseUrl must be a valid URL');
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error('Together AI baseUrl must use http or https');
+  }
+
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error('Together AI baseUrl must be a clean API base without credentials, query, or hash');
+  }
+
+  return url.toString().replace(/\/+$/, '');
 }


### PR DESCRIPTION
## Summary
- normalize Together AI custom `baseUrl` values before appending `/chat/completions`
- reject invalid URLs, non-http(s) schemes, credentials, query strings, and fragments before any network request
- extend tests for trailing slash normalization and unsafe custom base URLs

## Why
The adapter currently concatenates user-provided `baseUrl` directly into the request URL. That can produce malformed request paths or surprising destinations. This change makes Together AI fail early with adapter-specific configuration errors.

## Validation
- `vitest run packages/ai/together/src/index.test.ts`
- `tsc -p packages/ai/together/tsconfig.json --noEmit`
- `git diff --check`