### PR TITLE
fix(dns-namecheap): ignore invalid ttl values

### DIFF
--- a/packages/dns/namecheap/src/index.test.ts
+++ b/packages/dns/namecheap/src/index.test.ts
@@ -71,6 +71,25 @@ describe('dns-namecheap', () => {
     });
   });
 
+  it('falls back for non-integer TTL values from Namecheap', async () => {
+    await dns.connect(ctx(), {});
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(xmlResponse([
+      host({ HostId: 'sci', Name: 'sci', Type: 'A', Address: '192.0.2.20', TTL: '1e2' }),
+      host({ HostId: 'hex', Name: 'hex', Type: 'A', Address: '192.0.2.21', TTL: '0x10' }),
+      host({ HostId: 'decimal', Name: 'decimal', Type: 'A', Address: '192.0.2.22', TTL: '600.5' }),
+      host({ HostId: 'normal', Name: 'normal', Type: 'A', Address: '192.0.2.23', TTL: '600' }),
+    ]));
+
+    const records = await dns.listRecords('example.com', { defaultTtl: 900 });
+
+    expect(records.map((record) => [record.id, record.ttl])).toEqual([
+      ['sci', 900],
+      ['hex', 900],
+      ['decimal', 900],
+      ['normal', 600],
+    ]);
+  });
+
   it('creates a record via full-zone setHosts while preserving existing records', async () => {
     await dns.connect(ctx(), {});
     const fetchMock = vi.spyOn(globalThis, 'fetch')

--- a/packages/dns/namecheap/src/index.ts
+++ b/packages/dns/namecheap/src/index.ts
@@ -113,16 +113,22 @@ function parseXml(text: string): { ok: boolean; hosts: ParsedHost[]; error?: str
 }
 
 function mapHost(zoneId: string, host: ParsedHost, config: Config): NamecheapRecord {
-  const ttl = Number(host.ttl);
+  const ttl = parseNamecheapTtl(host.ttl);
   return {
     id: host.id,
     zone: zoneId,
     name: normalizeRecordName(zoneId, host.name),
     type: host.type as DnsRecord['type'],
     value: host.address,
-    ttl: Number.isFinite(ttl) && ttl > 0 ? ttl : ttlValue(undefined, config),
+    ttl: ttl ?? ttlValue(undefined, config),
     mxPref: host.mxPref,
   };
+}
+
+function parseNamecheapTtl(ttl: string): number | undefined {
+  if (!/^[1-9]\d*$/.test(ttl)) return undefined;
+  const parsed = Number(ttl);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
 }
 
 function apiParams(command: string, extra: Record<string, string> = {}, config: Config = {}) {


### PR DESCRIPTION
## Summary
- parse Namecheap TTL values as positive safe integers only
- fall back to the configured/default TTL for malformed values such as `1e2`, `0x10`, or `600.5`
- add regression coverage for invalid XML TTL values while preserving normal integer TTLs

## Validation
- `node ..\sh1pt\node_modules\.pnpm\vitest@2.1.9_@types+node@22.19.17\node_modules\vitest\vitest.mjs run packages\dns\namecheap\src\index.test.ts` passed 12 tests
- `tsc -p packages\dns\namecheap\tsconfig.json --noEmit` is still blocked by existing fetch/Response ambient type errors in the package tests/runtime, unrelated to this TTL parser change