### PR TITLE
fix(bot-whatsapp): validate integer env limits

### DIFF
--- a/packages/bot/whatsapp/src/index.test.ts
+++ b/packages/bot/whatsapp/src/index.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { loadConfig } from "./index.js";
+
+describe("loadConfig", () => {
+  it("parses positive integer environment limits", () => {
+    const config = loadConfig({
+      SESSION_TIMEOUT_MS: "60000",
+      MAX_OUTPUT_LENGTH: "1200",
+      MAX_CONCURRENT_SESSIONS: "3",
+    });
+
+    expect(config.sessionTimeoutMs).toBe(60000);
+    expect(config.maxOutputLength).toBe(1200);
+    expect(config.maxConcurrentSessions).toBe(3);
+  });
+
+  it("rejects partially parsed and non-integer environment limits", () => {
+    expect(() => loadConfig({ SESSION_TIMEOUT_MS: "10abc" })).toThrow(
+      "SESSION_TIMEOUT_MS must be a positive integer"
+    );
+    expect(() => loadConfig({ MAX_OUTPUT_LENGTH: "1.5" })).toThrow(
+      "MAX_OUTPUT_LENGTH must be a positive integer"
+    );
+    expect(() => loadConfig({ MAX_CONCURRENT_SESSIONS: "0" })).toThrow(
+      "MAX_CONCURRENT_SESSIONS must be a positive integer"
+    );
+  });
+});

--- a/packages/bot/whatsapp/src/index.ts
+++ b/packages/bot/whatsapp/src/index.ts
@@ -120,10 +120,26 @@ export function loadConfig(env: Record<string, string | undefined>): Config {
     aiProvider: (env.AI_PROVIDER as any) || "claude-code",
     aiCliPath: env.AI_CLI_PATH || "claude",
     aiModel: env.AI_MODEL,
-    sessionTimeoutMs: parseInt(env.SESSION_TIMEOUT_MS || "1800000", 10),
-    maxOutputLength: parseInt(env.MAX_OUTPUT_LENGTH || "4000", 10),
-    maxConcurrentSessions: parseInt(env.MAX_CONCURRENT_SESSIONS || "5", 10),
+    sessionTimeoutMs: parseEnvPositiveInteger(env.SESSION_TIMEOUT_MS, 1800000, "SESSION_TIMEOUT_MS"),
+    maxOutputLength: parseEnvPositiveInteger(env.MAX_OUTPUT_LENGTH, 4000, "MAX_OUTPUT_LENGTH"),
+    maxConcurrentSessions: parseEnvPositiveInteger(env.MAX_CONCURRENT_SESSIONS, 5, "MAX_CONCURRENT_SESSIONS"),
     allowedUsers: env.ALLOWED_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
     adminUsers: env.ADMIN_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
   });
+}
+
+function parseEnvPositiveInteger(
+  value: string | undefined,
+  defaultValue: number,
+  name: string
+): number {
+  if (value === undefined || value.trim() === "") return defaultValue;
+  if (!/^\d+$/.test(value.trim())) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
 }


### PR DESCRIPTION
## Summary
- replace partial `parseInt` handling for WhatsApp bot numeric env limits with strict positive integer parsing
- reject malformed values such as `10abc`, decimals, and zero before config startup
- add regression coverage for valid and invalid environment limits

## Validation
- `node ...vitest.mjs run packages/bot/whatsapp/src/index.test.ts` passed 2 tests
- `node ...typescript/lib/tsc.js -p packages/bot/whatsapp/tsconfig.json --noEmit` passed

Note: `pnpm install` currently fails the repository supply-chain policy because `@profullstack/autoblog@0.4.0` has no lockfile integrity entry, so I did not modify the lockfile.