### PR TITLE
fix(payment-coinpay): require integer webhook timestamps

### DIFF
--- a/packages/payments/coinpay/src/index.test.ts
+++ b/packages/payments/coinpay/src/index.test.ts
@@ -178,6 +178,22 @@ describe('payment-coinpay', () => {
       {},
     )).rejects.toThrow('Invalid CoinPay webhook signature');
   });
+
+  it('rejects non-integer CoinPay webhook timestamps before signature matching', async () => {
+    const raw = JSON.stringify({ type: 'payment.confirmed' });
+    const timestamp = '1e9';
+    const secret = 'whsec_test';
+    const signature = createHmac('sha256', secret)
+      .update(`${timestamp}.${raw}`)
+      .digest('hex');
+
+    await expect(payment.verifyWebhook(
+      ctx({ COINPAY_WEBHOOK_SECRET: secret }),
+      raw,
+      `t=${timestamp},v1=${signature}`,
+      { webhookToleranceSeconds: 0 },
+    )).rejects.toThrow('CoinPay signature timestamp is invalid');
+  });
 });
 
 function ctx(secrets: Record<string, string>) {

--- a/packages/payments/coinpay/src/index.ts
+++ b/packages/payments/coinpay/src/index.ts
@@ -205,8 +205,8 @@ function verifyCoinPaySignature(
     throw new Error('CoinPay signature missing t or v1');
   }
 
-  const timestampSeconds = Number(timestamp);
-  if (!Number.isFinite(timestampSeconds)) throw new Error('CoinPay signature timestamp is invalid');
+  const timestampSeconds = parseWebhookTimestamp(timestamp);
+  if (timestampSeconds === undefined) throw new Error('CoinPay signature timestamp is invalid');
   if (toleranceSeconds > 0) {
     const age = Math.floor(Date.now() / 1000) - timestampSeconds;
     if (Math.abs(age) > toleranceSeconds) throw new Error('CoinPay webhook signature timestamp outside tolerance');
@@ -230,6 +230,12 @@ function verifyCoinPaySignature(
   if (!valid) {
     throw new Error('Invalid CoinPay webhook signature');
   }
+}
+
+function parseWebhookTimestamp(timestamp: string): number | undefined {
+  if (!/^\d+$/.test(timestamp)) return undefined;
+  const parsed = Number(timestamp);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
 }
 
 function normalizeWebhook(event: CoinPayWebhookEvent): Webhook {


### PR DESCRIPTION
## Summary
- require CoinPay webhook signature timestamps to be plain positive safe-integer seconds
- reject malformed signed timestamps such as `1e9` before tolerance/signature matching
- add regression coverage for a signed malformed timestamp header

## Validation
- `node ..\sh1pt\node_modules\.pnpm\vitest@2.1.9_@types+node@22.19.17\node_modules\vitest\vitest.mjs run packages\payments\coinpay\src\index.test.ts` passed 9 tests
- `tsc -p packages\payments\coinpay\tsconfig.json --noEmit` is still blocked by existing Node/fetch/Response ambient type errors in this package, unrelated to this timestamp parser change