### PR TITLE
fix(discord): guard integer env config values

### DIFF
--- a/packages/bots/discord/src/index.test.ts
+++ b/packages/bots/discord/src/index.test.ts
@@ -1,4 +1,20 @@
+import { describe, expect, it } from 'vitest';
 import { contractTestBot } from '@profullstack/sh1pt-core/testing';
-import bot from './index.js';
+import bot, { loadConfig } from './index.js';
 
 contractTestBot(bot, { sampleConfig: {}, sampleChannel: '1234567890' });
+
+describe('loadConfig', () => {
+  it('uses safe defaults for invalid positive integer env values', () => {
+    const config = loadConfig({
+      DISCORD_BOT_TOKEN: 'discord-token',
+      SESSION_TIMEOUT_MS: 'not-a-number',
+      MAX_OUTPUT_LENGTH: '0',
+      MAX_CONCURRENT_SESSIONS: '-2',
+    });
+
+    expect(config.sessionTimeoutMs).toBe(1800000);
+    expect(config.maxOutputLength).toBe(2000);
+    expect(config.maxConcurrentSessions).toBe(5);
+  });
+});

--- a/packages/bots/discord/src/index.ts
+++ b/packages/bots/discord/src/index.ts
@@ -154,13 +154,19 @@ export function loadConfig(env: Record<string, string | undefined>): Config {
     aiProvider: (env.AI_PROVIDER as any) || "claude-code",
     aiCliPath: env.AI_CLI_PATH || "claude",
     aiModel: env.AI_MODEL,
-    sessionTimeoutMs: parseInt(env.SESSION_TIMEOUT_MS || "1800000", 10),
-    maxOutputLength: parseInt(env.MAX_OUTPUT_LENGTH || "2000", 10),
-    maxConcurrentSessions: parseInt(env.MAX_CONCURRENT_SESSIONS || "5", 10),
+    sessionTimeoutMs: parsePositiveIntegerEnv(env.SESSION_TIMEOUT_MS, 1800000),
+    maxOutputLength: parsePositiveIntegerEnv(env.MAX_OUTPUT_LENGTH, 2000),
+    maxConcurrentSessions: parsePositiveIntegerEnv(env.MAX_CONCURRENT_SESSIONS, 5),
     allowedUsers: env.ALLOWED_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
     allowedChannels: env.ALLOWED_CHANNELS?.split(",").map((c) => c.trim()).filter(Boolean),
     adminUsers: env.ADMIN_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
   });
+}
+
+function parsePositiveIntegerEnv(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 interface SendableChannel {


### PR DESCRIPTION
## Summary
- Parse Discord bot integer env config through a shared positive-integer helper.
- Fall back to safe defaults when `SESSION_TIMEOUT_MS`, `MAX_OUTPUT_LENGTH`, or `MAX_CONCURRENT_SESSIONS` are invalid, zero, or negative.
- Add a regression test covering invalid env values so Discord config loading remains resilient.

## Validation
- `git diff --check`

I attempted `pnpm vitest run packages/bots/discord/src/index.test.ts` and `pnpm --filter @profullstack/sh1pt-bot-discord typecheck`, but this checkout stops during dependency preparation because the committed lockfile fails the active supply-chain policy: `@profullstack/autoblog@0.4.0` has no tarball integrity field. I did not modify the lockfile; the regression test is included for maintainers' normal CI/runtime.