### PR TITLE
fix(telnyx): guard invalid signature tolerance config

### DIFF
--- a/packages/bots/telnyx/src/index.test.ts
+++ b/packages/bots/telnyx/src/index.test.ts
@@ -184,6 +184,45 @@ describe('bot-telnyx webhook behavior', () => {
       await handle.close();
     }
   });
+
+  it('falls back to the default signature tolerance for invalid config values', async () => {
+    const keys = generateKeyPairSync('ed25519');
+    const publicKey = Buffer.from(keys.publicKey.export({ format: 'der', type: 'spki' })).toString('base64');
+    const handler = vi.fn();
+    const handle = await bot.register(ctx(), [{ match: { type: 'message' }, handle: handler }], {
+      from: '+15551234567',
+      webhookPort: 0,
+      publicKey,
+      signatureToleranceSeconds: Number.POSITIVE_INFINITY,
+    }) as { close(): Promise<void>; port: number };
+
+    try {
+      const body = JSON.stringify({
+        data: {
+          event_type: 'message.received',
+          payload: {
+            from: { phone_number: '+15559876543' },
+            text: 'hello',
+          },
+        },
+      });
+      const staleTimestamp = String(Math.floor(Date.now() / 1000) - 600);
+      const response = await fetch(`http://127.0.0.1:${handle.port}/telnyx/messaging`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'telnyx-timestamp': staleTimestamp,
+          'telnyx-signature-ed25519': signature(keys.privateKey, staleTimestamp, body),
+        },
+        body,
+      });
+
+      expect(response.status).toBe(403);
+      expect(handler).not.toHaveBeenCalled();
+    } finally {
+      await handle.close();
+    }
+  });
 });
 
 function ctx() {

--- a/packages/bots/telnyx/src/index.ts
+++ b/packages/bots/telnyx/src/index.ts
@@ -130,7 +130,7 @@ class TelnyxWebhookServer {
     const signature = request.headers['telnyx-signature-ed25519'];
     const timestamp = request.headers['telnyx-timestamp'];
     if (typeof signature !== 'string' || typeof timestamp !== 'string') return false;
-    const tolerance = this.config.signatureToleranceSeconds ?? DEFAULT_SIGNATURE_TOLERANCE_SECONDS;
+    const tolerance = normalizeSignatureToleranceSeconds(this.config.signatureToleranceSeconds);
     if (!validTimestamp(timestamp, tolerance)) return false;
     return verifyTelnyxSignature(publicKey, timestamp, body, signature);
   }
@@ -305,6 +305,12 @@ function validTimestamp(value: string, toleranceSeconds: number): boolean {
   const parsed = Number(value);
   if (!Number.isFinite(parsed)) return false;
   return Math.abs(Date.now() / 1000 - parsed) <= toleranceSeconds;
+}
+
+function normalizeSignatureToleranceSeconds(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_SIGNATURE_TOLERANCE_SECONDS;
+  if (Number.isFinite(value) && value >= 0) return value;
+  return DEFAULT_SIGNATURE_TOLERANCE_SECONDS;
 }
 
 function parseEvent(body: string): TelnyxEvent {


### PR DESCRIPTION
## Summary
- Normalize Telnyx signature tolerance config before using it for webhook timestamp checks.
- Keep the default 300-second replay window when config receives invalid numeric values such as `Infinity`, `NaN`, or negatives.
- Add a regression test showing an old but correctly signed Telnyx webhook is rejected when the configured tolerance is invalid.

## Validation
- `git diff --check`
- `node node_modules\vitest\vitest.mjs run packages/bots/telnyx/src/index.test.ts` (8 tests passed)

I also attempted `pnpm vitest run packages/bots/telnyx/src/index.test.ts` and `pnpm --filter @profullstack/sh1pt-bot-telnyx typecheck`, but this checkout stops during dependency preparation because the committed lockfile fails the active supply-chain policy: `@profullstack/autoblog@0.4.0` has no tarball integrity field. I did not modify the lockfile.