### PR TITLE
fix(payment-stripe): reject stale webhook signatures

### DIFF
--- a/packages/payments/stripe/src/index.test.ts
+++ b/packages/payments/stripe/src/index.test.ts
@@ -74,7 +74,7 @@ describe('payment-stripe', () => {
       },
     });
     const secret = 'whsec_test';
-    const timestamp = '1700000000';
+    const timestamp = Math.floor(Date.now() / 1000).toString();
     const signature = createHmac('sha256', secret)
       .update(`${timestamp}.${raw}`)
       .digest('hex');
@@ -97,12 +97,45 @@ describe('payment-stripe', () => {
   });
 
   it('rejects invalid Stripe webhook signatures', async () => {
+    const timestamp = Math.floor(Date.now() / 1000).toString();
     await expect(adapter.verifyWebhook(
       ctx({ STRIPE_WEBHOOK_SECRET: 'whsec_test' }),
       JSON.stringify({ type: 'checkout.session.completed' }),
-      't=1700000000,v1=bad',
+      `t=${timestamp},v1=bad`,
       {},
     )).rejects.toThrow('Invalid Stripe webhook signature');
+  });
+
+  it('rejects Stripe webhook signatures outside the timestamp tolerance', async () => {
+    const raw = JSON.stringify({ type: 'checkout.session.completed' });
+    const secret = 'whsec_test';
+    const timestamp = String(Math.floor(Date.now() / 1000) - 600);
+    const signature = createHmac('sha256', secret)
+      .update(`${timestamp}.${raw}`)
+      .digest('hex');
+
+    await expect(adapter.verifyWebhook(
+      ctx({ STRIPE_WEBHOOK_SECRET: secret }),
+      raw,
+      `t=${timestamp},v1=${signature}`,
+      {},
+    )).rejects.toThrow('Stripe webhook signature timestamp outside tolerance');
+  });
+
+  it('allows Stripe webhook timestamp tolerance to be disabled', async () => {
+    const raw = JSON.stringify({ type: 'checkout.session.completed' });
+    const secret = 'whsec_test';
+    const timestamp = '1700000000';
+    const signature = createHmac('sha256', secret)
+      .update(`${timestamp}.${raw}`)
+      .digest('hex');
+
+    await expect(adapter.verifyWebhook(
+      ctx({ STRIPE_WEBHOOK_SECRET: secret }),
+      raw,
+      `t=${timestamp},v1=${signature}`,
+      { webhookToleranceSeconds: 0 },
+    )).resolves.toMatchObject({ type: 'checkout.session.completed' });
   });
 });
 

--- a/packages/payments/stripe/src/index.ts
+++ b/packages/payments/stripe/src/index.ts
@@ -6,6 +6,7 @@ import { definePayment, tokenSetup, type CheckoutRequest, type Webhook } from '@
 interface Config {
   accountId?: string;
   apiVersion?: string;
+  webhookToleranceSeconds?: number;
 }
 
 const STRIPE_API = 'https://api.stripe.com/v1';
@@ -40,10 +41,10 @@ export default definePayment<Config>({
     };
   },
 
-  async verifyWebhook(ctx, rawBody, signature): Promise<Webhook> {
+  async verifyWebhook(ctx, rawBody, signature, config): Promise<Webhook> {
     const secret = ctx.secret('STRIPE_WEBHOOK_SECRET');
     if (!secret) throw new Error('STRIPE_WEBHOOK_SECRET not in vault');
-    verifyStripeSignature(rawBody, signature, secret);
+    verifyStripeSignature(rawBody, signature, secret, config?.webhookToleranceSeconds);
 
     const payload = JSON.parse(rawBody) as StripeEvent;
     const object = payload.data?.object ?? {};
@@ -161,7 +162,12 @@ async function readStripeJson<T>(res: Response): Promise<T> {
   return json;
 }
 
-function verifyStripeSignature(rawBody: string, header: string, secret: string): void {
+function verifyStripeSignature(
+  rawBody: string,
+  header: string,
+  secret: string,
+  toleranceSeconds = 300,
+): void {
   // Parse all key=value pairs preserving duplicate v1 keys.
   // Stripe sends multiple v1 signatures during webhook secret rotation;
   // Object.fromEntries() would silently drop all but one.
@@ -182,6 +188,13 @@ function verifyStripeSignature(rawBody: string, header: string, secret: string):
 
   if (!timestamp || v1Signatures.length === 0) {
     throw new Error('Stripe-Signature missing t or v1');
+  }
+
+  const timestampSeconds = Number(timestamp);
+  if (!Number.isFinite(timestampSeconds)) throw new Error('Stripe-Signature timestamp is invalid');
+  if (toleranceSeconds > 0) {
+    const age = Math.floor(Date.now() / 1000) - timestampSeconds;
+    if (Math.abs(age) > toleranceSeconds) throw new Error('Stripe webhook signature timestamp outside tolerance');
   }
 
   const expected = createHmac('sha256', secret)


### PR DESCRIPTION
## Summary
- add a default 5-minute timestamp tolerance to Stripe webhook signature verification
- reject non-finite and stale Stripe-Signature timestamps before accepting signed payloads
- keep an explicit `webhookToleranceSeconds: 0` escape hatch for controlled tests/local replay

## Validation
- `node ...vitest.mjs run packages/payments/stripe/src/index.test.ts` passed 8 tests

Note: direct package typecheck is limited by the current local dependency link state after the monorepo install policy failure; I left dependency metadata untouched.