### PR TITLE
fix(wechat): reject invalid message timestamps

### DIFF
--- a/packages/bots/wechat/src/index.ts
+++ b/packages/bots/wechat/src/index.ts
@@ -1,6 +1,7 @@
 import { createHash, timingSafeEqual } from 'node:crypto';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { defineBot, tokenSetup, type BotEvent, type BotHandler, type BotReply } from '@profullstack/sh1pt-core';
+import { parseWeChatTimestamp } from './timestamp.js';
 
 type FetchLike = (url: string, init?: {
   method?: string;
@@ -217,9 +218,7 @@ function renderReplyText(reply: BotReply): string {
 function toBotEvent(input: WeChatXmlMessage, commandPrefix: string): BotEvent | undefined {
   const fromUser = input.FromUserName ?? '';
   const msgType = (input.MsgType ?? '').toLowerCase();
-  const timestamp = input.CreateTime
-    ? new Date(Number(input.CreateTime) * 1000).toISOString()
-    : new Date().toISOString();
+  const timestamp = parseWeChatTimestamp(input.CreateTime);
 
   if (msgType === 'event') {
     return toEventBotEvent(input, fromUser, timestamp);

--- a/packages/bots/wechat/src/timestamp.test.ts
+++ b/packages/bots/wechat/src/timestamp.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { parseWeChatTimestamp } from './timestamp.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('parseWeChatTimestamp', () => {
+  it('converts a decimal Unix timestamp', () => {
+    expect(parseWeChatTimestamp('1710000001')).toBe('2024-03-09T16:00:01.000Z');
+  });
+
+  it.each([
+    undefined,
+    '',
+    '1e3',
+    '1.5',
+    '-1',
+    ' 1710000001 ',
+    '9007199254740992',
+    '8640000000001',
+  ])('falls back to the current time for an invalid timestamp: %s', (value) => {
+    vi.useFakeTimers().setSystemTime(new Date('2026-08-01T18:30:00.000Z'));
+    expect(parseWeChatTimestamp(value)).toBe('2026-08-01T18:30:00.000Z');
+  });
+});

--- a/packages/bots/wechat/src/timestamp.ts
+++ b/packages/bots/wechat/src/timestamp.ts
@@ -1,0 +1,7 @@
+export function parseWeChatTimestamp(value: string | undefined): string {
+  if (!value || !/^\d+$/.test(value)) return new Date().toISOString();
+  const seconds = Number(value);
+  if (!Number.isSafeInteger(seconds)) return new Date().toISOString();
+  const date = new Date(seconds * 1000);
+  return Number.isNaN(date.getTime()) ? new Date().toISOString() : date.toISOString();
+}


### PR DESCRIPTION
## Summary

- validate WeChat `CreateTime` as a complete decimal Unix timestamp
- fall back to the current time for malformed, unsafe, or out-of-range values
- prevent invalid webhook timestamps from throwing during `toISOString()`

## Root cause

Inbound XML passed `CreateTime` through `Number()` and directly into `Date#toISOString()`. A malformed or out-of-range value produced an invalid `Date`, causing a `RangeError` and aborting callback processing. Numeric formats outside WeChat's integer timestamp format were also accepted.

## Verification

- `9` focused Vitest cases pass for valid, missing, malformed, unsafe, and out-of-range values
- `git diff --check`

The full workspace install/typecheck is currently blocked by the checked-in lockfile entry for `@profullstack/autoblog@0.4.0`, whose tarball has no integrity metadata. GitHub CI remains the authoritative full-repository check.
