### PR TITLE
fix(bot-signal): validate numeric env values

### DIFF
--- a/packages/bot/signal/src/index.test.ts
+++ b/packages/bot/signal/src/index.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { loadConfig } from "./index.js";
+
+const requiredEnv = {
+  SIGNAL_PHONE_NUMBER: "+15551234567",
+};
+
+describe("loadConfig", () => {
+  it("uses numeric defaults when optional env values are absent", () => {
+    expect(loadConfig(requiredEnv)).toMatchObject({
+      httpPort: 7580,
+      sessionTimeoutMs: 1800000,
+      maxOutputLength: 4000,
+      maxConcurrentSessions: 5,
+    });
+  });
+
+  it("accepts complete positive integer env values", () => {
+    expect(
+      loadConfig({
+        ...requiredEnv,
+        SIGNAL_HTTP_PORT: "8080",
+        SESSION_TIMEOUT_MS: "60000",
+        MAX_OUTPUT_LENGTH: "1200",
+        MAX_CONCURRENT_SESSIONS: "3",
+      }),
+    ).toMatchObject({
+      httpPort: 8080,
+      sessionTimeoutMs: 60000,
+      maxOutputLength: 1200,
+      maxConcurrentSessions: 3,
+    });
+  });
+
+  it.each([
+    ["SIGNAL_HTTP_PORT", "7580abc"],
+    ["SIGNAL_HTTP_PORT", "65536"],
+    ["SESSION_TIMEOUT_MS", "10abc"],
+    ["MAX_OUTPUT_LENGTH", "1.5"],
+    ["MAX_CONCURRENT_SESSIONS", "0"],
+  ])("rejects malformed numeric env %s=%s", (name, value) => {
+    expect(() => loadConfig({ ...requiredEnv, [name]: value })).toThrow();
+  });
+});

--- a/packages/bot/signal/src/index.ts
+++ b/packages/bot/signal/src/index.ts
@@ -30,6 +30,18 @@ export interface IncomingMessage {
 
 type MessageHandler = (msg: IncomingMessage) => void | Promise<void>;
 
+function parsePositiveIntegerEnv(value: string | undefined, fallback: number): number {
+  if (value === undefined || value.trim() === "") return fallback;
+  if (!/^\d+$/.test(value)) return Number.NaN;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : Number.NaN;
+}
+
+function parsePortEnv(value: string | undefined, fallback: number): number {
+  const parsed = parsePositiveIntegerEnv(value, fallback);
+  return parsed <= 65535 ? parsed : Number.NaN;
+}
+
 export class SignalBot {
   private handlers: MessageHandler[] = [];
   private config: Config;
@@ -98,13 +110,13 @@ export function loadConfig(env: Record<string, string | undefined>): Config {
     botName: env.BOT_NAME || "Bot",
     signalCliPath: env.SIGNAL_CLI_PATH || "signal-cli",
     phoneNumber: env.SIGNAL_PHONE_NUMBER || "",
-    httpPort: parseInt(env.SIGNAL_HTTP_PORT || "7580", 10),
+    httpPort: parsePortEnv(env.SIGNAL_HTTP_PORT, 7580),
     aiProvider: (env.AI_PROVIDER as any) || "claude-code",
     aiCliPath: env.AI_CLI_PATH || "claude",
     aiModel: env.AI_MODEL,
-    sessionTimeoutMs: parseInt(env.SESSION_TIMEOUT_MS || "1800000", 10),
-    maxOutputLength: parseInt(env.MAX_OUTPUT_LENGTH || "4000", 10),
-    maxConcurrentSessions: parseInt(env.MAX_CONCURRENT_SESSIONS || "5", 10),
+    sessionTimeoutMs: parsePositiveIntegerEnv(env.SESSION_TIMEOUT_MS, 1800000),
+    maxOutputLength: parsePositiveIntegerEnv(env.MAX_OUTPUT_LENGTH, 4000),
+    maxConcurrentSessions: parsePositiveIntegerEnv(env.MAX_CONCURRENT_SESSIONS, 5),
     allowedUsers: env.ALLOWED_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
     adminUsers: env.ADMIN_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
   });


### PR DESCRIPTION
## Summary
- replace partial `parseInt` parsing for Signal bot numeric env values
- enforce a valid TCP port range for `SIGNAL_HTTP_PORT`
- add regression coverage for defaults, valid values, partial numbers, out-of-range ports, decimals, and zero limits

## Bug
Signal bot configuration used `parseInt`, so values such as `SIGNAL_HTTP_PORT=7580abc`, `SESSION_TIMEOUT_MS=10abc`, or `MAX_OUTPUT_LENGTH=1.5` could be partially accepted. The port also lacked a 1-65535 range check, so an invalid port could pass schema validation.

## Validation
- `node "node_modules/.pnpm/vitest@2.1.9_@types+node@22.19.17/node_modules/vitest/vitest.mjs" run packages/bot/signal/src/index.test.ts` passed 7 tests
- `node "node_modules/.pnpm/typescript@5.9.3/node_modules/typescript/lib/tsc.js" -p packages/bot/signal/tsconfig.json --noEmit` is currently blocked locally by ambient type errors for `node:child_process` and `fetch`