### PR TITLE
fix(cli): require safe promote integer options

### DIFF
--- a/packages/cli/src/commands/promote.test.ts
+++ b/packages/cli/src/commands/promote.test.ts
@@ -6,7 +6,7 @@ describe('promote numeric option parsers', () => {
     expect(parsePositiveInteger('25')).toBe(25);
   });
 
-  it.each(['0', '-1', '1.5', '1e2', '0x10', 'Infinity', 'NaN', 'abc'])(
+  it.each(['0', '-1', '1.5', '1e2', '0x10', 'Infinity', 'NaN', 'abc', '9007199254740993'])(
     'rejects invalid positive integer %s',
     (value) => {
       expect(() => parsePositiveInteger(value)).toThrow('positive integer');
@@ -18,7 +18,7 @@ describe('promote numeric option parsers', () => {
     expect(parseNonNegativeInteger('2000')).toBe(2000);
   });
 
-  it.each(['-1', '1.5', '1e2', '0x10', 'Infinity', 'NaN', 'abc'])(
+  it.each(['-1', '1.5', '1e2', '0x10', 'Infinity', 'NaN', 'abc', '9007199254740993'])(
     'rejects invalid non-negative integer %s',
     (value) => {
       expect(() => parseNonNegativeInteger(value)).toThrow('zero or a positive integer');

--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -869,14 +869,14 @@ function stripAiPrefix(p: string): string {
 export function parsePositiveInteger(value: string): number {
   if (!/^\d+$/.test(value)) throw new InvalidArgumentError('must be a positive integer');
   const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed < 1) throw new InvalidArgumentError('must be a positive integer');
+  if (!Number.isSafeInteger(parsed) || parsed < 1) throw new InvalidArgumentError('must be a positive integer');
   return parsed;
 }
 
 export function parseNonNegativeInteger(value: string): number {
   if (!/^\d+$/.test(value)) throw new InvalidArgumentError('must be zero or a positive integer');
   const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed < 0) throw new InvalidArgumentError('must be zero or a positive integer');
+  if (!Number.isSafeInteger(parsed) || parsed < 0) throw new InvalidArgumentError('must be zero or a positive integer');
   return parsed;
 }
 


### PR DESCRIPTION
## Summary
- reject unsafe integer values for promote `--max` and `--delay-ms`
- add regression coverage for a value above JavaScript's safe integer range

## Bug
The promote command already requires decimal integer syntax, but it accepted values that are not safe JavaScript integers. A value such as `9007199254740993` can be rounded by `Number(...)`, so the CLI may process a different limit/delay than the user supplied.

## Validation
- `node "node_modules/.pnpm/vitest@2.1.9_@types+node@22.19.17/node_modules/vitest/vitest.mjs" run packages/cli/src/commands/promote.test.ts` passed 19 tests