### PR TITLE
fix(dns-dnsimple): validate ttl values

### DIFF
--- a/packages/dns/dnsimple/src/index.test.ts
+++ b/packages/dns/dnsimple/src/index.test.ts
@@ -89,6 +89,24 @@ describe('DNSimple DNS API adapter', () => {
     ]);
   });
 
+  it('falls back when DNSimple TTL values are not positive safe integers', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+      data: [
+        { id: 10, name: '', type: 'A', content: '1.2.3.4', ttl: 600.5 },
+        { id: 11, name: 'www', type: 'A', content: '2.2.3.4', ttl: Number.POSITIVE_INFINITY },
+      ],
+      pagination: { current_page: 1, total_pages: 1 },
+    })));
+
+    await dns.connect(ctx(), {});
+    const records = await dns.listRecords('example.com', { accountId: '1010', defaultTtl: 900.5 });
+
+    expect(records).toEqual([
+      { id: '10', zone: 'example.com', name: 'example.com', type: 'A', value: '1.2.3.4', ttl: 3600 },
+      { id: '11', zone: 'example.com', name: 'www.example.com', type: 'A', value: '2.2.3.4', ttl: 3600 },
+    ]);
+  });
+
   it('creates a record when no matching name and type exists', async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(jsonResponse({
@@ -123,6 +141,31 @@ describe('DNSimple DNS API adapter', () => {
       type: 'A',
       value: '1.2.3.4',
       ttl: 600,
+    });
+  });
+
+  it('does not send fractional TTL values when creating records', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({
+        data: [],
+        pagination: { current_page: 1, total_pages: 1 },
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        data: { id: 55, name: 'www', type: 'A', content: '1.2.3.4', ttl: 3600 },
+      }, true, 201));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await dns.connect(ctx(), {});
+    await dns.upsertRecord('example.com', {
+      zone: 'example.com',
+      name: 'www.example.com',
+      type: 'A',
+      value: '1.2.3.4',
+      ttl: 600.5,
+    }, { accountId: '1010', defaultTtl: 1200 });
+
+    expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1].body))).toMatchObject({
+      ttl: 1200,
     });
   });
 

--- a/packages/dns/dnsimple/src/index.ts
+++ b/packages/dns/dnsimple/src/index.ts
@@ -65,8 +65,12 @@ function authHeader(): Record<string, string> {
   };
 }
 
+function positiveInteger(value: number | undefined): number | undefined {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 ? value : undefined;
+}
+
 function ttlValue(ttl: number | undefined, config: Config): number {
-  return ttl ?? config.defaultTtl ?? 3600;
+  return positiveInteger(ttl) ?? positiveInteger(config.defaultTtl) ?? 3600;
 }
 
 function pageSize(config: Config): number {
@@ -93,7 +97,7 @@ function mapRecord(zoneId: string, record: DnsimpleRecord, config: Config): DnsR
     name: normalizeRecordName(zoneId, record.name),
     type: record.type as DnsRecord['type'],
     value: record.content,
-    ttl: record.ttl ?? ttlValue(undefined, config),
+    ttl: ttlValue(record.ttl ?? undefined, config),
   };
 }
 


### PR DESCRIPTION
## Summary
- require DNSimple DNS TTLs to be positive safe integers
- fall back to configured/default TTLs for fractional, infinite, or invalid values
- add regression coverage for listed records and record creation payloads

## Tests
- node ..\sh1pt\node_modules\.pnpm\vitest@2.1.9_@types+node@22.19.17\node_modules\vitest\vitest.mjs run packages/dns/dnsimple/src/index.test.ts

Typecheck note: package typecheck is currently blocked by existing ambient type gaps for fetch/RequestInit in this package, unrelated to this TTL validation change.