### PR TITLE
feat(cli): probe remote build sources for issue #133

### DIFF
--- a/packages/cli/src/commands/build.test.ts
+++ b/packages/cli/src/commands/build.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } from 'node:
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
-import { detectStack, cloneAndDetect } from './build.js';
+import { detectStack, cloneAndDetect, probeRemoteBuild } from './build.js';
 import type { ResolvedInput } from '../input.js';
 
 describe('detectStack', () => {
@@ -262,5 +262,76 @@ describe('cloneAndDetect', () => {
     // Cleanup
     rmSync(result1.cloneDir, { recursive: true, force: true });
     rmSync(result2.cloneDir, { recursive: true, force: true });
+  });
+});
+
+describe('probeRemoteBuild', () => {
+  it('uses HEAD and reports the remote content type', async () => {
+    const methods: string[] = [];
+    const fetcher: typeof fetch = async (_input, init) => {
+      methods.push(init?.method ?? 'GET');
+      return new Response(null, {
+        status: 200,
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      });
+    };
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetcher;
+    try {
+      const result = await probeRemoteBuild({
+        kind: 'url',
+        raw: 'https://example.com/app',
+        value: 'https://example.com/app',
+        inferredName: 'app',
+      });
+      expect(result.status).toBe(200);
+      expect(result.contentType).toBe('text/html; charset=utf-8');
+      expect(methods).toEqual(['HEAD']);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('falls back to a range GET when HEAD is unsupported', async () => {
+    const requests: RequestInit[] = [];
+    const fetcher: typeof fetch = async (_input, init) => {
+      requests.push(init ?? {});
+      if (requests.length === 1) return new Response(null, { status: 405 });
+      return new Response(null, {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    };
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetcher;
+    try {
+      const result = await probeRemoteBuild({
+        kind: 'url',
+        raw: 'https://example.com/manifest.json',
+        value: 'https://example.com/manifest.json',
+      });
+      expect(result.status).toBe(200);
+      expect(requests.map((request) => request.method)).toEqual(['HEAD', 'GET']);
+      expect(requests[1]?.headers).toEqual({ Range: 'bytes=0-0' });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('fails with the HTTP status when the source is unavailable', async () => {
+    const fetcher: typeof fetch = async () => new Response(null, { status: 404 });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetcher;
+    try {
+      await expect(probeRemoteBuild({
+        kind: 'url',
+        raw: 'https://example.com/missing',
+        value: 'https://example.com/missing',
+      })).rejects.toThrow('build source returned HTTP 404');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -111,6 +111,39 @@ export function detectStack(dir: string): DetectedStack | undefined {
   return undefined;
 }
 
+export interface RemoteBuildSummary {
+  sourceUrl: string;
+  finalUrl: string;
+  status: number;
+  contentType: string | undefined;
+}
+
+/** Probe a live --from URL without downloading its response body. */
+export async function probeRemoteBuild(input: ResolvedInput): Promise<RemoteBuildSummary> {
+  if (input.kind !== 'url') {
+    throw new Error(`expected a live URL, received ${input.kind}`);
+  }
+
+  let response = await fetch(input.value, { method: 'HEAD', redirect: 'follow' });
+  if (response.status === 405 || response.status === 501) {
+    response = await fetch(input.value, {
+      method: 'GET',
+      headers: { Range: 'bytes=0-0' },
+      redirect: 'follow',
+    });
+  }
+  if (!response.ok) {
+    throw new Error(`build source returned HTTP ${response.status}: ${input.value}`);
+  }
+
+  return {
+    sourceUrl: input.value,
+    finalUrl: response.url || input.value,
+    status: response.status,
+    contentType: response.headers.get('content-type') ?? undefined,
+  };
+}
+
 // --- Git clone ---------------------------------------------------------------
 
 export interface CloneResult {
@@ -153,7 +186,7 @@ export const buildCmd = new Command('build')
   .option('--cloud', 'run build in sh1pt cloud instead of locally')
   .option('--from <input>', 'existing git repo, live url, local path, or manifest doc to build from')
   .option('--keep-clone', 'keep the cloned repo instead of cleaning up after build')
-  .action((opts: { target?: string[]; channel: string; cloud?: boolean; from?: string; keepClone?: boolean }) => {
+  .action(async (opts: { target?: string[]; channel: string; cloud?: boolean; from?: string; keepClone?: boolean }) => {
     const targets = opts.target?.join(', ') ?? 'all enabled';
     const where = opts.cloud ? 'cloud' : 'local';
     if (opts.from) {
@@ -175,6 +208,20 @@ export const buildCmd = new Command('build')
           rmSync(cloneDir, { recursive: true, force: true });
           console.log(kleur.dim('  (clone removed — use --keep-clone to retain)'));
         }
+        return;
+      }
+
+      if (input.kind === 'url') {
+        const summary = await probeRemoteBuild(input);
+        console.log(kleur.green('[ok] Remote source reachable'));
+        console.log();
+        console.log(kleur.bold('Build summary'));
+        console.log(`  project:  ${input.inferredName ?? summary.finalUrl}`);
+        console.log(`  status:   ${summary.status}`);
+        console.log(`  type:     ${summary.contentType ?? 'unknown'}`);
+        console.log(`  channel:  ${opts.channel}`);
+        console.log(`  target:   ${where}`);
+        console.log(`  source:   ${summary.finalUrl}`);
         return;
       }
 


### PR DESCRIPTION
## Summary
- probe URL build sources with a lightweight HEAD request
- fall back to a one-byte ranged GET when HEAD is unsupported
- report status, content type, final URL, channel, and target without downloading the source

Closes #133

## Verification
- Vitest build.test.ts: 18 tests passed
- git diff --check