### PR TITLE
fix(worldremit): validate payout inputs

### DIFF
--- a/packages/payments/worldremit/src/index.test.ts
+++ b/packages/payments/worldremit/src/index.test.ts
@@ -1,7 +1,23 @@
 import { smokeTest } from '@profullstack/sh1pt-core/testing';
+import { describe, expect, it } from 'vitest';
 import adapter from './index.js';
 
 // worldremit is a payouts adapter, not a checkout provider — supports[] is
 // intentionally empty (the interface's supports field enumerates buyer-side
 // currencies/methods). requireSupports skipped.
 smokeTest(adapter, { idPrefix: 'payment', requireSupports: false });
+
+describe('payment-worldremit payout validation', () => {
+  it('rejects missing payout recipients before returning a transfer id', async () => {
+    await expect(adapter.payout('   ', 1000, 'USD', {})).rejects.toThrow('recipient accountId is required');
+  });
+
+  it('rejects invalid payout amounts before returning a transfer id', async () => {
+    await expect(adapter.payout('recipient-1', 0, 'USD', {})).rejects.toThrow('positive finite number');
+    await expect(adapter.payout('recipient-1', Number.NaN, 'USD', {})).rejects.toThrow('positive finite number');
+  });
+
+  it('rejects malformed payout currencies before returning a transfer id', async () => {
+    await expect(adapter.payout('recipient-1', 1000, 'US', {})).rejects.toThrow('3-letter ISO code');
+  });
+});

--- a/packages/payments/worldremit/src/index.ts
+++ b/packages/payments/worldremit/src/index.ts
@@ -23,6 +23,10 @@ export default definePayment<Config>({
     return { type: 'unknown', payload: JSON.parse(rawBody) };
   },
   async payout(accountId, amount, currency) {
+    const recipient = accountId.trim();
+    if (!recipient) throw new Error('WorldRemit payout recipient accountId is required');
+    if (!Number.isFinite(amount) || amount <= 0) throw new Error('WorldRemit payout amount must be a positive finite number');
+    if (!/^[a-z]{3}$/i.test(currency)) throw new Error('WorldRemit payout currency must be a 3-letter ISO code');
     // TODO: quote → create transfer → pay via saved funding source
     return { id: `wr_${Date.now()}` };
   },


### PR DESCRIPTION
## Summary
- Validate WorldRemit payout recipient, amount, and currency before returning a transfer id.
- Reject blank recipients, non-positive/non-finite amounts, and malformed currency codes early.
- Add regression coverage so invalid payout requests cannot look like successful transfers.

## Validation
- `git diff --check`
- `node node_modules\vitest\vitest.mjs run packages/payments/worldremit/src/index.test.ts` (5 tests passed)

This checkout's standard pnpm flow is currently blocked during dependency preparation by the committed lockfile policy issue around `@profullstack/autoblog@0.4.0` lacking a tarball integrity field, so I used the already-present Vitest runtime directly and did not modify the lockfile.