### PR TITLE
fix(api): validate PORT before server startup

### DIFF
--- a/packages/api/src/port.test.ts
+++ b/packages/api/src/port.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_API_PORT, resolveApiPort } from './port.js';
+
+describe('resolveApiPort', () => {
+  it('uses the default when PORT is absent', () => {
+    expect(resolveApiPort(undefined)).toBe(DEFAULT_API_PORT);
+  });
+
+  it('accepts decimal ports in the valid range', () => {
+    expect(resolveApiPort('8080')).toBe(8080);
+    expect(resolveApiPort(' 443 ')).toBe(443);
+    expect(resolveApiPort('0')).toBe(0);
+  });
+
+  it('falls back for non-decimal, negative, and out-of-range values', () => {
+    for (const value of ['1e3', '0x1f90', '4000oops', '-1', '65536', '9007199254740992']) {
+      expect(resolveApiPort(value)).toBe(DEFAULT_API_PORT);
+    }
+  });
+});

--- a/packages/api/src/port.ts
+++ b/packages/api/src/port.ts
@@ -1,0 +1,11 @@
+export const DEFAULT_API_PORT = 4000;
+
+export function resolveApiPort(value: string | undefined): number {
+  const text = value?.trim();
+  if (!text || !/^\d+$/.test(text)) return DEFAULT_API_PORT;
+
+  const parsed = Number(text);
+  return Number.isSafeInteger(parsed) && parsed >= 0 && parsed <= 65535
+    ? parsed
+    : DEFAULT_API_PORT;
+}

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -1,6 +1,7 @@
 import { serve } from '@hono/node-server';
 import app from './index.js';
+import { resolveApiPort } from './port.js';
 
-const port = Number(process.env.PORT ?? 4000);
+const port = resolveApiPort(process.env.PORT);
 serve({ fetch: app.fetch, port });
 console.log(`sh1pt api listening on :${port}`);


### PR DESCRIPTION
Validate the API server PORT environment value before passing it to @hono/node-server. The previous Number(...) conversion accepted JavaScript numeric spellings such as 1e3 and 0x1f90 and allowed out-of-range or negative values to reach server startup. The new resolver accepts decimal ports 0-65535 and falls back to 4000 for malformed or out-of-range values.

Validation:
- Focused Vitest: packages/api/src/port.test.ts (3 tests passed)
- git diff --check passed
- Full packages/api typecheck could not run in the isolated worktree because its existing workspace dependencies (Hono/Vitest) are not installed there.