### PR TITLE
fix(coinpay): guard invalid webhook tolerance config

### DIFF
--- a/packages/payments/coinpay/src/index.test.ts
+++ b/packages/payments/coinpay/src/index.test.ts
@@ -194,6 +194,22 @@ describe('payment-coinpay', () => {
       { webhookToleranceSeconds: 0 },
     )).rejects.toThrow('CoinPay signature timestamp is invalid');
   });
+
+  it('falls back to the default timestamp tolerance for invalid config values', async () => {
+    const raw = JSON.stringify({ type: 'payment.confirmed' });
+    const secret = 'whsec_test';
+    const timestamp = String(Math.floor(Date.now() / 1000) - 600);
+    const signature = createHmac('sha256', secret)
+      .update(`${timestamp}.${raw}`)
+      .digest('hex');
+
+    await expect(payment.verifyWebhook(
+      ctx({ COINPAY_WEBHOOK_SECRET: secret }),
+      raw,
+      `t=${timestamp},v1=${signature}`,
+      { webhookToleranceSeconds: Number.NaN },
+    )).rejects.toThrow('CoinPay webhook signature timestamp outside tolerance');
+  });
 });
 
 function ctx(secrets: Record<string, string>) {

--- a/packages/payments/coinpay/src/index.ts
+++ b/packages/payments/coinpay/src/index.ts
@@ -183,6 +183,8 @@ function verifyCoinPaySignature(
   secret: string,
   toleranceSeconds = 300,
 ): void {
+  const effectiveToleranceSeconds = normalizeWebhookToleranceSeconds(toleranceSeconds);
+
   // Parse all key=value pairs, preserving duplicate keys as arrays.
   // CoinPay can send multiple v1 signatures during secret rotation;
   // using Object.fromEntries() would silently drop all but one.
@@ -207,9 +209,9 @@ function verifyCoinPaySignature(
 
   const timestampSeconds = parseWebhookTimestamp(timestamp);
   if (timestampSeconds === undefined) throw new Error('CoinPay signature timestamp is invalid');
-  if (toleranceSeconds > 0) {
+  if (effectiveToleranceSeconds > 0) {
     const age = Math.floor(Date.now() / 1000) - timestampSeconds;
-    if (Math.abs(age) > toleranceSeconds) throw new Error('CoinPay webhook signature timestamp outside tolerance');
+    if (Math.abs(age) > effectiveToleranceSeconds) throw new Error('CoinPay webhook signature timestamp outside tolerance');
   }
 
   const expected = createHmac('sha256', secret)
@@ -230,6 +232,12 @@ function verifyCoinPaySignature(
   if (!valid) {
     throw new Error('Invalid CoinPay webhook signature');
   }
+}
+
+function normalizeWebhookToleranceSeconds(value: number): number {
+  if (value === 0) return 0;
+  if (Number.isFinite(value) && value > 0) return value;
+  return 300;
 }
 
 function parseWebhookTimestamp(timestamp: string): number | undefined {


### PR DESCRIPTION
## Summary
- Keep CoinPay webhook timestamp tolerance enforcement active when config receives invalid numeric values.
- Preserve the explicit `0` escape hatch for disabling timestamp checks, while falling back to the default 300 seconds for `NaN`, negative, or otherwise invalid values.
- Add a regression test showing stale but correctly signed CoinPay webhooks are rejected when config contains `Number.NaN`.

## Validation
- `git diff --check`

I attempted `pnpm vitest run packages/payments/coinpay/src/index.test.ts` and `pnpm --filter @profullstack/sh1pt-payment-coinpay typecheck`, but this checkout stops during dependency preparation because the committed lockfile fails the active supply-chain policy: `@profullstack/autoblog@0.4.0` has no tarball integrity field. I did not modify the lockfile; the regression test is included for maintainers' normal CI/runtime.