### PR TITLE
fix(ai-mistral): require clean api base urls

### DIFF
--- a/packages/ai/mistral/src/index.test.ts
+++ b/packages/ai/mistral/src/index.test.ts
@@ -81,6 +81,20 @@ describe('Mistral OpenAI-compatible generation', () => {
     expect(url).toBe('https://proxy.example.com/v1/chat/completions');
   });
 
+  it.each([
+    ['not-a-url', 'valid URL'],
+    ['ftp://proxy.example.com', 'http or https'],
+    ['https://user:pass@proxy.example.com', 'must not include credentials'],
+    ['https://proxy.example.com?region=us', 'must not include query strings or fragments'],
+    ['https://proxy.example.com#v1', 'must not include query strings or fragments'],
+  ])('rejects unsafe configured base URL %s', async (baseUrl, message) => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(adapter.generate(ctx(), 'hello', {}, { baseUrl })).rejects.toThrow(message);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('includes status and redacted response body excerpt on errors', async () => {
     const apiKey = 'test-key-crossing-truncation-boundary';
     const prefix = 'x'.repeat(190);

--- a/packages/ai/mistral/src/index.ts
+++ b/packages/ai/mistral/src/index.ts
@@ -6,8 +6,31 @@ interface Config {
 
 const DEFAULT_BASE = 'https://api.mistral.ai';
 
+function cleanBaseUrl(baseUrl?: string): string {
+  if (!baseUrl) return DEFAULT_BASE;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    throw new Error('Mistral baseUrl must be a valid URL');
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new Error('Mistral baseUrl must use http or https');
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error('Mistral baseUrl must not include credentials');
+  }
+  if (parsed.search || parsed.hash) {
+    throw new Error('Mistral baseUrl must not include query strings or fragments');
+  }
+
+  return parsed.toString().replace(/\/+$/, '');
+}
+
 function chatCompletionsUrl(baseUrl?: string): string {
-  return `${(baseUrl ?? DEFAULT_BASE).replace(/\/+$/, '')}/v1/chat/completions`;
+  return `${cleanBaseUrl(baseUrl)}/v1/chat/completions`;
 }
 
 function redact(value: string, apiKey: string): string {


### PR DESCRIPTION
## Summary
- validate Mistral custom `baseUrl` values before building the chat completions URL
- reject invalid URLs, non-http(s) schemes, credentials, query strings, and fragments before any network request
- keep trailing slash normalization covered while adding unsafe custom base URL cases

## Why
The adapter trimmed trailing slashes, but still accepted malformed or surprising custom API bases. This change makes Mistral fail early with adapter-specific configuration errors instead of sending requests to unclear destinations.

## Validation
- `vitest run packages/ai/mistral/src/index.test.ts` (11 tests)
- `tsc -p packages/ai/mistral/tsconfig.json --noEmit`
- `git diff --check`