### PR TITLE
fix(cloudflare): tolerate invalid resource timestamps

### DIFF
--- a/packages/cloud/cloudflare/src/index.ts
+++ b/packages/cloud/cloudflare/src/index.ts
@@ -8,6 +8,7 @@ import {
   type ProvisionContext,
   type Quote,
 } from '@profullstack/sh1pt-core';
+import { normalizeCloudflareTimestamp } from './timestamp.js';
 
 type ResourceType = 'r2-bucket' | 'd1-database' | 'queue' | 'tunnel';
 type ConfigResourceType = ResourceType | 'worker';
@@ -432,7 +433,7 @@ function bucketInstance(bucket: R2Bucket, kind: InstanceKind, quote: Quote, fall
     id: prefixedId('r2-bucket', name),
     kind,
     status: 'running',
-    createdAt: iso(bucket.creation_date),
+    createdAt: normalizeCloudflareTimestamp(bucket.creation_date),
     hourlyRate: quote.hourly,
     currency: quote.currency,
     sku: quote.sku,
@@ -446,7 +447,7 @@ function d1Instance(db: D1Database, kind: InstanceKind, quote: Quote, fallbackRe
     id: prefixedId('d1-database', id),
     kind,
     status: 'running',
-    createdAt: iso(db.created_at),
+    createdAt: normalizeCloudflareTimestamp(db.created_at),
     hourlyRate: quote.hourly,
     currency: quote.currency,
     sku: quote.sku,
@@ -460,7 +461,7 @@ function queueInstance(queue: Queue, kind: InstanceKind, quote: Quote, fallbackR
     id: prefixedId('queue', id),
     kind,
     status: 'running',
-    createdAt: iso(queue.created_on ?? queue.modified_on),
+    createdAt: normalizeCloudflareTimestamp(queue.created_on ?? queue.modified_on),
     hourlyRate: quote.hourly,
     currency: quote.currency,
     sku: quote.sku,
@@ -474,7 +475,7 @@ function tunnelInstance(tunnel: Tunnel, kind: InstanceKind, quote: Quote, fallba
     id: prefixedId('tunnel', id),
     kind,
     status: tunnelStatus(tunnel.status),
-    createdAt: iso(tunnel.created_at),
+    createdAt: normalizeCloudflareTimestamp(tunnel.created_at),
     hourlyRate: quote.hourly,
     currency: quote.currency,
     sku: quote.sku,
@@ -528,10 +529,6 @@ function safeName(value: string): string {
 function requiredId(value: string | undefined, label: string): string {
   if (!value) throw new Error(`${label} response did not include an id`);
   return value;
-}
-
-function iso(value: string | undefined): string {
-  return value ? new Date(value).toISOString() : new Date().toISOString();
 }
 
 function arrayFromResult<T>(result: unknown, arrayKey: string): T[] {

--- a/packages/cloud/cloudflare/src/timestamp.test.ts
+++ b/packages/cloud/cloudflare/src/timestamp.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { normalizeCloudflareTimestamp } from './timestamp.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('normalizeCloudflareTimestamp', () => {
+  it('normalizes a valid provider timestamp', () => {
+    expect(normalizeCloudflareTimestamp('2026-06-14T00:00:00Z')).toBe('2026-06-14T00:00:00.000Z');
+  });
+
+  it.each([
+    undefined,
+    '',
+    'not-a-date',
+    '999999999999999999999',
+  ])('falls back to the current time for an invalid timestamp: %s', (value) => {
+    vi.useFakeTimers().setSystemTime(new Date('2026-08-01T18:40:00.000Z'));
+    expect(normalizeCloudflareTimestamp(value)).toBe('2026-08-01T18:40:00.000Z');
+  });
+});

--- a/packages/cloud/cloudflare/src/timestamp.ts
+++ b/packages/cloud/cloudflare/src/timestamp.ts
@@ -1,0 +1,5 @@
+export function normalizeCloudflareTimestamp(value: string | undefined): string {
+  if (!value) return new Date().toISOString();
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? new Date().toISOString() : date.toISOString();
+}


### PR DESCRIPTION
## Summary

- validate Cloudflare resource timestamps before ISO conversion
- fall back to the current time for missing or malformed provider dates
- protect R2, D1, Queue, and Tunnel instance mapping from `RangeError`

## Root cause

Cloudflare response dates were passed directly through `new Date(value).toISOString()`. A malformed non-empty date creates an invalid `Date`, causing resource provision, status, or list mapping to throw instead of returning the resource.

## Verification

- `5` focused Vitest cases pass for valid, missing, empty, malformed, and out-of-range values
- `git diff --check`

The full workspace suite cannot run in this worktree because the shared checkout lacks workspace dependencies such as `zod`. GitHub CI performs a clean frozen-lockfile install and remains the authoritative integration check.
