### PR TITLE
fix(cli): fail when commands cannot start

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -7,18 +7,13 @@ import { randomBytes } from 'node:crypto';
 import kleur from 'kleur';
 import { describeInput, resolveInput } from '../input.js';
 import type { ResolvedInput } from '../input.js';
+import { runCommand } from '../run-command.js';
 import { entityCmd } from './entity.js';
 import { createActionsCmd } from './build-actions.js';
 
 function run(argv: string[], env?: Record<string, string>): number {
   console.log(kleur.cyan(`→ ${argv.join(' ')}`));
-  const [cmd, ...rest] = argv;
-  if (!cmd) throw new Error('empty command');
-  const r = spawnSync(cmd, rest, {
-    stdio: 'inherit',
-    env: env ? { ...process.env, ...env } : process.env,
-  });
-  return r.status ?? 0;
+  return runCommand(argv, env);
 }
 
 // --- Stack detection ---------------------------------------------------------

--- a/packages/cli/src/commands/self.ts
+++ b/packages/cli/src/commands/self.ts
@@ -6,20 +6,17 @@
 // `bun install -g`, `aube add -g`, or `deno install`.
 
 import { Command } from 'commander';
-import { spawnSync } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import kleur from 'kleur';
 import prompts from 'prompts';
 import { detectPackageManager } from '../installer.js';
+import { runCommand } from '../run-command.js';
 
 const PKG = '@profullstack/sh1pt';
 
 function run(argv: string[]): number {
   console.log(kleur.cyan(`→ ${argv.join(' ')}`));
-  const [cmd, ...rest] = argv;
-  if (!cmd) throw new Error('empty command');
-  const r = spawnSync(cmd, rest, { stdio: 'inherit' });
-  return r.status ?? 0;
+  return runCommand(argv);
 }
 
 export const updateCmd = new Command('update')

--- a/packages/cli/src/run-command.test.ts
+++ b/packages/cli/src/run-command.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { runCommand } from './run-command.js';
+
+describe('runCommand', () => {
+  it('returns a failure code when the executable cannot be started', () => {
+    expect(runCommand(['missing-sh1pt-command-for-test'])).toBe(1);
+  });
+
+  it('returns the child process exit code', () => {
+    expect(runCommand([process.execPath, '-e', 'process.exit(7)'])).toBe(7);
+  });
+});

--- a/packages/cli/src/run-command.ts
+++ b/packages/cli/src/run-command.ts
@@ -1,0 +1,18 @@
+import { spawnSync } from 'node:child_process';
+
+export function runCommand(argv: string[], env?: Record<string, string>): number {
+  const [command, ...args] = argv;
+  if (!command) throw new Error('empty command');
+
+  const result = spawnSync(command, args, {
+    stdio: 'inherit',
+    env: env ? { ...process.env, ...env } : process.env,
+  });
+
+  if (result.error) {
+    console.error(`Failed to start ${command}: ${result.error.message}`);
+    return 1;
+  }
+
+  return result.status ?? 1;
+}


### PR DESCRIPTION
## Summary

- centralize CLI child-process exit handling in a dependency-free helper
- return a failure code when `spawnSync` reports an error or null status
- use the helper for self-management and maintainer command wrappers so cleanup cannot follow a command that never started
- add regressions for missing executables and child exit-code propagation

## Tests

- focused command-runner tests: 2 passed
- `git diff --check`: passed

Closes #898