### PR TITLE
fix(ai-deepseek): require clean api base urls

### DIFF
--- a/packages/ai/deepseek/src/index.test.ts
+++ b/packages/ai/deepseek/src/index.test.ts
@@ -81,6 +81,22 @@ describe('DeepSeek OpenAI-compatible generation', () => {
     expect(url).toBe('https://proxy.example.com/v1/chat/completions');
   });
 
+  it.each([
+    ['missing scheme', 'proxy.example.com'],
+    ['unsupported scheme', 'ftp://proxy.example.com'],
+    ['credentials', 'https://user:pass@proxy.example.com'],
+    ['query string', 'https://proxy.example.com?debug=true'],
+    ['fragment', 'https://proxy.example.com#v1'],
+  ])('rejects unclean configured base URLs: %s', async (_case, baseUrl) => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(adapter.generate(ctx(), 'hello', {}, { baseUrl })).rejects.toThrow(
+      /DeepSeek baseUrl/,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('includes status and redacted response body excerpt on errors', async () => {
     const apiKey = 'test-key-crossing-truncation-boundary';
     const prefix = 'x'.repeat(190);

--- a/packages/ai/deepseek/src/index.ts
+++ b/packages/ai/deepseek/src/index.ts
@@ -7,7 +7,23 @@ interface Config {
 const DEFAULT_BASE = 'https://api.deepseek.com';
 
 function chatCompletionsUrl(baseUrl?: string): string {
-  return `${(baseUrl ?? DEFAULT_BASE).replace(/\/+$/, '')}/v1/chat/completions`;
+  return `${cleanBaseUrl(baseUrl ?? DEFAULT_BASE)}/v1/chat/completions`;
+}
+
+function cleanBaseUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('DeepSeek baseUrl must be a valid URL');
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw new Error('DeepSeek baseUrl must use http or https');
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error('DeepSeek baseUrl must be a clean API base without credentials, query, or hash');
+  }
+  return url.toString().replace(/\/+$/, '');
 }
 
 function redact(value: string, apiKey: string): string {


### PR DESCRIPTION
## Summary
- validate DeepSeek custom `baseUrl` values before building the chat completions URL
- reject invalid URLs, non-http(s) schemes, credentials, query strings, and fragments before any network request
- keep trailing slash normalization covered while adding unsafe custom base URL cases

## Why
The adapter trimmed trailing slashes, but still accepted malformed or surprising custom API bases. This change makes DeepSeek fail early with adapter-specific configuration errors instead of sending requests to unclear destinations.

## Validation
- `vitest run packages/ai/deepseek/src/index.test.ts`
- `tsc -p packages/ai/deepseek/tsconfig.json --noEmit`
- `git diff --check`