### PR TITLE
fix(cli): fail when package manager cannot spawn

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -9,16 +9,11 @@ import { describeInput, resolveInput } from '../input.js';
 import type { ResolvedInput } from '../input.js';
 import { entityCmd } from './entity.js';
 import { createActionsCmd } from './build-actions.js';
+import { runShellCommand } from './run-shell.js';
 
 function run(argv: string[], env?: Record<string, string>): number {
   console.log(kleur.cyan(`→ ${argv.join(' ')}`));
-  const [cmd, ...rest] = argv;
-  if (!cmd) throw new Error('empty command');
-  const r = spawnSync(cmd, rest, {
-    stdio: 'inherit',
-    env: env ? { ...process.env, ...env } : process.env,
-  });
-  return r.status ?? 0;
+  return runShellCommand(argv, env);
 }
 
 // --- Stack detection ---------------------------------------------------------

--- a/packages/cli/src/commands/run-shell.test.ts
+++ b/packages/cli/src/commands/run-shell.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { runShellCommand } from './run-shell.js';
+
+vi.mock('node:child_process', () => ({
+  spawnSync: vi.fn(),
+}));
+
+describe('runShellCommand', () => {
+  beforeEach(() => {
+    vi.mocked(spawnSync).mockReset();
+  });
+
+  it('returns the process exit status', () => {
+    vi.mocked(spawnSync).mockReturnValue({ status: 3, error: undefined } as never);
+
+    expect(runShellCommand(['pnpm', 'remove', '-g', '@profullstack/sh1pt'])).toBe(3);
+  });
+
+  it('fails when the executable cannot be spawned', () => {
+    vi.mocked(spawnSync).mockReturnValue({ status: null, error: new Error('not found') } as never);
+
+    expect(runShellCommand(['missing-sh1pt-command-for-test'])).toBe(1);
+  });
+
+  it('fails when spawnSync reports a null status without an error', () => {
+    vi.mocked(spawnSync).mockReturnValue({ status: null, error: undefined } as never);
+
+    expect(runShellCommand(['missing-sh1pt-command-for-test'])).toBe(1);
+  });
+});

--- a/packages/cli/src/commands/run-shell.ts
+++ b/packages/cli/src/commands/run-shell.ts
@@ -1,0 +1,14 @@
+import { spawnSync } from 'node:child_process';
+
+export function runShellCommand(argv: string[], env?: Record<string, string>): number {
+  const [cmd, ...rest] = argv;
+  if (!cmd) throw new Error('empty command');
+
+  const result = spawnSync(cmd, rest, {
+    stdio: 'inherit',
+    env: env ? { ...process.env, ...env } : process.env,
+  });
+
+  // Node reports a spawn failure with an error and a null status. Neither is success.
+  return result.error || result.status === null ? 1 : result.status;
+}

--- a/packages/cli/src/commands/self.ts
+++ b/packages/cli/src/commands/self.ts
@@ -6,20 +6,17 @@
 // `bun install -g`, `aube add -g`, or `deno install`.
 
 import { Command } from 'commander';
-import { spawnSync } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import kleur from 'kleur';
 import prompts from 'prompts';
 import { detectPackageManager } from '../installer.js';
+import { runShellCommand } from './run-shell.js';
 
 const PKG = '@profullstack/sh1pt';
 
 function run(argv: string[]): number {
   console.log(kleur.cyan(`→ ${argv.join(' ')}`));
-  const [cmd, ...rest] = argv;
-  if (!cmd) throw new Error('empty command');
-  const r = spawnSync(cmd, rest, { stdio: 'inherit' });
-  return r.status ?? 0;
+  return runShellCommand(argv);
 }
 
 export const updateCmd = new Command('update')


### PR DESCRIPTION
Fixes #898.

The CLI wrappers now return a non-zero status when `spawnSync` reports a spawn error or a null exit status. This prevents `update`, `remove`, `publish`, and related flows from treating a command that never started as successful, including the dangerous config-cleanup path in `sh1pt remove`.

Changes:
- share the shell execution behavior between `commands/build.ts` and `commands/self.ts`
- add regression tests for non-zero exits, spawn errors, and null statuses

Validation:
- `git diff --check` passed
- direct Vitest: `packages/cli/src/commands/run-shell.test.ts` (3 tests passed)
- standard pnpm validation is currently blocked by the repository lockfile policy because `@profullstack/autoblog@0.4.0` has no integrity field; no lockfile changes were made.