### PR TITLE
fix(dns-digitalocean): validate ttl values

### DIFF
--- a/packages/dns/digitalocean/src/index.test.ts
+++ b/packages/dns/digitalocean/src/index.test.ts
@@ -97,6 +97,24 @@ describe('DigitalOcean DNS API adapter', () => {
     ]);
   });
 
+  it('falls back when DigitalOcean TTL values are not positive safe integers', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+      domain_records: [
+        { id: 10, name: '@', type: 'A', data: '1.2.3.4', ttl: 600.5 },
+        { id: 11, name: 'www', type: 'A', data: '2.2.3.4', ttl: Number.POSITIVE_INFINITY },
+      ],
+      links: {},
+    })));
+
+    await dns.connect(ctx(), {});
+    const records = await dns.listRecords('example.com', { defaultTtl: 900.5 });
+
+    expect(records).toEqual([
+      { id: '10', zone: 'example.com', name: 'example.com', type: 'A', value: '1.2.3.4', ttl: 1800 },
+      { id: '11', zone: 'example.com', name: 'www.example.com', type: 'A', value: '2.2.3.4', ttl: 1800 },
+    ]);
+  });
+
   it('creates a record when no matching name and type exists', async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(jsonResponse({
@@ -131,6 +149,31 @@ describe('DigitalOcean DNS API adapter', () => {
       type: 'A',
       value: '1.2.3.4',
       ttl: 600,
+    });
+  });
+
+  it('does not send fractional TTL values when creating records', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({
+        domain_records: [],
+        links: {},
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        domain_record: { id: 55, name: 'www', type: 'A', data: '1.2.3.4', ttl: 1800 },
+      }, true, 201));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await dns.connect(ctx(), {});
+    await dns.upsertRecord('example.com', {
+      zone: 'example.com',
+      name: 'www.example.com',
+      type: 'A',
+      value: '1.2.3.4',
+      ttl: 600.5,
+    }, { defaultTtl: 1200 });
+
+    expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1].body))).toMatchObject({
+      ttl: 1200,
     });
   });
 

--- a/packages/dns/digitalocean/src/index.ts
+++ b/packages/dns/digitalocean/src/index.ts
@@ -62,8 +62,12 @@ function jsonHeader(): Record<string, string> {
   return { ...authHeader(), 'Content-Type': 'application/json' };
 }
 
+function positiveInteger(value: number | undefined): number | undefined {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 ? value : undefined;
+}
+
 function ttlValue(ttl: number | undefined, config: Config): number {
-  return ttl ?? config.defaultTtl ?? 1800;
+  return positiveInteger(ttl) ?? positiveInteger(config.defaultTtl) ?? 1800;
 }
 
 function pageSize(config: Config): number {
@@ -96,7 +100,7 @@ function mapRecord(zoneId: string, record: DigitalOceanRecord, config: Config): 
     name: normalizeRecordName(zoneId, record.name),
     type: record.type as DnsRecord['type'],
     value: record.data,
-    ttl: record.ttl ?? ttlValue(undefined, config),
+    ttl: ttlValue(record.ttl ?? undefined, config),
   };
 }
 


### PR DESCRIPTION
## Summary
- require DigitalOcean DNS TTLs to be positive safe integers
- fall back to configured/default TTLs for fractional, infinite, or invalid values
- add regression coverage for listed records and record creation payloads

## Tests
- node ..\sh1pt\node_modules\.pnpm\vitest@2.1.9_@types+node@22.19.17\node_modules\vitest\vitest.mjs run packages/dns/digitalocean/src/index.test.ts

Typecheck note: package typecheck is currently blocked by existing ambient type gaps for fetch/RequestInit in this package, unrelated to this TTL validation change.