### PR TITLE
fix(bot): serialize session queue on process close; decode twitch tags in one pass

### DIFF
--- a/packages/bot/core/src/index.ts
+++ b/packages/bot/core/src/index.ts
@@ -168,6 +168,20 @@ export class SessionManager {
           });
         });
       });
+    } catch (err) {
+      session.busy = false;
+      session.abortController = null;
+      this.processQueue(session);
+      return {
+        type: "result",
+        subtype: "error",
+        is_error: true,
+        result: err instanceof Error ? err.message : String(err),
+        duration_ms: 0,
+        num_turns: 0,
+        session_id: "",
+        total_cost_usd: 0,
+      };
     }
   }
 

--- a/packages/bot/core/src/index.ts
+++ b/packages/bot/core/src/index.ts
@@ -111,12 +111,27 @@ export class SessionManager {
       proc.stderr?.on("data", (chunk) => (stderr += chunk.toString()));
 
       return new Promise((resolve) => {
+        const finish = (result: {
+          type: string;
+          subtype: string;
+          is_error: boolean;
+          result: string;
+          duration_ms: number;
+          num_turns: number;
+          session_id: string;
+          total_cost_usd: number;
+        }) => {
+          session.busy = false;
+          session.abortController = null;
+          resolve(result);
+          this.processQueue(session);
+        };
         proc.on("close", (code) => {
           if (stdout.trim()) {
             try {
               const parsed = JSON.parse(stdout.trim());
               if (parsed.session_id) session.aiSessionId = parsed.session_id;
-              resolve({
+              finish({
                 type: "result",
                 subtype: parsed.is_error ? "error" : "success",
                 is_error: parsed.is_error || false,
@@ -129,7 +144,7 @@ export class SessionManager {
               return;
             } catch {}
           }
-          resolve({
+          finish({
             type: "result",
             subtype: code === 0 ? "success" : "error",
             is_error: code !== 0,
@@ -141,7 +156,7 @@ export class SessionManager {
           });
         });
         proc.on("error", (err) => {
-          resolve({
+          finish({
             type: "result",
             subtype: "error",
             is_error: true,
@@ -153,15 +168,10 @@ export class SessionManager {
           });
         });
       });
-    } finally {
-      session.busy = false;
-      session.abortController = null;
-      this.processQueue(session);
     }
   }
 
-  private processQueue(session: Session): void {
-    if (session.queue.length === 0) return;
+  private processQueue(session: Session): void {    if (session.queue.length === 0) return;
     const next = session.queue.shift()!;
     this.processMessage(session, next.prompt, next.senderName)
       .then(next.resolve)

--- a/packages/bots/core/src/index.ts
+++ b/packages/bots/core/src/index.ts
@@ -168,6 +168,20 @@ export class SessionManager {
           });
         });
       });
+    } catch (err) {
+      session.busy = false;
+      session.abortController = null;
+      this.processQueue(session);
+      return {
+        type: "result",
+        subtype: "error",
+        is_error: true,
+        result: err instanceof Error ? err.message : String(err),
+        duration_ms: 0,
+        num_turns: 0,
+        session_id: "",
+        total_cost_usd: 0,
+      };
     }
   }
 

--- a/packages/bots/core/src/index.ts
+++ b/packages/bots/core/src/index.ts
@@ -111,12 +111,27 @@ export class SessionManager {
       proc.stderr?.on("data", (chunk) => (stderr += chunk.toString()));
 
       return new Promise((resolve) => {
+        const finish = (result: {
+          type: string;
+          subtype: string;
+          is_error: boolean;
+          result: string;
+          duration_ms: number;
+          num_turns: number;
+          session_id: string;
+          total_cost_usd: number;
+        }) => {
+          session.busy = false;
+          session.abortController = null;
+          resolve(result);
+          this.processQueue(session);
+        };
         proc.on("close", (code) => {
           if (stdout.trim()) {
             try {
               const parsed = JSON.parse(stdout.trim());
               if (parsed.session_id) session.aiSessionId = parsed.session_id;
-              resolve({
+              finish({
                 type: "result",
                 subtype: parsed.is_error ? "error" : "success",
                 is_error: parsed.is_error || false,
@@ -129,7 +144,7 @@ export class SessionManager {
               return;
             } catch {}
           }
-          resolve({
+          finish({
             type: "result",
             subtype: code === 0 ? "success" : "error",
             is_error: code !== 0,
@@ -141,7 +156,7 @@ export class SessionManager {
           });
         });
         proc.on("error", (err) => {
-          resolve({
+          finish({
             type: "result",
             subtype: "error",
             is_error: true,
@@ -153,10 +168,6 @@ export class SessionManager {
           });
         });
       });
-    } finally {
-      session.busy = false;
-      session.abortController = null;
-      this.processQueue(session);
     }
   }
 

--- a/packages/bots/twitch/src/index.ts
+++ b/packages/bots/twitch/src/index.ts
@@ -305,12 +305,15 @@ function parseIrcMessage(line: string): IrcMessage {
 }
 
 function unescapeTagValue(value: string): string {
-  return value
-    .replace(/\\s/g, " ")
-    .replace(/\\:/g, ";")
-    .replace(/\\r/g, "\r")
-    .replace(/\\n/g, "\n")
-    .replace(/\\\\/g, "\\");
+  return value.replace(/\\(?:s|:|\r|n|\\)/g, (match) => {
+    switch (match) {
+      case "\\s": return " ";
+      case "\\:": return ";";
+      case "\\r": return "\r";
+      case "\\n": return "\n";
+      default: return "\\";
+    }
+  });
 }
 
 function escapeTagValue(value: string): string {


### PR DESCRIPTION
**Bug 1: Session queue race (HIGH)** — `bot/core` and `bots/core`

`session.busy` was cleared and `processQueue` called in the `finally` block, which runs immediately after `spawn()` — long before the child emits `close`. The next queued message would start a second concurrent AI process against the same `aiSessionId`, interleaving responses and defeating the serialization intent. Fix: clear `busy` and drain the queue only inside the `close`/`error` handlers.

**Bug 2: Twitch IRC tag unescaping (MEDIUM)** — `bots/twitch`

`\\s`-style sequences were decoded before `\\` (escaped backslash), so a literal `\\s` (backslash + s) became `\ ` (backslash + space). Per the IRCv3/Twitch tag spec, decoded in one pass. Fix: single-pass alternation regex.

Part of the ugig bounty workflow. Verified brace/paren balance in both files.