### PR TITLE
fix(ai-nebius): require clean api base urls

### DIFF
--- a/packages/ai/nebius/src/index.test.ts
+++ b/packages/ai/nebius/src/index.test.ts
@@ -72,20 +72,39 @@ describe('Nebius Token Factory chat completions generation', () => {
   });
 
   it('supports text-style choices from compatible Nebius responses', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({
         model: 'meta-llama/Llama-3.3-70B-Instruct',
         choices: [{ text: 'text choice response' }],
       }),
-    }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
 
-    const result = await adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://nebius.test' });
+    const result = await adapter.generate(ctx(), 'hello', {}, { baseUrl: 'https://nebius.test/' });
 
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://nebius.test/v1/chat/completions');
     expect(result).toEqual({
       text: 'text choice response',
       model: 'meta-llama/Llama-3.3-70B-Instruct',
     });
+  });
+
+  it.each([
+    ['missing scheme', 'nebius.test'],
+    ['ftp scheme', 'ftp://nebius.test'],
+    ['credentials', 'https://user:pass@nebius.test'],
+    ['query string', 'https://nebius.test?token=secret'],
+    ['fragment', 'https://nebius.test#chat'],
+  ])('rejects unclean custom baseUrl values: %s', async (_label, baseUrl) => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(adapter.generate(ctx(), 'hello', {}, { baseUrl })).rejects.toThrow(
+      /Nebius baseUrl/
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('includes status and response body excerpt on errors', async () => {

--- a/packages/ai/nebius/src/index.ts
+++ b/packages/ai/nebius/src/index.ts
@@ -28,7 +28,8 @@ export default defineAi<Config>({
     if (opts.system) messages.push({ role: 'system', content: opts.system });
     messages.push({ role: 'user', content: prompt });
 
-    const res = await fetch(`${config.baseUrl ?? DEFAULT_BASE}/v1/chat/completions`, {
+    const baseUrl = cleanBaseUrl(config.baseUrl ?? DEFAULT_BASE);
+    const res = await fetch(`${baseUrl}/v1/chat/completions`, {
       method: 'POST',
       headers: {
         authorization: `Bearer ${apiKey}`,
@@ -86,4 +87,23 @@ interface NebiusChatResponse {
     prompt_tokens?: number;
     completion_tokens?: number;
   };
+}
+
+function cleanBaseUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('Nebius baseUrl must be a valid URL');
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error('Nebius baseUrl must use http or https');
+  }
+
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error('Nebius baseUrl must be a clean API base without credentials, query, or hash');
+  }
+
+  return url.toString().replace(/\/+$/, '');
 }


### PR DESCRIPTION
## Summary
- normalize Nebius custom `baseUrl` values before appending `/v1/chat/completions`
- reject invalid URLs, non-http(s) schemes, credentials, query strings, and fragments before any network request
- extend tests for trailing slash normalization and unsafe custom base URLs

## Why
The adapter currently concatenates user-provided `baseUrl` directly into the request URL. That can produce malformed request paths or surprising destinations. This change makes Nebius fail early with adapter-specific configuration errors.

## Validation
- `vitest run packages/ai/nebius/src/index.test.ts`
- `tsc -p packages/ai/nebius/tsconfig.json --noEmit`
- `git diff --check`