### PR TITLE
fix: reject malformed integer env values in Signal and WhatsApp bots

### DIFF
--- a/packages/bots/signal/src/index.test.ts
+++ b/packages/bots/signal/src/index.test.ts
@@ -1,4 +1,37 @@
+import { describe, expect, it } from 'vitest';
 import { contractTestBot } from '@profullstack/sh1pt-core/testing';
-import bot from './index.js';
+import bot, { loadConfig } from './index.js';
 
 contractTestBot(bot, { sampleConfig: {}, sampleChannel: '+15551234567' });
+
+describe('loadConfig', () => {
+  it('uses defaults for malformed, fractional, non-positive, and unsafe integers', () => {
+    const config = loadConfig({
+      SIGNAL_PHONE_NUMBER: '+15551234567',
+      SIGNAL_HTTP_PORT: '8080http',
+      SESSION_TIMEOUT_MS: '1.5',
+      MAX_OUTPUT_LENGTH: '0',
+      MAX_CONCURRENT_SESSIONS: '9007199254740992',
+    });
+
+    expect(config.httpPort).toBe(7580);
+    expect(config.sessionTimeoutMs).toBe(1800000);
+    expect(config.maxOutputLength).toBe(4000);
+    expect(config.maxConcurrentSessions).toBe(5);
+  });
+
+  it('accepts positive safe integer strings', () => {
+    const config = loadConfig({
+      SIGNAL_PHONE_NUMBER: '+15551234567',
+      SIGNAL_HTTP_PORT: '8080',
+      SESSION_TIMEOUT_MS: '60000',
+      MAX_OUTPUT_LENGTH: '2000',
+      MAX_CONCURRENT_SESSIONS: '3',
+    });
+
+    expect(config.httpPort).toBe(8080);
+    expect(config.sessionTimeoutMs).toBe(60000);
+    expect(config.maxOutputLength).toBe(2000);
+    expect(config.maxConcurrentSessions).toBe(3);
+  });
+});

--- a/packages/bots/signal/src/index.ts
+++ b/packages/bots/signal/src/index.ts
@@ -99,16 +99,23 @@ export function loadConfig(env: Record<string, string | undefined>): Config {
     botName: env.BOT_NAME || "Bot",
     signalCliPath: env.SIGNAL_CLI_PATH || "signal-cli",
     phoneNumber: env.SIGNAL_PHONE_NUMBER || "",
-    httpPort: parseInt(env.SIGNAL_HTTP_PORT || "7580", 10),
+    httpPort: parsePositiveSafeIntegerEnv(env.SIGNAL_HTTP_PORT, 7580),
     aiProvider: (env.AI_PROVIDER as any) || "claude-code",
     aiCliPath: env.AI_CLI_PATH || "claude",
     aiModel: env.AI_MODEL,
-    sessionTimeoutMs: parseInt(env.SESSION_TIMEOUT_MS || "1800000", 10),
-    maxOutputLength: parseInt(env.MAX_OUTPUT_LENGTH || "4000", 10),
-    maxConcurrentSessions: parseInt(env.MAX_CONCURRENT_SESSIONS || "5", 10),
+    sessionTimeoutMs: parsePositiveSafeIntegerEnv(env.SESSION_TIMEOUT_MS, 1800000),
+    maxOutputLength: parsePositiveSafeIntegerEnv(env.MAX_OUTPUT_LENGTH, 4000),
+    maxConcurrentSessions: parsePositiveSafeIntegerEnv(env.MAX_CONCURRENT_SESSIONS, 5),
     allowedUsers: env.ALLOWED_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
     adminUsers: env.ADMIN_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
   });
+}
+
+function parsePositiveSafeIntegerEnv(value: string | undefined, fallback: number): number {
+  const text = value?.trim();
+  if (!text || !/^\d+$/.test(text)) return fallback;
+  const parsed = Number(text);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 function toBotEvent(msg: IncomingMessage): BotEvent {

--- a/packages/bots/whatsapp/src/index.test.ts
+++ b/packages/bots/whatsapp/src/index.test.ts
@@ -1,4 +1,31 @@
+import { describe, expect, it } from 'vitest';
 import { contractTestBot } from '@profullstack/sh1pt-core/testing';
-import bot from './index.js';
+import bot, { loadConfig } from './index.js';
 
 contractTestBot(bot, { sampleConfig: {}, sampleChannel: '15551234567@s.whatsapp.net' });
+
+describe('loadConfig', () => {
+  it('uses defaults for malformed, fractional, non-positive, and unsafe integers', () => {
+    const config = loadConfig({
+      SESSION_TIMEOUT_MS: '10seconds',
+      MAX_OUTPUT_LENGTH: '1.5',
+      MAX_CONCURRENT_SESSIONS: '9007199254740992',
+    });
+
+    expect(config.sessionTimeoutMs).toBe(1800000);
+    expect(config.maxOutputLength).toBe(4000);
+    expect(config.maxConcurrentSessions).toBe(5);
+  });
+
+  it('accepts positive safe integer strings', () => {
+    const config = loadConfig({
+      SESSION_TIMEOUT_MS: '60000',
+      MAX_OUTPUT_LENGTH: '2000',
+      MAX_CONCURRENT_SESSIONS: '3',
+    });
+
+    expect(config.sessionTimeoutMs).toBe(60000);
+    expect(config.maxOutputLength).toBe(2000);
+    expect(config.maxConcurrentSessions).toBe(3);
+  });
+});

--- a/packages/bots/whatsapp/src/index.ts
+++ b/packages/bots/whatsapp/src/index.ts
@@ -121,12 +121,19 @@ export function loadConfig(env: Record<string, string | undefined>): Config {
     aiProvider: (env.AI_PROVIDER as any) || "claude-code",
     aiCliPath: env.AI_CLI_PATH || "claude",
     aiModel: env.AI_MODEL,
-    sessionTimeoutMs: parseInt(env.SESSION_TIMEOUT_MS || "1800000", 10),
-    maxOutputLength: parseInt(env.MAX_OUTPUT_LENGTH || "4000", 10),
-    maxConcurrentSessions: parseInt(env.MAX_CONCURRENT_SESSIONS || "5", 10),
+    sessionTimeoutMs: parsePositiveSafeIntegerEnv(env.SESSION_TIMEOUT_MS, 1800000),
+    maxOutputLength: parsePositiveSafeIntegerEnv(env.MAX_OUTPUT_LENGTH, 4000),
+    maxConcurrentSessions: parsePositiveSafeIntegerEnv(env.MAX_CONCURRENT_SESSIONS, 5),
     allowedUsers: env.ALLOWED_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
     adminUsers: env.ADMIN_USERS?.split(",").map((u) => u.trim()).filter(Boolean) || [],
   });
+}
+
+function parsePositiveSafeIntegerEnv(value: string | undefined, fallback: number): number {
+  const text = value?.trim();
+  if (!text || !/^\d+$/.test(text)) return fallback;
+  const parsed = Number(text);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 function toBotEvent(msg: IncomingMessage): BotEvent {


### PR DESCRIPTION
Fixes #901.

Replace `parseInt` with strict positive safe integer parsing in the published Signal and WhatsApp bots. Invalid, fractional, non-positive, and unsafe values now fall back to documented defaults, while valid positive safe integer strings are accepted.

Validation:
- Direct Vitest: 10/10 tests passed for Signal and WhatsApp config loading.
- The standard pnpm install/typecheck path remains blocked by the repository's existing lockfile integrity policy for `@profullstack/autoblog@0.4.0`; no lockfile changes were made.