### PR TITLE
feat(cli): implement promote status snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ sh1pt ship target add|remove|list|available
 sh1pt promote [--platform X] [--budget N] [--duration 7d] [--objective install] [--dry-run]
 
 sh1pt promote setup [--platform id] [--poll]   # org + ad account + funding + OAuth
-sh1pt promote status [--platform id] [--json]  # aggregated spend / impressions / installs
+sh1pt promote status [--platform id] [--json] [--file path]  # aggregated spend / impressions / installs
 sh1pt promote stop [--platform id]
 sh1pt promote creatives
 ```

--- a/README.md
+++ b/README.md
@@ -430,6 +430,8 @@ sh1pt promote stop [--platform id]
 sh1pt promote creatives
 ```
 
+`promote status` is read-only and aggregates the local `.sh1pt/campaigns.json` snapshot. Use `--file <path>` to inspect a different snapshot; it never launches or changes a campaign.
+
 Publishing alone is table stakes. `promote` closes the loop — one command runs install / traffic / awareness campaigns on Reddit, Meta, TikTok, Google, YouTube, X, Apple Search, LinkedIn, and Microsoft Ads at once.
 
 For launch surfaces like **Product Hunt**, sh1pt can prepare the launch workflow and metadata, but the final submission still runs through browser/manual steps to stay aligned with platform rules.

