### PR TITLE
fix(discord,dns): count busy sessions; keep FQDN trailing dot for gcloud

### DIFF
--- a/packages/bot/discord/src/session-manager.ts
+++ b/packages/bot/discord/src/session-manager.ts
@@ -72,7 +72,7 @@ export class SessionManager {
     prompt: string,
     senderName: string
   ): Promise<ClaudeResult> {
-    if (this.sessions.size >= this.config.maxConcurrentSessions) {
+    if (this.activeSessions >= this.config.maxConcurrentSessions) {
       throw new Error("Too many concurrent sessions");
     }
 

--- a/packages/bots/discord/src/session-manager.ts
+++ b/packages/bots/discord/src/session-manager.ts
@@ -73,7 +73,7 @@ export class SessionManager {
     prompt: string,
     senderName: string
   ): Promise<ClaudeResult> {
-    if (this.sessions.size >= this.config.maxConcurrentSessions) {
+    if (this.activeSessions >= this.config.maxConcurrentSessions) {
       throw new Error("Too many concurrent sessions");
     }
 

--- a/packages/dns/googledns/src/index.ts
+++ b/packages/dns/googledns/src/index.ts
@@ -101,7 +101,7 @@ export default defineDns<Config>({
           zone: zoneId,
           name,
           type: rs.type as DnsRecord['type'],
-          value: val.replace(/\.$/, ''),
+          value: val,
           ttl: ttlValue(rs.ttl, config),
         });
       }


### PR DESCRIPTION
**Bug: Session guard never prunes (HIGH)** — `bot/discord` + `bots/discord`

The `maxConcurrentSessions` guard used `this.sessions.size`, which counts every session ever created (the Map is never deleted from). After N distinct channels, every new message from a new channel throws 'Too many concurrent sessions' forever. The `activeSessions` getter already exists and counts only busy sessions. Fix: use `activeSessions`.

**Bug: googledns strips FQDN trailing dot (MEDIUM)** — `dns/googledns`

`listRecords` removed the trailing dot from CNAME/NS `rrdatas`, but Google Cloud DNS requires fully-qualified names **with** the trailing dot. `upsertRecord`/`deleteRecord` reused those stripped values in the atomic deletions/additions, so creating or deleting a CNAME/NS was rejected. Fix: keep the FQDN intact in `value`.