### PR TITLE
feat(cli): inspect JSON build manifests for issue #133

### DIFF
--- a/packages/cli/src/commands/build.test.ts
+++ b/packages/cli/src/commands/build.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } from 'node:
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
-import { detectStack, cloneAndDetect } from './build.js';
+import { detectStack, cloneAndDetect, summarizeManifestBuild } from './build.js';
 import type { ResolvedInput } from '../input.js';
 
 describe('detectStack', () => {
@@ -262,5 +262,61 @@ describe('cloneAndDetect', () => {
     // Cleanup
     rmSync(result1.cloneDir, { recursive: true, force: true });
     rmSync(result2.cloneDir, { recursive: true, force: true });
+  });
+});
+
+describe('summarizeManifestBuild', () => {
+  let tempDir: string;
+
+  afterEach(() => {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('summarizes a JSON manifest with object targets', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'sh1pt-json-build-'));
+    const file = join(tempDir, 'manifest.json');
+    writeFileSync(file, JSON.stringify({
+      name: 'demo-app',
+      version: '1.2.3',
+      targets: { 'pkg-npm': {}, 'web-static': {} },
+    }));
+
+    const result = summarizeManifestBuild({
+      kind: 'doc',
+      raw: file,
+      value: file,
+      inferredName: 'fallback-name',
+      exists: true,
+    });
+
+    expect(result.projectName).toBe('demo-app');
+    expect(result.version).toBe('1.2.3');
+    expect(result.targetIds).toEqual(['pkg-npm', 'web-static']);
+  });
+
+  it('rejects malformed JSON with an actionable error', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'sh1pt-json-build-'));
+    const file = join(tempDir, 'manifest.json');
+    writeFileSync(file, '{"name":');
+
+    expect(() => summarizeManifestBuild({
+      kind: 'doc',
+      raw: file,
+      value: file,
+      exists: true,
+    })).toThrow('build manifest is not valid JSON');
+  });
+
+  it('rejects non-JSON manifest documents until their parser is implemented', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'sh1pt-json-build-'));
+    const file = join(tempDir, 'manifest.yaml');
+    writeFileSync(file, 'name: demo-app\n');
+
+    expect(() => summarizeManifestBuild({
+      kind: 'doc',
+      raw: file,
+      value: file,
+      exists: true,
+    })).toThrow('build manifest must be a JSON file');
   });
 });

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { spawnSync } from 'node:child_process';
 import { readFileSync, rmSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, extname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
 import kleur from 'kleur';
@@ -111,6 +111,53 @@ export function detectStack(dir: string): DetectedStack | undefined {
   return undefined;
 }
 
+export interface ManifestBuildSummary {
+  sourceFile: string;
+  projectName: string;
+  version: string | undefined;
+  targetIds: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Parse a JSON manifest supplied to build --from and expose its build shape. */
+export function summarizeManifestBuild(input: ResolvedInput): ManifestBuildSummary {
+  if (input.kind !== 'doc') {
+    throw new Error(`expected a manifest document, received ${input.kind}`);
+  }
+  if (!existsSync(input.value)) {
+    throw new Error(`build manifest does not exist: ${input.value}`);
+  }
+  if (extname(input.value).toLowerCase() !== '.json') {
+    throw new Error(`build manifest must be a JSON file: ${input.value}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(input.value, 'utf8'));
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'invalid JSON';
+    throw new Error(`build manifest is not valid JSON: ${detail}`);
+  }
+  if (!isRecord(parsed)) {
+    throw new Error('build manifest root must be a JSON object');
+  }
+
+  const targetsValue = parsed.targets;
+  const targetIds = Array.isArray(targetsValue)
+    ? targetsValue.filter((target): target is string => typeof target === 'string')
+    : isRecord(targetsValue) ? Object.keys(targetsValue) : [];
+
+  return {
+    sourceFile: input.value,
+    projectName: typeof parsed.name === 'string' ? parsed.name : input.inferredName ?? input.value,
+    version: typeof parsed.version === 'string' ? parsed.version : undefined,
+    targetIds,
+  };
+}
+
 // --- Git clone ---------------------------------------------------------------
 
 export interface CloneResult {
@@ -175,6 +222,20 @@ export const buildCmd = new Command('build')
           rmSync(cloneDir, { recursive: true, force: true });
           console.log(kleur.dim('  (clone removed — use --keep-clone to retain)'));
         }
+        return;
+      }
+
+      if (input.kind === 'doc' && extname(input.value).toLowerCase() === '.json') {
+        const summary = summarizeManifestBuild(input);
+        console.log(kleur.green('[ok] JSON manifest resolved'));
+        console.log();
+        console.log(kleur.bold('Build summary'));
+        console.log(`  project:  ${summary.projectName}`);
+        console.log(`  version:  ${summary.version ?? 'unknown'}`);
+        console.log(`  targets:  ${summary.targetIds.length ? summary.targetIds.join(', ') : 'none declared'}`);
+        console.log(`  channel:  ${opts.channel}`);
+        console.log(`  target:   ${where}`);
+        console.log(`  manifest: ${summary.sourceFile}`);
         return;
       }
 


### PR DESCRIPTION
## Summary
- parse JSON manifests passed through `sh1pt build --from <manifest.json>`
- report project name, version, target ids, channel, and local/cloud mode
- reject missing, malformed, non-object, and non-JSON manifest inputs with actionable errors
- add focused parser coverage

Closes #133

## Verification
- `node node_modules/vitest/vitest.mjs run packages/cli/src/commands/build.test.ts` (18 tests passed)
- `git diff --check` (passed)