### PR TITLE
fix(opencode): validate timeout as a decimal integer

### DIFF
--- a/packages/agent-providers/opencode/src/__tests__/timeout.test.ts
+++ b/packages/agent-providers/opencode/src/__tests__/timeout.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { createOpencodeProvider } from "../provider";
+
+describe("opencode timeout configuration", () => {
+  const provider = createOpencodeProvider();
+
+  it.each(["15000ms", "1e3", "1.5", "Infinity", "9007199254740992"])(
+    "rejects a non-decimal positive integer: %s",
+    (timeout) => {
+      expect(() => provider.validateEnv({ OPENCODE_TIMEOUT_MS: timeout })).toThrow("positive integer");
+    },
+  );
+
+  it("accepts surrounding whitespace around a valid decimal integer", () => {
+    expect(() => provider.validateEnv({ OPENCODE_TIMEOUT_MS: " 15000 " })).not.toThrow();
+  });
+});

--- a/packages/agent-providers/opencode/src/provider.ts
+++ b/packages/agent-providers/opencode/src/provider.ts
@@ -119,8 +119,9 @@ function resolveConfig(env: Record<string, string | undefined>): OpencodeConfig 
 
 function parseTimeout(value: string | undefined): number {
   if (!value) return 120_000;
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+  const normalized = value.trim();
+  const parsed = Number(normalized);
+  if (!/^\d+$/.test(normalized) || !Number.isSafeInteger(parsed) || parsed <= 0) {
     throw new AgentProviderConfigError("OPENCODE_TIMEOUT_MS must be a positive integer");
   }
   return parsed;


### PR DESCRIPTION
## Summary

- validate the complete `OPENCODE_TIMEOUT_MS` value as decimal digits
- reject suffixes, exponents, fractions, non-finite values, and unsafe integers
- preserve trimmed positive integer values and the existing default

## Why

`Number.parseInt` accepted a valid numeric prefix and silently ignored the rest. Values such as `15000ms`, `1e3`, or `1.5` therefore passed configuration validation even though the adapter promises a positive integer timeout.

## Validation

- focused Vitest suites: 12 tests passed
- `git diff --check`

The full workspace install/typecheck could not run because the checked-in lockfile fails the active integrity policy for `@profullstack/autoblog@0.4.0` (missing tarball integrity). The focused suite was run with the shared workspace package aliased directly to its local source.
