### PR TITLE
fix(cloud-atlantic): type dynamic plan fixture keys

### DIFF
--- a/packages/cloud/atlantic/src/index.test.ts
+++ b/packages/cloud/atlantic/src/index.test.ts
@@ -61,7 +61,8 @@ describe('Atlantic.Net cloud adapter', () => {
         return jsonResponse({ error: 'unexpected action' }, { ok: false, status: 400, statusText: 'Bad Request' });
       }
       const response = describePlanResponse();
-      response['describe-planresponse'].plans['0item'] = {
+      const plans: Record<string, Record<string, string>> = response['describe-planresponse'].plans;
+      plans['0item'] = {
         plan_name: 'Negative.4GB',
         display_ram: '4096MB',
         display_disk: '100GB',


### PR DESCRIPTION
## What changed

Type the Atlantic.Net test fixture's dynamic `plans` map before inserting the synthetic negative-price row.

## Why

`describePlanResponse()` infers a closed object shape with the keys `item`, `1item`, `3item`, and `4item`. The negative-price regression test adds `0item`, which works at runtime but fails the package TypeScript check with `TS2551`.

The Atlantic.Net API response is a string-keyed collection, so the fixture now reflects that shape before adding the extra row.

## Impact

This is test-only and does not change production adapter behavior. It restores the Atlantic.Net package typecheck while preserving the negative-price regression coverage.

## Verification

- `pnpm --filter @profullstack/sh1pt-cloud-atlantic typecheck`
- `pnpm exec vitest run packages/cloud/atlantic/src/index.test.ts` — 16 passed
- full repository test baseline — 3,313 passed, 1 skipped
- `git diff --check`
