### PR TITLE
fix: non-null assert payout in worldremit payout validation tests

### DIFF
--- a/packages/payments/worldremit/src/index.test.ts
+++ b/packages/payments/worldremit/src/index.test.ts
@@ -9,15 +9,15 @@ smokeTest(adapter, { idPrefix: 'payment', requireSupports: false });
 
 describe('payment-worldremit payout validation', () => {
   it('rejects missing payout recipients before returning a transfer id', async () => {
-    await expect(adapter.payout('   ', 1000, 'USD', {})).rejects.toThrow('recipient accountId is required');
+    await expect(adapter.payout!('   ', 1000, 'USD', {})).rejects.toThrow('recipient accountId is required');
   });
 
   it('rejects invalid payout amounts before returning a transfer id', async () => {
-    await expect(adapter.payout('recipient-1', 0, 'USD', {})).rejects.toThrow('positive finite number');
-    await expect(adapter.payout('recipient-1', Number.NaN, 'USD', {})).rejects.toThrow('positive finite number');
+    await expect(adapter.payout!('recipient-1', 0, 'USD', {})).rejects.toThrow('positive finite number');
+    await expect(adapter.payout!('recipient-1', Number.NaN, 'USD', {})).rejects.toThrow('positive finite number');
   });
 
   it('rejects malformed payout currencies before returning a transfer id', async () => {
-    await expect(adapter.payout('recipient-1', 1000, 'US', {})).rejects.toThrow('3-letter ISO code');
+    await expect(adapter.payout!('recipient-1', 1000, 'US', {})).rejects.toThrow('3-letter ISO code');
   });
 });


### PR DESCRIPTION
## Bug
`pnpm -r build` fails on `@profullstack/sh1pt-payment-worldremit` with 4× TS2722 (Cannot invoke an object which is possibly undefined) at `src/index.test.ts` lines 12, 16, 17, 21.

`payout()` is optional in the `PaymentProvider` interface, so `adapter.payout(...)` in the tests is typed as possibly-undefined. WorldRemit is a payouts adapter that always implements `payout()`.

## Fix
Use non-null assertion (`adapter.payout!`) in the payout validation tests.

## Verification
- `pnpm --filter @profullstack/sh1pt-payment-worldremit build` → passes
- `npx vitest run packages/payments/worldremit` → 5/5 pass
- `pnpm -r build` → 681 packages done, 0 errors