### PR TITLE
fix(ai-perceptron): require clean api base urls

### DIFF
--- a/packages/ai/perceptron/src/index.test.ts
+++ b/packages/ai/perceptron/src/index.test.ts
@@ -108,7 +108,7 @@ describe('Perceptron chat completions generation', () => {
           },
         },
       },
-      { baseUrl: 'https://perceptron.test/v1' }
+      { baseUrl: 'https://perceptron.test/v1/' }
     );
 
     expect(fetchMock).toHaveBeenCalledWith(
@@ -125,6 +125,22 @@ describe('Perceptron chat completions generation', () => {
         }),
       })
     );
+  });
+
+  it.each([
+    ['missing scheme', 'perceptron.test/v1'],
+    ['ftp scheme', 'ftp://perceptron.test/v1'],
+    ['credentials', 'https://user:pass@perceptron.test/v1'],
+    ['query string', 'https://perceptron.test/v1?token=secret'],
+    ['fragment', 'https://perceptron.test/v1#chat'],
+  ])('rejects unclean custom baseUrl values: %s', async (_label, baseUrl) => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(adapter.generate(ctx(), 'hello', {}, { baseUrl })).rejects.toThrow(
+      /Perceptron baseUrl/
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('includes status and response body excerpt on errors', async () => {

--- a/packages/ai/perceptron/src/index.ts
+++ b/packages/ai/perceptron/src/index.ts
@@ -29,7 +29,8 @@ export default defineAi<Config>({
     if (opts.system) messages.push({ role: 'system', content: opts.system });
     messages.push({ role: 'user', content: prompt });
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/chat/completions`, {
+    const baseUrl = cleanBaseUrl(config.baseUrl ?? DEFAULT_BASE);
+    const res = await fetch(`${baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         authorization: `Bearer ${apiKey}`,
@@ -89,4 +90,23 @@ interface PerceptronChatResponse {
     prompt_tokens?: number;
     completion_tokens?: number;
   };
+}
+
+function cleanBaseUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('Perceptron baseUrl must be a valid URL');
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error('Perceptron baseUrl must use http or https');
+  }
+
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error('Perceptron baseUrl must be a clean API base without credentials, query, or hash');
+  }
+
+  return url.toString().replace(/\/+$/, '');
 }


### PR DESCRIPTION
## Summary
- normalize Perceptron custom `baseUrl` values before appending `/chat/completions`
- reject invalid URLs, non-http(s) schemes, credentials, query strings, and fragments before any network request
- extend tests for trailing slash normalization and unsafe custom base URLs

## Why
The adapter currently concatenates user-provided `baseUrl` directly into the request URL. That can produce malformed request paths or surprising destinations. This change makes Perceptron fail early with adapter-specific configuration errors.

## Validation
- `vitest run packages/ai/perceptron/src/index.test.ts`
- `tsc -p packages/ai/perceptron/tsconfig.json --noEmit`
- `git diff --check`