### PR TITLE
fix(bot-discord): validate integer env limits

### DIFF
--- a/packages/bot/discord/src/index.test.ts
+++ b/packages/bot/discord/src/index.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { loadConfig } from "./index.js";
+
+const requiredEnv = {
+  DISCORD_BOT_TOKEN: "token",
+};
+
+describe("loadConfig", () => {
+  it("uses numeric defaults when optional env values are absent", () => {
+    expect(loadConfig(requiredEnv)).toMatchObject({
+      sessionTimeoutMs: 1800000,
+      maxOutputLength: 2000,
+      maxConcurrentSessions: 5,
+    });
+  });
+
+  it("accepts complete positive integer env values", () => {
+    expect(
+      loadConfig({
+        ...requiredEnv,
+        SESSION_TIMEOUT_MS: "60000",
+        MAX_OUTPUT_LENGTH: "1200",
+        MAX_CONCURRENT_SESSIONS: "3",
+      }),
+    ).toMatchObject({
+      sessionTimeoutMs: 60000,
+      maxOutputLength: 1200,
+      maxConcurrentSessions: 3,
+    });
+  });
+
+  it.each([
+    ["SESSION_TIMEOUT_MS", "10abc"],
+    ["MAX_OUTPUT_LENGTH", "1.5"],
+    ["MAX_CONCURRENT_SESSIONS", "0"],
+  ])("rejects malformed positive integer env %s=%s", (name, value) => {
+    expect(() => loadConfig({ ...requiredEnv, [name]: value })).toThrow();
+  });
+});

--- a/packages/bot/discord/src/index.ts
+++ b/packages/bot/discord/src/index.ts
@@ -38,6 +38,13 @@ export interface IncomingMessage {
 
 type MessageHandler = (msg: IncomingMessage) => void | Promise<void>;
 
+function parsePositiveIntegerEnv(value: string | undefined, fallback: number): number {
+  if (value === undefined || value.trim() === "") return fallback;
+  if (!/^\d+$/.test(value)) return Number.NaN;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : Number.NaN;
+}
+
 export class DiscordBot {
   private client: Client;
   private handlers: MessageHandler[] = [];
@@ -152,9 +159,9 @@ export function loadConfig(env: Record<string, string | undefined>): Config {
     aiProvider: (env.AI_PROVIDER as any) || "claude-code",
     aiCliPath: env.AI_CLI_PATH || "claude",
     aiModel: env.AI_MODEL,
-    sessionTimeoutMs: parseInt(env.SESSION_TIMEOUT_MS || "1800000", 10),
-    maxOutputLength: parseInt(env.MAX_OUTPUT_LENGTH || "2000", 10),
-    maxConcurrentSessions: parseInt(env.MAX_CONCURRENT_SESSIONS || "5", 10),
+    sessionTimeoutMs: parsePositiveIntegerEnv(env.SESSION_TIMEOUT_MS, 1800000),
+    maxOutputLength: parsePositiveIntegerEnv(env.MAX_OUTPUT_LENGTH, 2000),
+    maxConcurrentSessions: parsePositiveIntegerEnv(env.MAX_CONCURRENT_SESSIONS, 5),
     allowedUsers: env.ALLOWED_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
     allowedChannels: env.ALLOWED_CHANNELS?.split(",").map((c) => c.trim()).filter(Boolean),
     adminUsers: env.ADMIN_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],


### PR DESCRIPTION
## Summary
- replace partial `parseInt` config parsing with strict positive integer parsing for the Discord bot
- add regression coverage for defaults, valid values, and malformed integer env values

## Bug
Discord bot runtime limits used `parseInt`, so malformed values like `SESSION_TIMEOUT_MS=10abc` or decimal values like `MAX_OUTPUT_LENGTH=1.5` could be partially accepted as valid integers. That can hide deployment/configuration mistakes and run the bot with different limits than intended.

## Validation
- `node "node_modules/.pnpm/vitest@2.1.9_@types+node@22.19.17/node_modules/vitest/vitest.mjs" run packages/bot/discord/src/index.test.ts` passed 5 tests
- `node "node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/tsc.js" -p packages/bot/discord/tsconfig.json --noEmit` is currently blocked by pre-existing local Node ambient type errors in `packages/bot/discord/src/session-manager.ts`