### PR TITLE
fix: add seedbox to TargetKind union

### DIFF
--- a/packages/core/src/target.ts
+++ b/packages/core/src/target.ts
@@ -20,7 +20,8 @@ export type TargetKind =
   | 'sdk'
   | 'webhook'
   | 'payment'
-  | 'package-manager';
+  | 'package-manager'
+  | 'seedbox';
 
 export type Channel = 'stable' | 'beta' | 'canary' | (string & {});
 


### PR DESCRIPTION
## Bug
`pnpm -r build` fails on `@profullstack/sh1pt-seedbox-bytesized` with TS2322: Type "seedbox" is not assignable to type 'TargetKind'.

Nine seedbox adapters declare `kind: 'seedbox'` but `TargetKind` in `packages/core/src/target.ts` never included 'seedbox', so none of them can build.

## Fix
Add 'seedbox' to the `TargetKind` union.

## Verification
- `pnpm --filter @profullstack/sh1pt-core build` → passes
- `pnpm -r build` → 681 packages done, 0 errors (all 8 seedbox adapters build)