### PR TITLE
fix(telnyx): guard voice timeout env values

### DIFF
--- a/sites/sh1pt.com/lib/telnyx-voice.test.ts
+++ b/sites/sh1pt.com/lib/telnyx-voice.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+import { positiveEnvNumber } from './telnyx-voice';
+
+describe('positiveEnvNumber', () => {
+  it('uses valid positive numeric env values', () => {
+    expect(positiveEnvNumber('12000', 8000)).toBe(12000);
+  });
+
+  it('falls back for malformed, non-finite, and non-positive values', () => {
+    expect(positiveEnvNumber(undefined, 8000)).toBe(8000);
+    expect(positiveEnvNumber('abc', 8000)).toBe(8000);
+    expect(positiveEnvNumber('Infinity', 8000)).toBe(8000);
+    expect(positiveEnvNumber('0', 8000)).toBe(8000);
+    expect(positiveEnvNumber('-1', 8000)).toBe(8000);
+  });
+});

--- a/sites/sh1pt.com/lib/telnyx-voice.ts
+++ b/sites/sh1pt.com/lib/telnyx-voice.ts
@@ -30,6 +30,9 @@ export type NormalizedTelnyxVoiceEvent = {
 
 const API = 'https://api.telnyx.com/v2';
 const DEFAULT_SIGNATURE_TOLERANCE_SECONDS = 300;
+const DEFAULT_GATHER_TIMEOUT_MS = 8000;
+const DEFAULT_GATHER_INTER_DIGIT_TIMEOUT_MS = 3000;
+const DEFAULT_OWNER_DECISION_TIMEOUT_MS = 20000;
 
 export type TelnyxClientState =
   | { role: 'owner_review'; handoffId: string }
@@ -177,8 +180,11 @@ export async function gatherUsingSpeak(callControlId: string, text: string, comm
     language: process.env.TELNYX_VOICE_LANGUAGE ?? 'en-US',
     maximum_digits: 0,
     valid_digits: '',
-    timeout_millis: Number(process.env.TELNYX_GATHER_TIMEOUT_MS ?? 8000),
-    inter_digit_timeout_millis: Number(process.env.TELNYX_GATHER_INTER_DIGIT_TIMEOUT_MS ?? 3000),
+    timeout_millis: positiveEnvNumber(process.env.TELNYX_GATHER_TIMEOUT_MS, DEFAULT_GATHER_TIMEOUT_MS),
+    inter_digit_timeout_millis: positiveEnvNumber(
+      process.env.TELNYX_GATHER_INTER_DIGIT_TIMEOUT_MS,
+      DEFAULT_GATHER_INTER_DIGIT_TIMEOUT_MS,
+    ),
     command_id: commandId(commandTag, 'gather'),
   });
 }
@@ -196,7 +202,10 @@ export async function gatherOwnerDecision(
     minimum_digits: 1,
     maximum_digits: 1,
     valid_digits: '12',
-    timeout_millis: Number(process.env.TELNYX_OWNER_DECISION_TIMEOUT_MS ?? 20000),
+    timeout_millis: positiveEnvNumber(
+      process.env.TELNYX_OWNER_DECISION_TIMEOUT_MS,
+      DEFAULT_OWNER_DECISION_TIMEOUT_MS,
+    ),
     command_id: commandId(commandTag, 'owner-gather'),
     client_state: encodeClientState(clientState),
   });
@@ -360,6 +369,11 @@ function validTimestamp(value: string, toleranceSeconds: number): boolean {
   const parsed = Number(value);
   if (!Number.isFinite(parsed)) return false;
   return Math.abs(Date.now() / 1000 - parsed) <= toleranceSeconds;
+}
+
+export function positiveEnvNumber(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 function transcriptText(payload: Record<string, unknown>): string | undefined {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,8 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['packages/**/src/**/*.test.ts', 'services/**/src/**/*.test.ts'],
-    exclude: ['**/node_modules/**', '**/dist/**', 'boilerplates/**', 'sites/**'],
+    include: [
+      'packages/**/src/**/*.test.ts',
+      'services/**/src/**/*.test.ts',
+      'sites/sh1pt.com/lib/**/*.test.ts',
+    ],
+    exclude: ['**/node_modules/**', '**/dist/**', 'boilerplates/**'],
     passWithNoTests: true,
     // Contract tests never touch the network; nothing should take > 5s.
     testTimeout: 5000,


### PR DESCRIPTION
## Summary
- Guard Telnyx voice gather timeout env parsing against malformed, infinite, zero, and negative values
- Fall back to known-good timeout defaults instead of sending `NaN`/invalid values to Telnyx
- Include sh1pt site lib tests in Vitest so this regression runs in CI

## Why
The Telnyx voice gather payloads used `Number(process.env...)` directly. If an env value is mistyped, JavaScript can produce `NaN`, `Infinity`, or non-positive timeout values that get serialized into the Telnyx request payload instead of falling back to safe defaults.

## Tests
- `node .\\node_modules\\.pnpm\\vitest@2.1.9_@types+node@22.19.17\\node_modules\\vitest\\vitest.mjs run sites/sh1pt.com/lib/telnyx-voice.test.ts` (2 tests passed)
- `git diff --check`

Note: `pnpm exec vitest ...` attempted a dependency install first and was blocked by the repo lockfile policy because `@profullstack/autoblog@0.4.0` has no tarball integrity field. The direct local Vitest invocation above ran the regression without changing versioned files.