### PR TITLE
fix(teams): reject malformed JWT segments

### DIFF
--- a/packages/bots/teams/src/index.ts
+++ b/packages/bots/teams/src/index.ts
@@ -8,6 +8,7 @@ import {
   type BotHandler,
   type BotReply,
 } from "@profullstack/sh1pt-core";
+import { decodeBotFrameworkJwt, type ParsedJwt } from "./jwt.js";
 
 const DEFAULT_PATH = "/api/messages";
 const DEFAULT_PORT = 3978;
@@ -110,24 +111,6 @@ interface OpenIdMetadata {
 
 interface JsonWebKeySet {
   keys?: Array<JsonWebKey & { kid?: string; x5t?: string; endorsements?: string[] }>;
-}
-
-interface ParsedJwt {
-  header: {
-    alg?: string;
-    kid?: string;
-    x5t?: string;
-  };
-  payload: {
-    aud?: string | string[];
-    iss?: string;
-    exp?: number;
-    nbf?: number;
-    serviceurl?: string;
-    serviceUrl?: string;
-  };
-  signed: string;
-  signature: Buffer;
 }
 
 export class HttpError extends Error {
@@ -620,25 +603,12 @@ async function getSigningKeys(fetcher: FetchLike, url: string): Promise<JsonWebK
 }
 
 function parseJwt(token: string): ParsedJwt {
-  const parts = token.split(".");
-  if (parts.length !== 3) throw new HttpError(403, "Bot Framework JWT must have three parts");
-  const [encodedHeader, encodedPayload, encodedSignature] = parts;
-  if (!encodedHeader || !encodedPayload || !encodedSignature) throw new HttpError(403, "Bot Framework JWT part missing");
-  const header = JSON.parse(base64UrlDecode(encodedHeader).toString("utf8")) as unknown;
-  const payload = JSON.parse(base64UrlDecode(encodedPayload).toString("utf8")) as unknown;
-  if (!isRecord(header) || !isRecord(payload)) throw new HttpError(403, "Bot Framework JWT payload invalid");
-  return {
-    header: header as ParsedJwt["header"],
-    payload: payload as ParsedJwt["payload"],
-    signed: `${encodedHeader}.${encodedPayload}`,
-    signature: base64UrlDecode(encodedSignature),
-  };
-}
-
-function base64UrlDecode(value: string): Buffer {
-  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
-  const padding = "=".repeat((4 - (normalized.length % 4)) % 4);
-  return Buffer.from(`${normalized}${padding}`, "base64");
+  try {
+    return decodeBotFrameworkJwt(token);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Bot Framework JWT malformed";
+    throw new HttpError(403, message);
+  }
 }
 
 function hasAudience(aud: string | string[] | undefined, appId: string): boolean {

--- a/packages/bots/teams/src/jwt.test.ts
+++ b/packages/bots/teams/src/jwt.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { decodeBotFrameworkJwt } from "./jwt.js";
+
+function segment(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+describe("decodeBotFrameworkJwt", () => {
+  it("decodes a three-part Bot Framework token", () => {
+    const header = segment({ alg: "RS256", kid: "key-1" });
+    const payload = segment({ aud: "app-1", exp: 2_000_000_000 });
+    const signature = Buffer.from("signed-bytes").toString("base64url");
+
+    expect(decodeBotFrameworkJwt(`${header}.${payload}.${signature}`)).toMatchObject({
+      header: { alg: "RS256", kid: "key-1" },
+      payload: { aud: "app-1", exp: 2_000_000_000 },
+      signed: `${header}.${payload}`,
+    });
+  });
+
+  it("rejects tokens with the wrong number of parts", () => {
+    expect(() => decodeBotFrameworkJwt("one.two")).toThrow("must have three parts");
+  });
+
+  it("rejects empty token parts", () => {
+    expect(() => decodeBotFrameworkJwt(`${segment({})}..signature`)).toThrow("part missing");
+  });
+
+  it("rejects invalid Base64URL characters", () => {
+    expect(() => decodeBotFrameworkJwt(`***.${segment({})}.signature`)).toThrow("not valid Base64URL");
+  });
+
+  it("rejects malformed JSON segments", () => {
+    const invalidJson = Buffer.from("not-json").toString("base64url");
+    expect(() => decodeBotFrameworkJwt(`${invalidJson}.${segment({})}.signature`)).toThrow("header is not valid JSON");
+  });
+
+  it("rejects non-object headers and payloads", () => {
+    expect(() => decodeBotFrameworkJwt(`${segment([])}.${segment({})}.signature`)).toThrow("header must be an object");
+    expect(() => decodeBotFrameworkJwt(`${segment({})}.${segment([])}.signature`)).toThrow("payload must be an object");
+  });
+});

--- a/packages/bots/teams/src/jwt.ts
+++ b/packages/bots/teams/src/jwt.ts
@@ -1,0 +1,56 @@
+export interface ParsedJwt {
+  header: {
+    alg?: string;
+    kid?: string;
+    x5t?: string;
+  };
+  payload: {
+    aud?: string | string[];
+    iss?: string;
+    exp?: number;
+    nbf?: number;
+    serviceurl?: string;
+    serviceUrl?: string;
+  };
+  signed: string;
+  signature: Buffer;
+}
+
+export function decodeBotFrameworkJwt(token: string): ParsedJwt {
+  const parts = token.split(".");
+  if (parts.length !== 3) throw new Error("Bot Framework JWT must have three parts");
+  const [encodedHeader, encodedPayload, encodedSignature] = parts;
+  if (!encodedHeader || !encodedPayload || !encodedSignature) throw new Error("Bot Framework JWT part missing");
+
+  const header = decodeJsonObject(encodedHeader, "header");
+  const payload = decodeJsonObject(encodedPayload, "payload");
+  return {
+    header: header as ParsedJwt["header"],
+    payload: payload as ParsedJwt["payload"],
+    signed: `${encodedHeader}.${encodedPayload}`,
+    signature: decodeBase64Url(encodedSignature, "signature"),
+  };
+}
+
+function decodeJsonObject(value: string, label: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(decodeBase64Url(value, label).toString("utf8"));
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Bot Framework JWT")) throw error;
+    throw new Error(`Bot Framework JWT ${label} is not valid JSON`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`Bot Framework JWT ${label} must be an object`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function decodeBase64Url(value: string, label: string): Buffer {
+  if (!/^[A-Za-z0-9_-]+$/.test(value) || value.length % 4 === 1) {
+    throw new Error(`Bot Framework JWT ${label} is not valid Base64URL`);
+  }
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = "=".repeat((4 - (normalized.length % 4)) % 4);
+  return Buffer.from(`${normalized}${padding}`, "base64");
+}


### PR DESCRIPTION
## Summary

- validate all three Bot Framework JWT segments as strict Base64URL
- report malformed header/payload JSON and non-object claims consistently
- translate JWT decoding failures into HTTP 403 responses instead of generic HTTP 500 errors

## Root cause

Teams bearer tokens were decoded with Node's permissive Base64 parser and parsed with unguarded `JSON.parse()` calls. Malformed external tokens could therefore be partially decoded or raise raw parsing errors, which escaped authentication as internal server errors.

## Verification

- `6` focused Vitest cases pass for valid tokens, wrong or empty parts, invalid Base64URL, malformed JSON, and non-object claims
- `git diff --check`

The full workspace suite cannot run in this worktree because the shared checkout lacks workspace dependencies such as `zod`. GitHub CI performs a clean frozen-lockfile install and remains the authoritative integration check.
