### PR TITLE
fix(ai-claude): require clean api base urls

### DIFF
--- a/packages/ai/claude/src/index.test.ts
+++ b/packages/ai/claude/src/index.test.ts
@@ -61,7 +61,7 @@ describe('Claude Messages API generation', () => {
         temperature: 0.2,
         extra: { top_p: 0.9 },
       },
-      { baseUrl: 'https://anthropic.test' },
+      { baseUrl: 'https://anthropic.test/' },
     );
 
     expect(fetchMock).toHaveBeenCalledOnce();
@@ -86,6 +86,22 @@ describe('Claude Messages API generation', () => {
       inputTokens: 11,
       outputTokens: 4,
     });
+  });
+
+  it.each([
+    ['missing scheme', 'anthropic.test'],
+    ['ftp scheme', 'ftp://anthropic.test'],
+    ['credentials', 'https://user:pass@anthropic.test'],
+    ['query string', 'https://anthropic.test?token=secret'],
+    ['fragment', 'https://anthropic.test#messages'],
+  ])('rejects unclean custom baseUrl values: %s', async (_label, baseUrl) => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(adapter.generate(ctx(), 'hello', {}, { baseUrl })).rejects.toThrow(
+      /Anthropic baseUrl/,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('uses a safe default max_tokens value when not provided', async () => {

--- a/packages/ai/claude/src/index.ts
+++ b/packages/ai/claude/src/index.ts
@@ -23,7 +23,8 @@ export default defineAi<Config>({
     ctx.log(`claude · model=${model} · ${prompt.length} chars in`);
     if (ctx.dryRun) return { text: '[dry-run]', model };
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/messages`, {
+    const baseUrl = cleanBaseUrl(config.baseUrl ?? DEFAULT_BASE);
+    const res = await fetch(`${baseUrl}/v1/messages`, {
       method: 'POST',
       headers: {
         'x-api-key': apiKey,
@@ -70,4 +71,23 @@ function redact(value: string, apiKey: string): string {
   return value
     .replaceAll(apiKey, '[redacted]')
     .replace(/sk-ant-[A-Za-z0-9._~+/=-]{12,}/g, '[redacted]');
+}
+
+function cleanBaseUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('Anthropic baseUrl must be a valid URL');
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error('Anthropic baseUrl must use http or https');
+  }
+
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error('Anthropic baseUrl must be a clean API base without credentials, query, or hash');
+  }
+
+  return url.toString().replace(/\/+$/, '');
 }


### PR DESCRIPTION
## Summary
- normalize Claude custom `baseUrl` values before appending `/v1/messages`
- reject invalid URLs, non-http(s) schemes, credentials, query strings, and fragments before any network request
- extend tests for trailing slash normalization and unsafe custom base URLs

## Why
The adapter currently concatenates user-provided `baseUrl` directly into the request URL. That can produce malformed request paths or surprising destinations. This change makes Claude fail early with Anthropic-specific configuration errors.

## Validation
- `vitest run packages/ai/claude/src/index.test.ts`
- `tsc -p packages/ai/claude/tsconfig.json --noEmit`
- `git diff --check`