### PR TITLE
fix(dns-azure): validate ttl values

### DIFF
--- a/packages/dns/azure/src/index.test.ts
+++ b/packages/dns/azure/src/index.test.ts
@@ -1,7 +1,102 @@
 import { contractTestDns } from '@profullstack/sh1pt-core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import dns from './index.js';
 
 contractTestDns(dns, {
   sampleConfig: {},
   requiredSecrets: ['AZURE_CLIENT_ID', 'AZURE_CLIENT_SECRET', 'AZURE_TENANT_ID'],
+});
+
+const ctx = (secrets: Record<string, string> = {
+  AZURE_CLIENT_ID: 'azure-client',
+  AZURE_CLIENT_SECRET: 'azure-secret',
+  AZURE_TENANT_ID: 'azure-tenant',
+  AZURE_SUBSCRIPTION_ID: 'azure-subscription',
+  AZURE_RESOURCE_GROUP: 'dns-rg',
+}) => ({
+  secret: (key: string) => secrets[key],
+  log: () => {},
+});
+
+const jsonResponse = (body: unknown, ok = true, status = ok ? 200 : 400) => ({
+  ok,
+  status,
+  json: async () => body,
+});
+
+describe('Azure DNS adapter', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('falls back when Azure DNS TTL values are not positive safe integers', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ access_token: 'azure-token' }))
+      .mockResolvedValueOnce(jsonResponse({ access_token: 'azure-token' }))
+      .mockResolvedValueOnce(jsonResponse({
+        value: [
+          {
+            name: '@',
+            type: 'Microsoft.Network/dnsZones/A',
+            properties: { TTL: 600.5, ARecords: [{ ipv4Address: '1.2.3.4' }] },
+            etag: 'etag-a',
+          },
+          {
+            name: 'www',
+            type: 'Microsoft.Network/dnsZones/CNAME',
+            properties: { TTL: Number.POSITIVE_INFINITY, CNAMERecord: { cname: 'example.net' } },
+            etag: 'etag-cname',
+          },
+        ],
+      }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await dns.connect(ctx(), {});
+    const records = await dns.listRecords('example.com', { defaultTtl: 900.5 });
+
+    expect(records).toEqual([
+      { id: 'etag-a', zone: 'example.com', name: 'example.com', type: 'A', value: '1.2.3.4', ttl: 3600 },
+      { id: 'etag-cname', zone: 'example.com', name: 'www.example.com', type: 'CNAME', value: 'example.net', ttl: 3600 },
+    ]);
+  });
+
+  it('does not send fractional TTL values when upserting records', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ access_token: 'azure-token' }))
+      .mockResolvedValueOnce(jsonResponse({ access_token: 'azure-token' }))
+      .mockResolvedValueOnce(jsonResponse({ etag: 'new-etag' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await dns.connect(ctx(), {});
+    await dns.upsertRecord('example.com', {
+      zone: 'example.com',
+      name: 'www.example.com',
+      type: 'A',
+      value: '1.2.3.4',
+      ttl: 600.5,
+    }, { defaultTtl: 1200 });
+
+    expect(JSON.parse(String(fetchMock.mock.calls[2]?.[1].body))).toEqual({
+      properties: {
+        TTL: 1200,
+        ARecords: [{ ipv4Address: '1.2.3.4' }],
+      },
+    });
+  });
+
+  it('uses a valid default TTL for round-robin records', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ access_token: 'azure-token' })));
+
+    await dns.connect(ctx(), {});
+
+    await expect(dns.syncRoundRobin({
+      zoneId: 'example.com',
+      name: 'api.example.com',
+      ips: ['1.1.1.1', '2.2.2.2'],
+      ttl: 600.5,
+    }, { defaultTtl: 1200 })).resolves.toEqual([
+      { id: 'azure-rr-0', zone: 'example.com', name: 'api.example.com', type: 'A', value: '1.1.1.1', ttl: 1200 },
+      { id: 'azure-rr-1', zone: 'example.com', name: 'api.example.com', type: 'A', value: '2.2.2.2', ttl: 1200 },
+    ]);
+  });
 });

--- a/packages/dns/azure/src/index.ts
+++ b/packages/dns/azure/src/index.ts
@@ -49,6 +49,14 @@ function subRg(config: Config): { sub: string; rg: string } {
   return { sub, rg };
 }
 
+function positiveInteger(value: number | undefined): number | undefined {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 ? value : undefined;
+}
+
+function ttlValue(ttl: number | undefined, config: Config): number {
+  return positiveInteger(ttl) ?? positiveInteger(config.defaultTtl) ?? 3600;
+}
+
 export default defineDns<Config>({
   id: 'dns-azure',
   label: 'Azure DNS',
@@ -93,10 +101,10 @@ export default defineDns<Config>({
       const fqdn = rs.name === '@' ? zoneId : `${rs.name}.${zoneId}`;
       if (rtype === 'A' && rs.properties.ARecords) {
         for (const a of rs.properties.ARecords) {
-          records.push({ id: rs.etag, zone: zoneId, name: fqdn, type: 'A', value: a.ipv4Address, ttl: rs.properties.TTL });
+          records.push({ id: rs.etag, zone: zoneId, name: fqdn, type: 'A', value: a.ipv4Address, ttl: ttlValue(rs.properties.TTL, config) });
         }
       } else if (rtype === 'CNAME' && rs.properties.CNAMERecord) {
-        records.push({ id: rs.etag, zone: zoneId, name: fqdn, type: 'CNAME', value: rs.properties.CNAMERecord.cname, ttl: rs.properties.TTL });
+        records.push({ id: rs.etag, zone: zoneId, name: fqdn, type: 'CNAME', value: rs.properties.CNAMERecord.cname, ttl: ttlValue(rs.properties.TTL, config) });
       }
     }
     return records;
@@ -105,7 +113,7 @@ export default defineDns<Config>({
   async upsertRecord(zoneId, record, config) {
     const token = await getAccessToken();
     const { sub, rg } = subRg(config);
-    const ttl = record.ttl ?? config.defaultTtl ?? 3600;
+    const ttl = ttlValue(record.ttl, config);
     const name = record.name.endsWith(`.${zoneId}`)
       ? record.name.slice(0, -(zoneId.length + 1))
       : record.name === zoneId ? '@' : record.name;
@@ -143,7 +151,7 @@ export default defineDns<Config>({
     //   PUT ${MGMT}/subscriptions/${sub}/resourceGroups/${rg}/providers/
     //     Microsoft.Network/dnsZones/${zoneId}/A/${relName}?api-version=…
     //   body: { properties: { TTL, ARecords: [{ ipv4Address }] } }
-    const ttlFinal = ttl ?? config.defaultTtl ?? 3600;
+    const ttlFinal = ttlValue(ttl, config);
     return ips.map((ip, i) => ({
       id: `azure-rr-${i}`,
       zone: zoneId,


### PR DESCRIPTION
## Summary
- require Azure DNS TTLs to be positive safe integers
- fall back to configured/default TTLs for fractional, infinite, or invalid values
- add regression coverage for listed records, upsert payloads, and round-robin fallback output

## Tests
- node ..\sh1pt\node_modules\.pnpm\vitest@2.1.9_@types+node@22.19.17\node_modules\vitest\vitest.mjs run packages/dns/azure/src/index.test.ts

Typecheck note: package typecheck is currently blocked by existing ambient type gaps for fetch in this package, unrelated to this TTL validation change.