### PR TITLE
fix(stripe): guard invalid webhook tolerance config

### DIFF
--- a/packages/payments/stripe/src/index.test.ts
+++ b/packages/payments/stripe/src/index.test.ts
@@ -137,6 +137,22 @@ describe('payment-stripe', () => {
       { webhookToleranceSeconds: 0 },
     )).resolves.toMatchObject({ type: 'checkout.session.completed' });
   });
+
+  it('falls back to the default timestamp tolerance for invalid config values', async () => {
+    const raw = JSON.stringify({ type: 'checkout.session.completed' });
+    const secret = 'whsec_test';
+    const timestamp = String(Math.floor(Date.now() / 1000) - 600);
+    const signature = createHmac('sha256', secret)
+      .update(`${timestamp}.${raw}`)
+      .digest('hex');
+
+    await expect(adapter.verifyWebhook(
+      ctx({ STRIPE_WEBHOOK_SECRET: secret }),
+      raw,
+      `t=${timestamp},v1=${signature}`,
+      { webhookToleranceSeconds: Number.NaN },
+    )).rejects.toThrow('Stripe webhook signature timestamp outside tolerance');
+  });
 });
 
 function ctx(secrets: Record<string, string>) {

--- a/packages/payments/stripe/src/index.ts
+++ b/packages/payments/stripe/src/index.ts
@@ -168,6 +168,8 @@ function verifyStripeSignature(
   secret: string,
   toleranceSeconds = 300,
 ): void {
+  const effectiveToleranceSeconds = normalizeWebhookToleranceSeconds(toleranceSeconds);
+
   // Parse all key=value pairs preserving duplicate v1 keys.
   // Stripe sends multiple v1 signatures during webhook secret rotation;
   // Object.fromEntries() would silently drop all but one.
@@ -192,9 +194,9 @@ function verifyStripeSignature(
 
   const timestampSeconds = Number(timestamp);
   if (!Number.isFinite(timestampSeconds)) throw new Error('Stripe-Signature timestamp is invalid');
-  if (toleranceSeconds > 0) {
+  if (effectiveToleranceSeconds > 0) {
     const age = Math.floor(Date.now() / 1000) - timestampSeconds;
-    if (Math.abs(age) > toleranceSeconds) throw new Error('Stripe webhook signature timestamp outside tolerance');
+    if (Math.abs(age) > effectiveToleranceSeconds) throw new Error('Stripe webhook signature timestamp outside tolerance');
   }
 
   const expected = createHmac('sha256', secret)
@@ -215,6 +217,12 @@ function verifyStripeSignature(
   if (!valid) {
     throw new Error('Invalid Stripe webhook signature');
   }
+}
+
+function normalizeWebhookToleranceSeconds(value: number): number {
+  if (value === 0) return 0;
+  if (Number.isFinite(value) && value > 0) return value;
+  return 300;
 }
 
 function normalizeStripeStatus(status: unknown): Webhook['status'] | undefined {


### PR DESCRIPTION
## Summary
- Keep Stripe webhook timestamp tolerance enforcement active when config receives invalid numeric values.
- Preserve the existing explicit `{ webhookToleranceSeconds: 0 }` escape hatch for disabling timestamp checks.
- Add a regression test showing `NaN` falls back to the default tolerance instead of bypassing stale-signature protection.

## Validation
- `git diff --check`

I attempted `pnpm vitest run packages/payments/stripe/src/index.test.ts` and `pnpm --filter @profullstack/sh1pt-payment-stripe typecheck`, but this checkout stops during dependency preparation because the committed lockfile fails the active supply-chain policy: `@profullstack/autoblog@0.4.0` has no tarball integrity field. I did not modify the lockfile; the regression test is included for maintainers' normal CI/runtime.