### PR TITLE
fix(cli): resolve config removal path safely

### DIFF
--- a/packages/cli/src/commands/self.ts
+++ b/packages/cli/src/commands/self.ts
@@ -9,6 +9,7 @@ import { Command } from 'commander';
 import { promises as fs } from 'node:fs';
 import kleur from 'kleur';
 import prompts from 'prompts';
+import { configDir } from '@profullstack/sh1pt-core';
 import { detectPackageManager } from '../installer.js';
 import { runCommand } from '../run-command.js';
 
@@ -69,10 +70,7 @@ export const removeCmd = new Command('remove')
 
     const code = run(argv);
     if (code === 0 && deleteConfig) {
-      const xdg = process.env.XDG_CONFIG_HOME;
-      const dir = xdg && xdg.length > 0
-        ? `${xdg}/sh1pt`
-        : `${process.env.HOME}/.config/sh1pt`;
+      const dir = configDir();
       try {
         await fs.rm(dir, { recursive: true, force: true });
         console.log(kleur.dim(`removed ${dir}`));


### PR DESCRIPTION
## Summary

- reuse the shared `configDir()` resolver when `sh1pt remove` deletes configuration
- preserve `XDG_CONFIG_HOME` behavior and add the existing OS home-directory fallback

## Why

The remove command built its fallback from `process.env.HOME` directly. On Windows or other environments where `HOME` is unset, confirming config deletion produced the relative path `undefined/.config/sh1pt` instead of the user's configuration directory.

The core resolver is already used by other CLI configuration paths and falls back to `os.homedir()` safely.

## Validation

- `packages/core/src/config-store.test.ts`: 2 tests passed
- `git diff --check`

The full workspace install/typecheck remains unavailable because the checked-in lockfile fails the active integrity policy for `@profullstack/autoblog@0.4.0` (missing tarball integrity).
