### PR TITLE
fix(bot-telegram): guard published adapter env limits

### DIFF
--- a/packages/bots/telegram/src/index.test.ts
+++ b/packages/bots/telegram/src/index.test.ts
@@ -1,4 +1,33 @@
+import { describe, expect, it } from 'vitest';
 import { contractTestBot } from '@profullstack/sh1pt-core/testing';
-import bot from './index.js';
+import bot, { loadConfig } from './index.js';
 
 contractTestBot(bot, { sampleConfig: {}, sampleChannel: '1234567890' });
+
+describe('loadConfig', () => {
+  it('accepts positive integer env values', () => {
+    const config = loadConfig({
+      TELEGRAM_BOT_TOKEN: 'telegram-token',
+      SESSION_TIMEOUT_MS: '60000',
+      MAX_OUTPUT_LENGTH: '1200',
+      MAX_CONCURRENT_SESSIONS: '3',
+    });
+
+    expect(config.sessionTimeoutMs).toBe(60000);
+    expect(config.maxOutputLength).toBe(1200);
+    expect(config.maxConcurrentSessions).toBe(3);
+  });
+
+  it('uses safe defaults for invalid positive integer env values', () => {
+    const config = loadConfig({
+      TELEGRAM_BOT_TOKEN: 'telegram-token',
+      SESSION_TIMEOUT_MS: '10seconds',
+      MAX_OUTPUT_LENGTH: '1.5',
+      MAX_CONCURRENT_SESSIONS: '0',
+    });
+
+    expect(config.sessionTimeoutMs).toBe(1800000);
+    expect(config.maxOutputLength).toBe(4000);
+    expect(config.maxConcurrentSessions).toBe(5);
+  });
+});

--- a/packages/bots/telegram/src/index.ts
+++ b/packages/bots/telegram/src/index.ts
@@ -103,12 +103,18 @@ export function loadConfig(env: Record<string, string | undefined>): Config {
     aiProvider: (env.AI_PROVIDER as any) || "claude-code",
     aiCliPath: env.AI_CLI_PATH || "claude",
     aiModel: env.AI_MODEL,
-    sessionTimeoutMs: parseInt(env.SESSION_TIMEOUT_MS || "1800000", 10),
-    maxOutputLength: parseInt(env.MAX_OUTPUT_LENGTH || "4000", 10),
-    maxConcurrentSessions: parseInt(env.MAX_CONCURRENT_SESSIONS || "5", 10),
+    sessionTimeoutMs: parsePositiveIntegerEnv(env.SESSION_TIMEOUT_MS, 1800000),
+    maxOutputLength: parsePositiveIntegerEnv(env.MAX_OUTPUT_LENGTH, 4000),
+    maxConcurrentSessions: parsePositiveIntegerEnv(env.MAX_CONCURRENT_SESSIONS, 5),
     allowedUsers: env.ALLOWED_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
     adminUsers: env.ADMIN_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
   });
+}
+
+function parsePositiveIntegerEnv(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 function toBotEvent(msg: IncomingMessage): BotEvent {


### PR DESCRIPTION
## Summary

- replace partial `parseInt` handling in the published Telegram adapter with complete positive safe-integer validation
- fall back to documented defaults for malformed, decimal, zero, negative, or unsafe values
- add regression coverage for valid and invalid runtime-limit environment values

## Root cause and impact

`parseInt` accepts numeric prefixes, so values such as `SESSION_TIMEOUT_MS=10seconds` were silently interpreted as `10`. The public `@profullstack/sh1pt-bot-telegram` package could therefore run with limits different from the deployment configuration's apparent intent.

The new helper validates the complete value and preserves the adapter's existing defaults whenever the value is not a positive safe integer.

## Validation

- `pnpm vitest run packages/bots/telegram/src/index.test.ts` — 5 tests passed
- `pnpm --filter @profullstack/sh1pt-bot-telegram typecheck` — passed
- `pnpm test` — 700 test files passed; 3,351 tests passed; 1 pre-existing test skipped
- `git diff --check` — passed
