### PR TITLE
fix(dns-googledns): validate ttl values

### DIFF
--- a/packages/dns/googledns/src/index.test.ts
+++ b/packages/dns/googledns/src/index.test.ts
@@ -26,6 +26,33 @@ describe('Google Cloud DNS adapter', () => {
     vi.unstubAllGlobals();
   });
 
+  it('falls back when Google DNS TTL values are not positive safe integers', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+      rrsets: [
+        {
+          name: 'www.example.com.',
+          type: 'A',
+          ttl: 600.5,
+          rrdatas: ['1.1.1.1'],
+        },
+        {
+          name: 'api.example.com.',
+          type: 'A',
+          ttl: Number.POSITIVE_INFINITY,
+          rrdatas: ['2.2.2.2'],
+        },
+      ],
+    })));
+
+    await dns.connect(ctx(), {});
+    const records = await dns.listRecords('example-zone', { defaultTtl: 900.5 });
+
+    expect(records).toEqual([
+      { id: 'A/www.example.com.', zone: 'example-zone', name: 'www.example.com', type: 'A', value: '1.1.1.1', ttl: 300 },
+      { id: 'A/api.example.com.', zone: 'example-zone', name: 'api.example.com', type: 'A', value: '2.2.2.2', ttl: 300 },
+    ]);
+  });
+
   it('matches existing records when upserting a trailing-dot FQDN', async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(jsonResponse({
@@ -69,5 +96,44 @@ describe('Google Cloud DNS adapter', () => {
       name: 'www.example.com.',
       value: '2.2.2.2',
     });
+  });
+
+  it('does not send fractional TTL values when upserting records', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ rrsets: [] }))
+      .mockResolvedValueOnce(jsonResponse({ id: 'change-1' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await dns.connect(ctx(), {});
+    await dns.upsertRecord('example-zone', {
+      zone: 'example-zone',
+      name: 'www.example.com',
+      type: 'A',
+      value: '2.2.2.2',
+      ttl: 600.5,
+    }, { defaultTtl: 1200 });
+
+    expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1].body))).toMatchObject({
+      additions: [{
+        name: 'www.example.com.',
+        type: 'A',
+        ttl: 1200,
+        rrdatas: ['2.2.2.2'],
+      }],
+    });
+  });
+
+  it('uses a valid default TTL for round-robin records', async () => {
+    await dns.connect(ctx(), {});
+
+    await expect(dns.syncRoundRobin({
+      zoneId: 'example-zone',
+      name: 'api.example.com',
+      ips: ['1.1.1.1', '2.2.2.2'],
+      ttl: 600.5,
+    }, { defaultTtl: 1200 })).resolves.toEqual([
+      { id: 'gcp-rr-0', zone: 'example-zone', name: 'api.example.com', type: 'A', value: '1.1.1.1', ttl: 1200 },
+      { id: 'gcp-rr-1', zone: 'example-zone', name: 'api.example.com', type: 'A', value: '2.2.2.2', ttl: 1200 },
+    ]);
   });
 });

--- a/packages/dns/googledns/src/index.ts
+++ b/packages/dns/googledns/src/index.ts
@@ -25,6 +25,14 @@ function ensureTrailingDot(name: string): string {
   return name.endsWith('.') ? name : `${name}.`;
 }
 
+function positiveInteger(value: number | undefined): number | undefined {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 ? value : undefined;
+}
+
+function ttlValue(ttl: number | undefined, config: Config): number {
+  return positiveInteger(ttl) ?? positiveInteger(config.defaultTtl) ?? 300;
+}
+
 async function getAccessToken(): Promise<string> {
   // Prefer GOOGLE_ACCESS_TOKEN (pre-fetched by caller or CI) for simplicity.
   // For service-account flow, use GOOGLE_APPLICATION_CREDENTIALS path.
@@ -94,7 +102,7 @@ export default defineDns<Config>({
           name,
           type: rs.type as DnsRecord['type'],
           value: val.replace(/\.$/, ''),
-          ttl: rs.ttl,
+          ttl: ttlValue(rs.ttl, config),
         });
       }
     }
@@ -105,7 +113,7 @@ export default defineDns<Config>({
     const token = await getAccessToken();
     const project = config.projectId ?? _secret('GOOGLE_PROJECT_ID');
     if (!project) throw new Error('GOOGLE_PROJECT_ID not set');
-    const ttl = record.ttl ?? config.defaultTtl ?? 300;
+    const ttl = ttlValue(record.ttl, config);
     const name = ensureTrailingDot(record.name);
     const normalizedName = trimTrailingDot(record.name);
 
@@ -171,7 +179,7 @@ export default defineDns<Config>({
   async syncRoundRobin({ zoneId, name, ips, ttl }, config) {
     // Stubbed: shape-only return. Real impl POSTs an atomic change
     // (deletions + additions) to managedZones/${zoneId}/changes.
-    const ttlFinal = ttl ?? config.defaultTtl ?? 300;
+    const ttlFinal = ttlValue(ttl, config);
     return ips.map((ip, i) => ({
       id: `gcp-rr-${i}`,
       zone: zoneId,


### PR DESCRIPTION
## Summary
- require Google Cloud DNS TTLs to be positive safe integers
- fall back to configured/default TTLs for fractional, infinite, or invalid values
- add regression coverage for listed records, upsert payloads, and round-robin fallback output

## Tests
- node ..\sh1pt\node_modules\.pnpm\vitest@2.1.9_@types+node@22.19.17\node_modules\vitest\vitest.mjs run packages/dns/googledns/src/index.test.ts

Typecheck note: package typecheck is currently blocked by existing ambient type gaps for fetch in this package, unrelated to this TTL validation change.