### PR TITLE
fix(atlantic): reject invalid instance timestamps

### DIFF
--- a/packages/cloud/atlantic/src/index.ts
+++ b/packages/cloud/atlantic/src/index.ts
@@ -1,5 +1,6 @@
 import { createHmac, randomUUID } from 'node:crypto';
 import { defineCloud, tokenSetup, type Instance, type InstanceSpec, type Quote } from '@profullstack/sh1pt-core';
+import { normalizeAtlanticTimestamp } from './timestamp.js';
 
 // Atlantic.Net Cloud API — classic signed query API for Cloud Servers.
 // API docs: https://www.atlantic.net/docs/api/
@@ -211,7 +212,7 @@ function instanceToInstance(record: AtlanticInstanceRecord): Instance {
     kind: isBareMetal({ plan_name: sku }) ? 'bare-metal' : 'cpu-vps',
     status,
     publicIp: firstNonEmpty(record.vm_ip_address, record.ip_address),
-    createdAt: toIso(record.vm_created_date ?? record.created_date),
+    createdAt: normalizeAtlanticTimestamp(record.vm_created_date ?? record.created_date),
     hourlyRate: parseMoney(record.rate_per_hr),
     currency: 'USD',
     sku,
@@ -228,16 +229,6 @@ function mapStatus(value: string | undefined): Instance['status'] {
   if (status.includes('fail') || status.includes('error')) return 'failed';
   if (status.includes('terminat') || status.includes('remove') || status.includes('delete')) return 'destroyed';
   return 'provisioning';
-}
-
-function toIso(value: string | undefined): string {
-  if (!value) return new Date().toISOString();
-  const numeric = Number(value);
-  if (Number.isFinite(numeric) && numeric > 0) {
-    return new Date(numeric < 10_000_000_000 ? numeric * 1000 : numeric).toISOString();
-  }
-  const parsed = Date.parse(value);
-  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : new Date().toISOString();
 }
 
 function planToQuote(plan: AtlanticPlan): Quote {

--- a/packages/cloud/atlantic/src/timestamp.test.ts
+++ b/packages/cloud/atlantic/src/timestamp.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { normalizeAtlanticTimestamp } from './timestamp.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('normalizeAtlanticTimestamp', () => {
+  it.each([
+    ['1438048503', '2015-07-28T01:55:03.000Z'],
+    ['1438048503000', '2015-07-28T01:55:03.000Z'],
+    ['2026-06-14T00:00:00Z', '2026-06-14T00:00:00.000Z'],
+  ])('normalizes provider timestamp %s', (value, expected) => {
+    expect(normalizeAtlanticTimestamp(value)).toBe(expected);
+  });
+
+  it.each([
+    undefined,
+    '',
+    '0',
+    '-1',
+    '1e3',
+    '1.5',
+    '9007199254740992',
+    '8640000000000001',
+    'not-a-date',
+  ])('falls back to the current time for an invalid timestamp: %s', (value) => {
+    vi.useFakeTimers().setSystemTime(new Date('2026-08-01T18:45:00.000Z'));
+    expect(normalizeAtlanticTimestamp(value)).toBe('2026-08-01T18:45:00.000Z');
+  });
+});

--- a/packages/cloud/atlantic/src/timestamp.ts
+++ b/packages/cloud/atlantic/src/timestamp.ts
@@ -1,0 +1,14 @@
+export function normalizeAtlanticTimestamp(value: string | undefined): string {
+  if (!value) return new Date().toISOString();
+
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    if (!/^\d+$/.test(value) || !Number.isSafeInteger(numeric) || numeric <= 0) return new Date().toISOString();
+    const milliseconds = numeric < 10_000_000_000 ? numeric * 1000 : numeric;
+    const date = new Date(milliseconds);
+    return Number.isNaN(date.getTime()) ? new Date().toISOString() : date.toISOString();
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? new Date().toISOString() : new Date(parsed).toISOString();
+}


### PR DESCRIPTION
## Summary

- validate Atlantic.Net numeric instance timestamps before ISO conversion
- preserve support for Unix seconds, Unix milliseconds, and ISO date strings
- fall back safely for exponent, fractional, unsafe, non-positive, malformed, and out-of-range values

## Root cause

Atlantic.Net instance dates were parsed with `Number()` and sent directly to `Date#toISOString()`. Finite values can still be outside JavaScript's supported date range and throw `RangeError`; permissive numeric parsing also accepted exponent and fractional formats that are not provider timestamps.

## Verification

- `12` focused Vitest cases pass across supported and invalid timestamp formats
- `git diff --check`

The full workspace suite cannot run in this worktree because the shared checkout lacks workspace dependencies such as `zod`. GitHub CI performs a clean frozen-lockfile install and remains the authoritative integration check.
