### PR TITLE
fix(bots): validate integer environment values

### DIFF
--- a/packages/bots/signal/src/index.test.ts
+++ b/packages/bots/signal/src/index.test.ts
@@ -1,4 +1,37 @@
+import { describe, expect, it } from 'vitest';
 import { contractTestBot } from '@profullstack/sh1pt-core/testing';
-import bot from './index.js';
+import bot, { loadConfig } from './index.js';
 
 contractTestBot(bot, { sampleConfig: {}, sampleChannel: '+15551234567' });
+
+describe('loadConfig', () => {
+  it('accepts positive integer environment values', () => {
+    const config = loadConfig({
+      SIGNAL_PHONE_NUMBER: '+15551234567',
+      SIGNAL_HTTP_PORT: '8080',
+      SESSION_TIMEOUT_MS: '60000',
+      MAX_OUTPUT_LENGTH: '1200',
+      MAX_CONCURRENT_SESSIONS: '3',
+    });
+
+    expect(config.httpPort).toBe(8080);
+    expect(config.sessionTimeoutMs).toBe(60000);
+    expect(config.maxOutputLength).toBe(1200);
+    expect(config.maxConcurrentSessions).toBe(3);
+  });
+
+  it('uses safe defaults for malformed or unsafe integer values', () => {
+    const config = loadConfig({
+      SIGNAL_PHONE_NUMBER: '+15551234567',
+      SIGNAL_HTTP_PORT: '8080http',
+      SESSION_TIMEOUT_MS: '10seconds',
+      MAX_OUTPUT_LENGTH: '1.5',
+      MAX_CONCURRENT_SESSIONS: '9007199254740993',
+    });
+
+    expect(config.httpPort).toBe(7580);
+    expect(config.sessionTimeoutMs).toBe(1800000);
+    expect(config.maxOutputLength).toBe(4000);
+    expect(config.maxConcurrentSessions).toBe(5);
+  });
+});

--- a/packages/bots/signal/src/index.ts
+++ b/packages/bots/signal/src/index.ts
@@ -99,16 +99,22 @@ export function loadConfig(env: Record<string, string | undefined>): Config {
     botName: env.BOT_NAME || "Bot",
     signalCliPath: env.SIGNAL_CLI_PATH || "signal-cli",
     phoneNumber: env.SIGNAL_PHONE_NUMBER || "",
-    httpPort: parseInt(env.SIGNAL_HTTP_PORT || "7580", 10),
+    httpPort: parsePositiveIntegerEnv(env.SIGNAL_HTTP_PORT, 7580),
     aiProvider: (env.AI_PROVIDER as any) || "claude-code",
     aiCliPath: env.AI_CLI_PATH || "claude",
     aiModel: env.AI_MODEL,
-    sessionTimeoutMs: parseInt(env.SESSION_TIMEOUT_MS || "1800000", 10),
-    maxOutputLength: parseInt(env.MAX_OUTPUT_LENGTH || "4000", 10),
-    maxConcurrentSessions: parseInt(env.MAX_CONCURRENT_SESSIONS || "5", 10),
+    sessionTimeoutMs: parsePositiveIntegerEnv(env.SESSION_TIMEOUT_MS, 1800000),
+    maxOutputLength: parsePositiveIntegerEnv(env.MAX_OUTPUT_LENGTH, 4000),
+    maxConcurrentSessions: parsePositiveIntegerEnv(env.MAX_CONCURRENT_SESSIONS, 5),
     allowedUsers: env.ALLOWED_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
     adminUsers: env.ADMIN_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
   });
+}
+
+function parsePositiveIntegerEnv(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 function toBotEvent(msg: IncomingMessage): BotEvent {

--- a/packages/bots/whatsapp/src/index.test.ts
+++ b/packages/bots/whatsapp/src/index.test.ts
@@ -1,4 +1,31 @@
+import { describe, expect, it } from 'vitest';
 import { contractTestBot } from '@profullstack/sh1pt-core/testing';
-import bot from './index.js';
+import bot, { loadConfig } from './index.js';
 
 contractTestBot(bot, { sampleConfig: {}, sampleChannel: '15551234567@s.whatsapp.net' });
+
+describe('loadConfig', () => {
+  it('accepts positive integer environment limits', () => {
+    const config = loadConfig({
+      SESSION_TIMEOUT_MS: '60000',
+      MAX_OUTPUT_LENGTH: '1200',
+      MAX_CONCURRENT_SESSIONS: '3',
+    });
+
+    expect(config.sessionTimeoutMs).toBe(60000);
+    expect(config.maxOutputLength).toBe(1200);
+    expect(config.maxConcurrentSessions).toBe(3);
+  });
+
+  it('uses safe defaults for malformed or unsafe environment limits', () => {
+    const config = loadConfig({
+      SESSION_TIMEOUT_MS: '10seconds',
+      MAX_OUTPUT_LENGTH: '1.5',
+      MAX_CONCURRENT_SESSIONS: '9007199254740993',
+    });
+
+    expect(config.sessionTimeoutMs).toBe(1800000);
+    expect(config.maxOutputLength).toBe(4000);
+    expect(config.maxConcurrentSessions).toBe(5);
+  });
+});

--- a/packages/bots/whatsapp/src/index.ts
+++ b/packages/bots/whatsapp/src/index.ts
@@ -121,12 +121,18 @@ export function loadConfig(env: Record<string, string | undefined>): Config {
     aiProvider: (env.AI_PROVIDER as any) || "claude-code",
     aiCliPath: env.AI_CLI_PATH || "claude",
     aiModel: env.AI_MODEL,
-    sessionTimeoutMs: parseInt(env.SESSION_TIMEOUT_MS || "1800000", 10),
-    maxOutputLength: parseInt(env.MAX_OUTPUT_LENGTH || "4000", 10),
-    maxConcurrentSessions: parseInt(env.MAX_CONCURRENT_SESSIONS || "5", 10),
+    sessionTimeoutMs: parsePositiveIntegerEnv(env.SESSION_TIMEOUT_MS, 1800000),
+    maxOutputLength: parsePositiveIntegerEnv(env.MAX_OUTPUT_LENGTH, 4000),
+    maxConcurrentSessions: parsePositiveIntegerEnv(env.MAX_CONCURRENT_SESSIONS, 5),
     allowedUsers: env.ALLOWED_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
     adminUsers: env.ADMIN_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
   });
+}
+
+function parsePositiveIntegerEnv(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 function toBotEvent(msg: IncomingMessage): BotEvent {


### PR DESCRIPTION
Fixes #901

## Summary

- replace partial parseInt handling in the published Signal and WhatsApp bot packages
- accept only positive safe integers and use established adapter defaults otherwise
- cover valid, malformed, fractional, and unsafe environment values

## Validation

- git diff --check
- focused tests added; the isolated checkout has no installed workspace dependencies, so repository CI is the executable test run