### PR TITLE
fix(cli): avoid partial payment fee parsing

### DIFF
--- a/packages/cli/src/commands/config-payments.ts
+++ b/packages/cli/src/commands/config-payments.ts
@@ -88,7 +88,7 @@ function readStringProperty(source: string, key: string): string | undefined {
 }
 
 function readNumberProperty(source: string, key: string): number | undefined {
-  const match = new RegExp(`${propertyKeyPattern(key)}\\s*:\\s*(\\d+)`).exec(source);
+  const match = new RegExp(`${propertyKeyPattern(key)}\\s*:\\s*(\\d+)\\s*(?=,|})`).exec(source);
   return match?.[1] ? Number(match[1]) : undefined;
 }
 

--- a/packages/cli/src/commands/config.test.ts
+++ b/packages/cli/src/commands/config.test.ts
@@ -58,4 +58,20 @@ describe('parsePaymentsSummary', () => {
       ],
     });
   });
+
+  it('ignores malformed platform fee values instead of partially parsing them', () => {
+    const summary = parsePaymentsSummary(`
+      export default defineConfig({
+        payments: {
+          defaultProvider: 'coinpay',
+          providers: {
+            coinpay: { use: 'payment-coinpay' },
+          },
+          platformFeeBps: 1500abc,
+        },
+      });
+    `);
+
+    expect(summary?.platformFeeBps).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- require `platformFeeBps` summary extraction to match a complete numeric literal
- avoid reporting malformed values like `1500abc` as if they were valid `1500`
- add regression coverage for malformed payment fee config text

## Validation
- `node ...vitest.mjs run packages/cli/src/commands/config.test.ts` passed 4 tests

Note: a broader `tsc -p packages/cli/tsconfig.json --noEmit` run is currently blocked by the local dependency install/lockfile policy state (`@profullstack/autoblog@0.4.0` has no integrity entry), so I did not alter dependency metadata for this focused fix.