### PR TITLE
fix(slack): guard invalid timestamp tolerance config

### DIFF
--- a/packages/bots/slack/src/index.test.ts
+++ b/packages/bots/slack/src/index.test.ts
@@ -33,6 +33,10 @@ function captureFetch(responses: Array<{ ok: boolean; ts?: string; error?: strin
 
 function signHeaders(body: string, signingKey = 'synthetic-signing-key'): Record<string, string> {
   const timestamp = String(Math.floor(Date.now() / 1000));
+  return signHeadersAt(body, timestamp, signingKey);
+}
+
+function signHeadersAt(body: string, timestamp: string, signingKey = 'synthetic-signing-key'): Record<string, string> {
   return {
     'x-slack-request-timestamp': timestamp,
     'x-slack-signature': slackSignature(body, timestamp, signingKey),
@@ -193,6 +197,24 @@ describe('Slack bot adapter', () => {
       'x-slack-request-timestamp': String(Math.floor(Date.now() / 1000)),
       'x-slack-signature': 'v0=bad',
     });
+
+    expect(response.status).toBe(401);
+    expect(JSON.parse(response.body)).toEqual({ ok: false, error: 'invalid_signature' });
+    await closeable.close();
+  });
+
+  it('uses the default timestamp tolerance when config contains an invalid value', async () => {
+    const { fetcher } = captureFetch();
+    let server: Server | undefined;
+    const closeable = await bot.register(
+      ctx(),
+      [],
+      { port: 0, fetch: fetcher, timestampToleranceSeconds: Number.NaN, onServerReady: (value) => { server = value; } },
+    );
+    const body = JSON.stringify({ type: 'event_callback', event: { type: 'message', channel: 'C123' } });
+    const staleTimestamp = String(Math.floor(Date.now() / 1000) - 600);
+
+    const response = await post(serverPort(server!), '/slack/events', body, signHeadersAt(body, staleTimestamp));
 
     expect(response.status).toBe(401);
     expect(JSON.parse(response.body)).toEqual({ ok: false, error: 'invalid_signature' });

--- a/packages/bots/slack/src/index.ts
+++ b/packages/bots/slack/src/index.ts
@@ -416,18 +416,28 @@ function verifySlackSignature(
   signingKey: string,
   toleranceSeconds = DEFAULT_TIMESTAMP_TOLERANCE_SECONDS,
 ): boolean {
+  const effectiveToleranceSeconds = normalizeTimestampToleranceSeconds(toleranceSeconds);
   const timestamp = firstHeader(headers["x-slack-request-timestamp"]);
   const signature = firstHeader(headers["x-slack-signature"]);
   if (!timestamp || !signature) return false;
   const timestampNumber = Number(timestamp);
   if (!Number.isFinite(timestampNumber)) return false;
-  if (toleranceSeconds > 0 && Math.abs(Math.floor(Date.now() / 1000) - timestampNumber) > toleranceSeconds) {
+  if (
+    effectiveToleranceSeconds > 0
+    && Math.abs(Math.floor(Date.now() / 1000) - timestampNumber) > effectiveToleranceSeconds
+  ) {
     return false;
   }
   const expected = slackSignature(rawBody, timestamp, signingKey);
   const actual = Buffer.from(signature, "utf8");
   const expectedBuffer = Buffer.from(expected, "utf8");
   return actual.length === expectedBuffer.length && timingSafeEqual(actual, expectedBuffer);
+}
+
+function normalizeTimestampToleranceSeconds(value: number): number {
+  if (value === 0) return 0;
+  if (Number.isFinite(value) && value > 0) return value;
+  return DEFAULT_TIMESTAMP_TOLERANCE_SECONDS;
 }
 
 export function slackSignature(rawBody: string, timestamp: string, signingKey: string): string {


### PR DESCRIPTION
## Summary
- Keep Slack request timestamp validation active when `timestampToleranceSeconds` receives invalid numeric values.
- Preserve the explicit `0` escape hatch for disabling timestamp checks, while falling back to the default 300 seconds for `NaN`, negative, or otherwise invalid values.
- Add a regression test that sends a stale but correctly signed Slack Events request with `Number.NaN` config and expects rejection.

## Validation
- `git diff --check`

I attempted `pnpm vitest run packages/bots/slack/src/index.test.ts` and `pnpm --filter @profullstack/sh1pt-bot-slack typecheck`, but this checkout stops during dependency preparation because the committed lockfile fails the active supply-chain policy: `@profullstack/autoblog@0.4.0` has no tarball integrity field. I did not modify the lockfile; the regression test is included for maintainers' normal CI/runtime.