### PR TITLE
fix(matrix): reject invalid event timestamps

### DIFF
--- a/packages/bots/matrix/src/index.ts
+++ b/packages/bots/matrix/src/index.ts
@@ -1,4 +1,5 @@
 import { defineBot, tokenSetup, type BotCtx, type BotEvent, type BotHandler, type BotReply } from '@profullstack/sh1pt-core';
+import { parseMatrixTimestamp } from './timestamp.js';
 
 // Matrix bot — sync loop against homeserver. Access token via MATRIX_ACCESS_TOKEN
 // (obtain via /login). E2EE rooms need an Olm/Megolm-capable client;
@@ -165,7 +166,7 @@ function toBotEvent(roomId: string, event: MatrixEvent, config: Config): BotEven
     text,
     command,
     args: isCommand ? args : undefined,
-    timestamp: new Date(event.origin_server_ts ?? Date.now()).toISOString(),
+    timestamp: parseMatrixTimestamp(event.origin_server_ts),
     raw: event,
   };
 }

--- a/packages/bots/matrix/src/timestamp.test.ts
+++ b/packages/bots/matrix/src/timestamp.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { parseMatrixTimestamp } from './timestamp.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('parseMatrixTimestamp', () => {
+  it('converts a millisecond timestamp', () => {
+    expect(parseMatrixTimestamp(1779336000000)).toBe('2026-05-21T04:00:00.000Z');
+  });
+
+  it.each([
+    undefined,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    1.5,
+    -1,
+    Number.MAX_SAFE_INTEGER + 1,
+    8640000000000001,
+  ])('falls back to the current time for an invalid timestamp: %s', (value) => {
+    vi.useFakeTimers().setSystemTime(new Date('2026-08-01T18:35:00.000Z'));
+    expect(parseMatrixTimestamp(value)).toBe('2026-08-01T18:35:00.000Z');
+  });
+});

--- a/packages/bots/matrix/src/timestamp.ts
+++ b/packages/bots/matrix/src/timestamp.ts
@@ -1,0 +1,5 @@
+export function parseMatrixTimestamp(value: number | undefined): string {
+  if (value === undefined || !Number.isSafeInteger(value) || value < 0) return new Date().toISOString();
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? new Date().toISOString() : date.toISOString();
+}


### PR DESCRIPTION
## Summary

- validate Matrix `origin_server_ts` before converting it to an ISO timestamp
- fall back to the current time for fractional, negative, unsafe, or out-of-range values
- prevent malformed sync events from throwing during message conversion

## Root cause

Inbound Matrix events passed `origin_server_ts` directly to `Date#toISOString()`. JSON values are not runtime-validated against the TypeScript interface, so a non-integer or out-of-range number could produce an invalid `Date` and abort sync event processing with a `RangeError`.

## Verification

- `8` focused Vitest cases pass for valid, missing, non-finite, fractional, negative, unsafe, and out-of-range values
- `git diff --check`

The full workspace install/typecheck is currently blocked by the checked-in lockfile entry for `@profullstack/autoblog@0.4.0`, whose tarball has no integrity metadata. GitHub CI remains the authoritative full-repository check.
