### PR TITLE
fix(vcs): filter invalid numeric IDs

### DIFF
--- a/packages/vcs/gitea/src/index.test.ts
+++ b/packages/vcs/gitea/src/index.test.ts
@@ -95,7 +95,7 @@ describe('vcs-gitea REST API', () => {
     const issue = await adapter.createIssue(ctx(), {
       title: 'Track store upload',
       body: 'Need release evidence.',
-      labels: ['12', 'not-an-id'],
+      labels: ['12', 'not-an-id', '0', '-1', '1.5', '9007199254740992', ' '],
       assignees: ['octo'],
     }, sampleConfig());
 

--- a/packages/vcs/gitea/src/index.ts
+++ b/packages/vcs/gitea/src/index.ts
@@ -213,7 +213,9 @@ function giteaErrorMessage(data: unknown, fallback: string): string {
 
 function numericIds(values?: string[]): number[] | undefined {
   if (!values?.length) return undefined;
-  const ids = values.map((v) => Number(v)).filter(Number.isInteger);
+  const ids = values
+    .map((value) => Number(value))
+    .filter((value) => Number.isSafeInteger(value) && value > 0);
   return ids.length ? ids : undefined;
 }
 

--- a/packages/vcs/gitlab/src/index.test.ts
+++ b/packages/vcs/gitlab/src/index.test.ts
@@ -28,7 +28,7 @@ describe('vcs-gitlab REST API', () => {
       base: 'main',
       draft: true,
       labels: ['automation', 'vcs'],
-      reviewers: ['42', 'not-a-user-id'],
+      reviewers: ['42', 'not-a-user-id', '0', '-1', '1.5', '9007199254740992', ' '],
     }, { projectId: 'acme/my-app' });
 
     expect(fetchMock).toHaveBeenCalledWith('https://gitlab.com/api/v4/projects/acme%2Fmy-app/merge_requests', expect.objectContaining({

--- a/packages/vcs/gitlab/src/index.ts
+++ b/packages/vcs/gitlab/src/index.ts
@@ -217,7 +217,9 @@ function gitlabErrorMessage(data: unknown, fallback: string): string {
 
 function numericIds(values?: string[]): number[] | undefined {
   if (!values?.length) return undefined;
-  const ids = values.map((v) => Number(v)).filter(Number.isInteger);
+  const ids = values
+    .map((value) => Number(value))
+    .filter((value) => Number.isSafeInteger(value) && value > 0);
   return ids.length ? ids : undefined;
 }
 


### PR DESCRIPTION
## Summary

- filter GitLab reviewer/assignee IDs to positive safe integers
- filter Gitea label IDs with the same validation
- cover zero, negative, fractional, unsafe, whitespace-only, and non-numeric inputs

## Tests

- `vitest run packages/vcs/gitlab/src/index.test.ts packages/vcs/gitea/src/index.test.ts` (17 passed)
- TypeScript typecheck for both affected packages
- `git diff --check`

Closes #852