### PR TITLE
fix(mastodon): preserve invalid numeric entities

### DIFF
--- a/packages/bridges/mastodon/src/html-entities.test.ts
+++ b/packages/bridges/mastodon/src/html-entities.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { decodeHtmlEntities } from './html-entities.js';
+
+describe('decodeHtmlEntities', () => {
+  it('decodes supported named and numeric entities', () => {
+    expect(decodeHtmlEntities('&amp; &LT; &#65; &#x1F680;')).toBe('& < A 🚀');
+  });
+
+  it('preserves unknown named entities', () => {
+    expect(decodeHtmlEntities('&copy;')).toBe('&copy;');
+  });
+
+  it.each([
+    '&#1114112;',
+    '&#999999999999999999999999;',
+    '&#x110000;',
+    '&#xD800;',
+  ])('preserves an invalid numeric entity: %s', (entity) => {
+    expect(decodeHtmlEntities(entity)).toBe(entity);
+  });
+});

--- a/packages/bridges/mastodon/src/html-entities.ts
+++ b/packages/bridges/mastodon/src/html-entities.ts
@@ -1,0 +1,23 @@
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  apos: "'",
+  gt: '>',
+  lt: '<',
+  nbsp: ' ',
+  quot: '"',
+};
+
+export function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&#(\d+);/g, (entity, code: string) => decodeCodePoint(entity, code, 10))
+    .replace(/&#x([0-9a-f]+);/gi, (entity, code: string) => decodeCodePoint(entity, code, 16))
+    .replace(/&([a-z]+);/gi, (entity, name: string) => NAMED_ENTITIES[name.toLowerCase()] ?? entity);
+}
+
+function decodeCodePoint(entity: string, value: string, radix: number): string {
+  const codePoint = Number.parseInt(value, radix);
+  if (!Number.isSafeInteger(codePoint) || codePoint > 0x10ffff || (codePoint >= 0xd800 && codePoint <= 0xdfff)) {
+    return entity;
+  }
+  return String.fromCodePoint(codePoint);
+}

--- a/packages/bridges/mastodon/src/index.ts
+++ b/packages/bridges/mastodon/src/index.ts
@@ -1,4 +1,5 @@
 import { defineBridge, type BridgeAttachment, type BridgeMessage, tokenSetup } from '@profullstack/sh1pt-core';
+import { decodeHtmlEntities } from './html-entities.js';
 
 // Mastodon bridge — streaming API for receive (/api/v1/streaming/user),
 // /api/v1/statuses for send. "Channels" on Mastodon are hashtag streams
@@ -289,22 +290,6 @@ function htmlToText(value: string): string {
     .replace(/[ \t]+\n/g, '\n')
     .replace(/\n{3,}/g, '\n\n')
     .trim());
-}
-
-function decodeHtmlEntities(value: string): string {
-  const named: Record<string, string> = {
-    amp: '&',
-    apos: "'",
-    gt: '>',
-    lt: '<',
-    nbsp: ' ',
-    quot: '"',
-  };
-
-  return value
-    .replace(/&#(\d+);/g, (_, code: string) => String.fromCodePoint(Number(code)))
-    .replace(/&#x([0-9a-f]+);/gi, (_, code: string) => String.fromCodePoint(Number.parseInt(code, 16)))
-    .replace(/&([a-z]+);/gi, (entity, name: string) => named[name.toLowerCase()] ?? entity);
 }
 
 function mastodonAttachment(media: MastodonMediaAttachment): BridgeAttachment | undefined {


### PR DESCRIPTION
## Summary

- guard Mastodon numeric HTML entity decoding against invalid Unicode values
- preserve invalid decimal, hexadecimal, oversized, and surrogate entities literally
- keep valid named and numeric entity decoding unchanged

## Root cause

Mastodon status content is untrusted HTML. Numeric entities were passed directly to `String.fromCodePoint()`, which throws a `RangeError` for values above `0x10ffff`. One malformed status could therefore abort status-to-message conversion.

## Verification

- `6` focused Vitest cases pass for valid named/decimal/hex entities and invalid Unicode values
- `git diff --check`

The full workspace install/typecheck is currently blocked by the checked-in lockfile entry for `@profullstack/autoblog@0.4.0`, whose tarball has no integrity metadata. GitHub CI remains the authoritative full-repository check.