--- a/packages/cli/src/commands/promote.test.ts
+++ b/packages/cli/src/commands/promote.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { parseNonNegativeInteger, parsePositiveInteger } from './promote.js';
+import {
+  aggregateCampaignStatus,
+  loadCampaignSnapshots,
+  parseNonNegativeInteger,
+  parsePositiveInteger,
+} from './promote.js';
 
 describe('promote numeric option parsers', () => {
   it('accepts decimal positive integers', () => {
@@ -24,4 +29,39 @@ describe('promote numeric option parsers', () => {
       expect(() => parseNonNegativeInteger(value)).toThrow('zero or a positive integer');
     },
   );
+});
+
+describe('promote campaign status', () => {
+  it('aggregates metrics and state counts by platform', () => {
+    const report = aggregateCampaignStatus([
+      { id: 'a', platform: 'reddit', state: 'active', spend: 12.5, impressions: 100, clicks: 8, installs: 2, conversions: 1 },
+      { id: 'b', platform: 'reddit', state: 'paused', spend: 2.5, impressions: 20, clicks: 2, installs: 0, conversions: 0 },
+      { id: 'c', platform: 'meta', state: 'pending', spend: 0, impressions: 0, clicks: 0, installs: 0, conversions: 0 },
+    ]);
+
+    expect(report.platforms).toEqual([
+      {
+        platform: 'meta', campaigns: 1, spend: 0, impressions: 0, clicks: 0, installs: 0, conversions: 0,
+        states: { pending: 1, active: 0, paused: 0, ended: 0, failed: 0, rejected: 0 },
+      },
+      {
+        platform: 'reddit', campaigns: 2, spend: 15, impressions: 120, clicks: 10, installs: 2, conversions: 1,
+        states: { pending: 0, active: 1, paused: 1, ended: 0, failed: 0, rejected: 0 },
+      },
+    ]);
+    expect(report.totals).toEqual({ campaigns: 3, spend: 15, impressions: 120, clicks: 10, installs: 2, conversions: 1 });
+  });
+
+  it('filters the aggregate without mutating the snapshot', () => {
+    const campaigns = [
+      { id: 'a', platform: 'reddit', state: 'active' as const, spend: 1, impressions: 2, clicks: 3, installs: 4, conversions: 5 },
+      { id: 'b', platform: 'meta', state: 'ended' as const, spend: 6, impressions: 7, clicks: 8, installs: 9, conversions: 10 },
+    ];
+    expect(aggregateCampaignStatus(campaigns, 'meta').totals).toEqual({ campaigns: 1, spend: 6, impressions: 7, clicks: 8, installs: 9, conversions: 10 });
+    expect(campaigns).toHaveLength(2);
+  });
+
+  it('returns an empty list for missing or malformed snapshots', () => {
+    expect(loadCampaignSnapshots('missing-campaigns.json')).toEqual([]);
+  });
 });

--- a/packages/cli/src/commands/promote.test.ts
+++ b/packages/cli/src/commands/promote.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import {
   aggregateCampaignStatus,
   loadCampaignSnapshots,
@@ -61,7 +64,18 @@ describe('promote campaign status', () => {
     expect(campaigns).toHaveLength(2);
   });
 
-  it('returns an empty list for missing or malformed snapshots', () => {
+  it('returns an empty list for a missing snapshot', () => {
     expect(loadCampaignSnapshots('missing-campaigns.json')).toEqual([]);
+  });
+
+  it('returns an empty list for malformed JSON', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'sh1pt-promote-status-'));
+    const filePath = join(directory, 'campaigns.json');
+    writeFileSync(filePath, '{ not valid json');
+    try {
+      expect(loadCampaignSnapshots(filePath)).toEqual([]);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -220,8 +220,11 @@ promoteCmd
     }
     console.log(kleur.bold('Campaign status'));
     console.log(kleur.dim(`Source: ${opts.file}`));
-    if (campaigns.length === 0) {
-      console.log(kleur.yellow('No campaign snapshot found. Launch a campaign or sync .sh1pt/campaigns.json first.'));
+    if (report.totals.campaigns === 0) {
+      const message = campaigns.length === 0
+        ? 'No campaign snapshot found. Launch a campaign or sync .sh1pt/campaigns.json first.'
+        : `No campaigns matched platform filter: ${opts.platform}`;
+      console.log(kleur.yellow(message));
       return;
     }
     for (const summary of report.platforms) {

--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -1,6 +1,8 @@
 import { Command, InvalidArgumentError } from 'commander';
 import kleur from 'kleur';
 import prompts from 'prompts';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import {
   runSetup,
   type AdapterWithSetup,
@@ -19,6 +21,133 @@ import {
   runBlueskySocialFollow,
   type SocialFollowAction,
 } from '../social-follow.js';
+
+export type CampaignState = 'pending' | 'active' | 'paused' | 'ended' | 'failed' | 'rejected';
+
+export interface CampaignSnapshot {
+  id: string;
+  platform: string;
+  state: CampaignState;
+  spend: number;
+  impressions: number;
+  clicks: number;
+  installs: number;
+  conversions: number;
+}
+
+export interface CampaignPlatformSummary {
+  platform: string;
+  campaigns: number;
+  spend: number;
+  impressions: number;
+  clicks: number;
+  installs: number;
+  conversions: number;
+  states: Record<CampaignState, number>;
+}
+
+export interface CampaignStatusReport {
+  platforms: CampaignPlatformSummary[];
+  totals: Omit<CampaignPlatformSummary, 'platform' | 'states'>;
+}
+
+export const DEFAULT_CAMPAIGN_SNAPSHOT = resolve('.sh1pt', 'campaigns.json');
+
+const CAMPAIGN_STATES: CampaignState[] = ['pending', 'active', 'paused', 'ended', 'failed', 'rejected'];
+
+function finiteNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function campaignState(value: unknown): CampaignState {
+  return typeof value === 'string' && CAMPAIGN_STATES.includes(value as CampaignState)
+    ? value as CampaignState
+    : 'pending';
+}
+
+function normalizeCampaign(value: unknown): CampaignSnapshot | null {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Record<string, unknown>;
+  if (typeof raw.id !== 'string' || typeof raw.platform !== 'string') return null;
+  return {
+    id: raw.id,
+    platform: raw.platform,
+    state: campaignState(raw.state),
+    spend: finiteNumber(raw.spend),
+    impressions: finiteNumber(raw.impressions),
+    clicks: finiteNumber(raw.clicks),
+    installs: finiteNumber(raw.installs),
+    conversions: finiteNumber(raw.conversions),
+  };
+}
+
+export function loadCampaignSnapshots(filePath = DEFAULT_CAMPAIGN_SNAPSHOT): CampaignSnapshot[] {
+  if (!existsSync(filePath)) return [];
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(filePath, 'utf8'));
+    const entries = Array.isArray(parsed)
+      ? parsed
+      : parsed && typeof parsed === 'object' && Array.isArray((parsed as { campaigns?: unknown }).campaigns)
+        ? (parsed as { campaigns: unknown[] }).campaigns
+        : [];
+    return entries.map(normalizeCampaign).filter((entry): entry is CampaignSnapshot => entry !== null);
+  } catch {
+    return [];
+  }
+}
+
+function emptyStates(): Record<CampaignState, number> {
+  return Object.fromEntries(CAMPAIGN_STATES.map((state) => [state, 0])) as Record<CampaignState, number>;
+}
+
+export function aggregateCampaignStatus(
+  campaigns: CampaignSnapshot[],
+  platform?: string,
+): CampaignStatusReport {
+  const selected = platform ? campaigns.filter((campaign) => campaign.platform === platform) : campaigns;
+  const byPlatform = new Map<string, CampaignPlatformSummary>();
+  const totals: CampaignStatusReport['totals'] = {
+    campaigns: 0,
+    spend: 0,
+    impressions: 0,
+    clicks: 0,
+    installs: 0,
+    conversions: 0,
+  };
+
+  for (const campaign of selected) {
+    const summary = byPlatform.get(campaign.platform) ?? {
+      platform: campaign.platform,
+      campaigns: 0,
+      spend: 0,
+      impressions: 0,
+      clicks: 0,
+      installs: 0,
+      conversions: 0,
+      states: emptyStates(),
+    };
+    summary.campaigns += 1;
+    summary.spend += campaign.spend;
+    summary.impressions += campaign.impressions;
+    summary.clicks += campaign.clicks;
+    summary.installs += campaign.installs;
+    summary.conversions += campaign.conversions;
+    summary.states[campaign.state] += 1;
+    byPlatform.set(campaign.platform, summary);
+
+    totals.campaigns += 1;
+    totals.spend += campaign.spend;
+    totals.impressions += campaign.impressions;
+    totals.clicks += campaign.clicks;
+    totals.installs += campaign.installs;
+    totals.conversions += campaign.conversions;
+  }
+
+  return {
+    platforms: [...byPlatform.values()].sort((a, b) => a.platform.localeCompare(b.platform)),
+    totals,
+  };
+}
 
 export const promoteCmd = new Command('promote')
   .description('Run ads + ship swag + list in affiliate marketplaces. Reddit, Meta, TikTok, Google, YouTube, X, Apple Search, LinkedIn, Microsoft — plus Printful/Printify merch and CJ/Rakuten/Impact/etc affiliate programs.')
@@ -78,15 +207,32 @@ promoteCmd
 
 promoteCmd
   .command('status')
-  .description('Aggregated metrics across active campaigns')
+  .description('Aggregated metrics across campaigns in the local snapshot')
   .option('--platform <id>', 'filter to one platform')
   .option('--json', 'machine-readable output')
-  .action((opts: { platform?: string; json?: boolean }) => {
+  .option('--file <path>', 'campaign snapshot path', DEFAULT_CAMPAIGN_SNAPSHOT)
+  .action((opts: { platform?: string; json?: boolean; file: string }) => {
+    const campaigns = loadCampaignSnapshots(opts.file);
+    const report = aggregateCampaignStatus(campaigns, opts.platform);
     if (opts.json) {
-      console.log(JSON.stringify({ platforms: [], totals: { spend: 0, impressions: 0, clicks: 0, installs: 0 } }, null, 2));
+      console.log(JSON.stringify({ source: opts.file, ...report }, null, 2));
       return;
     }
-    console.log(kleur.dim(`[stub] promote status · platform=${opts.platform ?? 'all'}`));
+    console.log(kleur.bold('Campaign status'));
+    console.log(kleur.dim(`Source: ${opts.file}`));
+    if (campaigns.length === 0) {
+      console.log(kleur.yellow('No campaign snapshot found. Launch a campaign or sync .sh1pt/campaigns.json first.'));
+      return;
+    }
+    for (const summary of report.platforms) {
+      const states = Object.entries(summary.states)
+        .filter(([, count]) => count > 0)
+        .map(([state, count]) => `${state}=${count}`)
+        .join(', ');
+      console.log(`  ${kleur.cyan(summary.platform.padEnd(16))} ${summary.campaigns} campaigns  ${states}`);
+      console.log(`    spend=$${summary.spend.toFixed(2)}  impressions=${summary.impressions}  clicks=${summary.clicks}  installs=${summary.installs}  conversions=${summary.conversions}`);
+    }
+    console.log(kleur.bold(`Totals: ${report.totals.campaigns} campaigns  spend=$${report.totals.spend.toFixed(2)}  impressions=${report.totals.impressions}  clicks=${report.totals.clicks}  installs=${report.totals.installs}  conversions=${report.totals.conversions}`));
   });
 
 promoteCmd


### PR DESCRIPTION
Closes #890

Implements the first focused slice for `sh1pt promote status`:

- reads a local `.sh1pt/campaigns.json` snapshot (or `--file <path>`);
- normalizes malformed/missing numeric fields without crashing;
- aggregates spend, impressions, clicks, installs, conversions, and state counts by platform;
- supports `--platform` filtering and machine-readable `--json` output;
- provides a clear human-readable empty state;
- remains read-only and never launches or changes campaigns.

Verification:
- `promote.test.ts`: 22 tests passed;
- `git diff --check`: passed;
- full `pnpm --dir packages/cli typecheck` was blocked before compilation by the repository lockfile policy because `@profullstack/autoblog@0.4.0` has no integrity field.