### PR TITLE
fix(stripe): validate webhook timestamp format

### DIFF
--- a/packages/payments/stripe/src/index.ts
+++ b/packages/payments/stripe/src/index.ts
@@ -1,5 +1,6 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import { definePayment, tokenSetup, type CheckoutRequest, type Webhook } from '@profullstack/sh1pt-core';
+import { parseStripeWebhookTimestamp } from './webhook-timestamp.js';
 
 // Stripe — cards + ACH + Link + local payment methods. Checkout API
 // for one-time + subscriptions; Connect for marketplace payouts.
@@ -192,8 +193,8 @@ function verifyStripeSignature(
     throw new Error('Stripe-Signature missing t or v1');
   }
 
-  const timestampSeconds = Number(timestamp);
-  if (!Number.isFinite(timestampSeconds)) throw new Error('Stripe-Signature timestamp is invalid');
+  const timestampSeconds = parseStripeWebhookTimestamp(timestamp);
+  if (timestampSeconds === undefined) throw new Error('Stripe-Signature timestamp is invalid');
   if (effectiveToleranceSeconds > 0) {
     const age = Math.floor(Date.now() / 1000) - timestampSeconds;
     if (Math.abs(age) > effectiveToleranceSeconds) throw new Error('Stripe webhook signature timestamp outside tolerance');

--- a/packages/payments/stripe/src/webhook-timestamp.test.ts
+++ b/packages/payments/stripe/src/webhook-timestamp.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { parseStripeWebhookTimestamp } from './webhook-timestamp.js';
+
+describe('parseStripeWebhookTimestamp', () => {
+  it('parses a decimal integer timestamp', () => {
+    expect(parseStripeWebhookTimestamp('1700000000')).toBe(1700000000);
+  });
+
+  it.each([
+    '',
+    '1e3',
+    '1.5',
+    '-1',
+    '+1',
+    ' 1700000000 ',
+    '9007199254740992',
+  ])('rejects a malformed timestamp: %s', (value) => {
+    expect(parseStripeWebhookTimestamp(value)).toBeUndefined();
+  });
+});

--- a/packages/payments/stripe/src/webhook-timestamp.ts
+++ b/packages/payments/stripe/src/webhook-timestamp.ts
@@ -1,0 +1,5 @@
+export function parseStripeWebhookTimestamp(value: string): number | undefined {
+  if (!/^\d+$/.test(value)) return undefined;
+  const timestamp = Number(value);
+  return Number.isSafeInteger(timestamp) ? timestamp : undefined;
+}


### PR DESCRIPTION
## Summary

- require Stripe webhook timestamps to be complete decimal integers
- reject exponent, fractional, signed, whitespace-wrapped, and unsafe values
- align Stripe signature timestamp validation with the hardened CoinPay verifier

## Root cause

The `Stripe-Signature` timestamp was parsed with `Number()` and only checked with `Number.isFinite()`. That accepted formats outside Stripe's decimal Unix timestamp grammar, including exponent and fractional notation, and allowed integers that cannot be represented safely by JavaScript.

## Verification

- `8` focused Vitest cases pass for valid and malformed timestamp formats
- `git diff --check`

The full workspace suite cannot run in this worktree because the shared checkout lacks workspace dependencies such as `zod`. GitHub CI performs a clean frozen-lockfile install and remains the authoritative integration check.
