### PR TITLE
feat(cli): resolve local build sources for issue #133

### DIFF
--- a/packages/cli/src/commands/build.test.ts
+++ b/packages/cli/src/commands/build.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } from 'node:
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
-import { detectStack, cloneAndDetect } from './build.js';
+import { detectStack, cloneAndDetect, summarizeLocalBuild } from './build.js';
 import type { ResolvedInput } from '../input.js';
 
 describe('detectStack', () => {
@@ -262,5 +262,57 @@ describe('cloneAndDetect', () => {
     // Cleanup
     rmSync(result1.cloneDir, { recursive: true, force: true });
     rmSync(result2.cloneDir, { recursive: true, force: true });
+  });
+});
+
+describe('summarizeLocalBuild', () => {
+  let tempDir: string;
+
+  afterEach(() => {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('resolves a local project and reports its detected stack', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'sh1pt-local-build-'));
+    writeFileSync(join(tempDir, 'package.json'), JSON.stringify({
+      name: 'local-app',
+      packageManager: 'pnpm@9.12.0',
+    }));
+
+    const result = summarizeLocalBuild({
+      kind: 'path',
+      raw: tempDir,
+      value: tempDir,
+      inferredName: 'fallback-name',
+      exists: true,
+    });
+
+    expect(result.sourceDir).toBe(tempDir);
+    expect(result.projectName).toBe('local-app');
+    expect(result.stack?.runtime).toBe('node');
+    expect(result.stack?.packageManager).toBe('pnpm');
+  });
+
+  it('rejects a missing local project path', () => {
+    const missing = join(tmpdir(), 'sh1pt-missing-build-input');
+    expect(() => summarizeLocalBuild({
+      kind: 'path',
+      raw: missing,
+      value: missing,
+      exists: false,
+    })).toThrow('build input path does not exist');
+  });
+
+  it('rejects a file when a directory is required', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'sh1pt-local-build-'));
+    const file = join(tempDir, 'package.json');
+    writeFileSync(file, '{}');
+
+    expect(() => summarizeLocalBuild({
+      kind: 'path',
+      raw: file,
+      value: file,
+      exists: true,
+    })).toThrow('build input path must be a directory');
   });
 });

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { spawnSync } from 'node:child_process';
-import { readFileSync, rmSync, existsSync } from 'node:fs';
+import { readFileSync, rmSync, existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
@@ -111,6 +111,38 @@ export function detectStack(dir: string): DetectedStack | undefined {
   return undefined;
 }
 
+export interface LocalBuildSummary {
+  sourceDir: string;
+  projectName: string;
+  stack: DetectedStack | undefined;
+}
+
+/**
+ * Resolve a local --from path before a build is attempted.
+ *
+ * Keeping this validation separate from the Commander action makes the
+ * behavior reusable by future build backends and gives callers a precise
+ * error instead of silently falling back to the old stub path.
+ */
+export function summarizeLocalBuild(input: ResolvedInput): LocalBuildSummary {
+  if (input.kind !== 'path') {
+    throw new Error(`expected a local path, received ${input.kind}`);
+  }
+  if (!existsSync(input.value)) {
+    throw new Error(`build input path does not exist: ${input.value}`);
+  }
+  if (!statSync(input.value).isDirectory()) {
+    throw new Error(`build input path must be a directory: ${input.value}`);
+  }
+
+  const stack = detectStack(input.value);
+  return {
+    sourceDir: input.value,
+    projectName: stack?.projectName ?? input.inferredName ?? input.value,
+    stack,
+  };
+}
+
 // --- Git clone ---------------------------------------------------------------
 
 export interface CloneResult {
@@ -175,6 +207,19 @@ export const buildCmd = new Command('build')
           rmSync(cloneDir, { recursive: true, force: true });
           console.log(kleur.dim('  (clone removed — use --keep-clone to retain)'));
         }
+        return;
+      }
+
+      if (input.kind === 'path') {
+        const summary = summarizeLocalBuild(input);
+        console.log(kleur.green('[ok] Local source resolved'));
+        console.log();
+        console.log(kleur.bold('Build summary'));
+        console.log(`  project:  ${summary.projectName}`);
+        console.log(`  stack:    ${summary.stack ? `${summary.stack.runtime} (${summary.stack.packageManager ?? 'unknown'})` : 'unknown'}`);
+        console.log(`  channel:  ${opts.channel}`);
+        console.log(`  target:   ${where}`);
+        console.log(`  source:   ${summary.sourceDir}`);
         return;
       }
 


### PR DESCRIPTION
## Summary
- make `sh1pt build --from <local-directory>` validate and resolve a local source instead of falling back to the stub
- report the detected project name, stack, package manager, channel, and target mode
- add focused coverage for valid, missing, and file-path inputs

Closes #133

## Verification
- `node node_modules/vitest/vitest.mjs run packages/cli/src/commands/build.test.ts` (18 tests passed)
- `git diff --check` (passed)
- full TypeScript check was attempted but this isolated worktree lacks the repository's Node type dependency links