### PR TITLE
fix(bots-core): validate integer env limits

### DIFF
--- a/packages/bots/core/src/index.test.ts
+++ b/packages/bots/core/src/index.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { loadAIConfig } from "./index";
+
+describe("loadAIConfig", () => {
+  it("loads positive integer env limits", () => {
+    expect(loadAIConfig({
+      AI_MAX_TURNS: "12",
+      SESSION_TIMEOUT_MS: "60000",
+      MAX_CONCURRENT_SESSIONS: "3",
+    })).toMatchObject({
+      aiMaxTurns: 12,
+      sessionTimeoutMs: 60000,
+      maxConcurrentSessions: 3,
+    });
+  });
+
+  it.each([
+    ["AI_MAX_TURNS", "10abc"],
+    ["SESSION_TIMEOUT_MS", "1.5"],
+    ["MAX_CONCURRENT_SESSIONS", "0"],
+  ])("rejects malformed %s values", (key, value) => {
+    expect(() => loadAIConfig({ [key]: value })).toThrow();
+  });
+});

--- a/packages/bots/core/src/index.ts
+++ b/packages/bots/core/src/index.ts
@@ -197,10 +197,18 @@ export function loadAIConfig(env: Record<string, string | undefined>): AIConfig 
     aiProvider: (env.AI_PROVIDER as any) || "claude-code",
     aiCliPath: env.AI_CLI_PATH || "claude",
     aiModel: env.AI_MODEL,
-    aiMaxTurns: parseInt(env.AI_MAX_TURNS || "10", 10),
-    sessionTimeoutMs: parseInt(env.SESSION_TIMEOUT_MS || "1800000", 10),
-    maxConcurrentSessions: parseInt(env.MAX_CONCURRENT_SESSIONS || "5", 10),
+    aiMaxTurns: parsePositiveIntegerEnv(env.AI_MAX_TURNS, 10),
+    sessionTimeoutMs: parsePositiveIntegerEnv(env.SESSION_TIMEOUT_MS, 1800000),
+    maxConcurrentSessions: parsePositiveIntegerEnv(env.MAX_CONCURRENT_SESSIONS, 5),
   });
+}
+
+function parsePositiveIntegerEnv(value: string | undefined, fallback: number): number {
+  const text = value?.trim();
+  if (!text) return fallback;
+  if (!/^\d+$/.test(text)) return Number.NaN;
+  const parsed = Number(text);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : Number.NaN;
 }
 
 export function chunkMessage(text: string, maxLength = 2000): string[] {


### PR DESCRIPTION
## Summary
- replace partial `parseInt` parsing for `packages/bots/core` env limits with strict positive safe-integer validation
- add focused coverage for valid env limits and malformed values like `10abc`, decimals, and zero

## Validation
- `node ..\sh1pt\node_modules\.pnpm\vitest@2.1.9_@types+node@22.19.17\node_modules\vitest\vitest.mjs run packages\bots\core\src\index.test.ts` passed 4 tests
- `tsc -p packages\bots\core\tsconfig.json --noEmit` is still blocked by existing Node/AbortController ambient type errors in this package, unrelated to this parser change