### PR TITLE
Validate GitHub repository IDs strictly

### DIFF
--- a/sites/sh1pt.com/app/api/v1/github/installations/[id]/repos/[repoId]/actions/[actionId]/install/route.ts
+++ b/sites/sh1pt.com/app/api/v1/github/installations/[id]/repos/[repoId]/actions/[actionId]/install/route.ts
@@ -7,6 +7,7 @@ import {
 } from '@profullstack/sh1pt-actions-fleet-core';
 import { authorizeInstallation } from '@/lib/github-installation';
 import { mintInstallationToken } from '@/lib/github-app';
+import { parseGithubRepoId } from '@/lib/github-repo-id';
 import { getSupabaseServiceClient } from '@/lib/supabase/service';
 
 export const runtime = 'nodejs';
@@ -34,8 +35,8 @@ export async function POST(
   const auth = await authorizeInstallation(id);
   if (auth instanceof NextResponse) return auth;
 
-  const githubRepoId = Number.parseInt(repoId, 10);
-  if (!Number.isFinite(githubRepoId)) {
+  const githubRepoId = parseGithubRepoId(repoId);
+  if (githubRepoId === null) {
     return NextResponse.json({ error: 'Invalid repo id' }, { status: 400 });
   }
 

--- a/sites/sh1pt.com/lib/github-repo-id.test.ts
+++ b/sites/sh1pt.com/lib/github-repo-id.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { parseGithubRepoId } from './github-repo-id';
+
+describe('parseGithubRepoId', () => {
+  it('parses a positive safe integer', () => {
+    expect(parseGithubRepoId('123456789')).toBe(123456789);
+  });
+
+  it.each(['123abc', '123.5', '-123', '0', '', ' 123', '9007199254740992'])(
+    'rejects invalid repo id %j',
+    (value) => {
+      expect(parseGithubRepoId(value)).toBeNull();
+    },
+  );
+});

--- a/sites/sh1pt.com/lib/github-repo-id.ts
+++ b/sites/sh1pt.com/lib/github-repo-id.ts
@@ -1,0 +1,6 @@
+export function parseGithubRepoId(value: string): number | null {
+  if (!/^[1-9]\d*$/.test(value)) return null;
+
+  const repoId = Number(value);
+  return Number.isSafeInteger(repoId) ? repoId : null;
+}


### PR DESCRIPTION
Closes #879

## Summary

- reject partial, decimal, non-positive, and unsafe GitHub repository IDs
- parse the route parameter only after validating the complete path segment
- add focused regression coverage for valid and malformed IDs

## Testing

- `vitest run sites/sh1pt.com/lib/github-repo-id.test.ts` (8 tests)
- `tsc --strict --noEmit --target ES2022 --module ESNext --moduleResolution Bundler sites/sh1pt.com/lib/github-repo-id.ts`