### PR TITLE
fix(twitch): reject invalid IRC timestamps

### DIFF
--- a/packages/bots/twitch/src/index.ts
+++ b/packages/bots/twitch/src/index.ts
@@ -1,6 +1,7 @@
 import { connect as netConnect, type Socket } from "node:net";
 import { connect as tlsConnect } from "node:tls";
 import { defineBot, tokenSetup, type BotCtx, type BotEvent, type BotHandler } from "@profullstack/sh1pt-core";
+import { parseTwitchTimestamp } from "./timestamp.js";
 
 // Twitch bot using Twitch IRC chat over TLS. OAuth token via TWITCH_OAUTH_TOKEN
 // with chat:read and chat:write scopes.
@@ -203,7 +204,7 @@ function toBotEvent(message: IrcMessage, commandPrefix: string): BotEvent | unde
     const channel = toChannelName(message.params[0] ?? "");
     const text = message.trailing ?? "";
     const user = parseUser(message);
-    const timestamp = tagTimestamp(message.tags["tmi-sent-ts"]);
+    const timestamp = parseTwitchTimestamp(message.tags["tmi-sent-ts"]);
     if (text.startsWith(commandPrefix) && text.length > commandPrefix.length) {
       const [command, ...args] = text.slice(commandPrefix.length).trim().split(/\s+/).filter(Boolean);
       if (command) {
@@ -252,12 +253,6 @@ function parseUser(message: IrcMessage): BotEvent["user"] {
     displayName: message.tags["display-name"] || username,
     isBot: false,
   };
-}
-
-function tagTimestamp(value: string | undefined): string {
-  if (!value) return new Date().toISOString();
-  const timestamp = Number(value);
-  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : new Date().toISOString();
 }
 
 function matches(handler: BotHandler, event: BotEvent): boolean {

--- a/packages/bots/twitch/src/timestamp.test.ts
+++ b/packages/bots/twitch/src/timestamp.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parseTwitchTimestamp } from "./timestamp.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("parseTwitchTimestamp", () => {
+  it("converts a decimal millisecond timestamp", () => {
+    expect(parseTwitchTimestamp("1700000000000")).toBe("2023-11-14T22:13:20.000Z");
+  });
+
+  it.each([
+    undefined,
+    "",
+    "1e3",
+    "1.5",
+    "-1",
+    " 1700000000000 ",
+    "9007199254740992",
+    "8640000000000001",
+  ])("falls back to the current time for an invalid timestamp: %s", (value) => {
+    vi.useFakeTimers().setSystemTime(new Date("2026-08-01T18:20:00.000Z"));
+    expect(parseTwitchTimestamp(value)).toBe("2026-08-01T18:20:00.000Z");
+  });
+});

--- a/packages/bots/twitch/src/timestamp.ts
+++ b/packages/bots/twitch/src/timestamp.ts
@@ -1,0 +1,7 @@
+export function parseTwitchTimestamp(value: string | undefined): string {
+  if (!value || !/^\d+$/.test(value)) return new Date().toISOString();
+  const timestamp = Number(value);
+  if (!Number.isSafeInteger(timestamp)) return new Date().toISOString();
+  const date = new Date(timestamp);
+  return Number.isNaN(date.getTime()) ? new Date().toISOString() : date.toISOString();
+}


### PR DESCRIPTION
## Summary

- reject non-decimal, unsafe, and out-of-range Twitch IRC timestamps
- fall back to the current time instead of throwing while converting an invalid `Date`
- isolate timestamp parsing so malformed IRC tags can be tested without a live connection

## Root cause

`Number.isFinite()` does not guarantee that a numeric value can be represented as a valid JavaScript `Date`. A finite `tmi-sent-ts` value outside the supported date range reached `toISOString()` and threw while processing an incoming Twitch message. Numeric formats that Twitch does not emit, such as exponent or fractional notation, were also accepted.

## Verification

- `9` focused Vitest cases pass for valid, missing, malformed, unsafe, and out-of-range values
- `git diff --check`

The full workspace install/typecheck is currently blocked by the checked-in lockfile entry for `@profullstack/autoblog@0.4.0`, whose tarball has no integrity metadata. GitHub CI remains the authoritative full-repository check.
