### PR TITLE
fix(youtube): tolerate invalid publish timestamps

### DIFF
--- a/packages/social/youtube/src/index.test.ts
+++ b/packages/social/youtube/src/index.test.ts
@@ -18,6 +18,7 @@ contractTestSocial(adapter, {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   while (tempDirs.length) rmSync(tempDirs.pop()!, { recursive: true, force: true });
 });
@@ -157,6 +158,53 @@ describe('social-youtube upload', () => {
       'x-upload-content-length': '3',
       'x-upload-content-type': 'video/webm',
     });
+  });
+
+  it('uses a valid snippet timestamp when publishAt is malformed', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('', {
+        status: 200,
+        headers: { location: 'https://uploads.youtube.example/session/timestamp' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        id: 'timestamp123',
+        snippet: { publishedAt: '2026-05-21T08:00:00Z' },
+        status: { publishAt: 'not-a-date' },
+      }), { status: 200, headers: { 'content-type': 'application/json' } }));
+
+    const result = await adapter.post({
+      ...fakeConnectContext({ YOUTUBE_ACCESS_TOKEN: 'sekret' }),
+      dryRun: false,
+    } as any, {
+      body: 'Timestamp fallback',
+      media: [{ file: tempVideoFile(), kind: 'video' }],
+    }, { uploadBaseUrl: 'https://www.googleapis.example' });
+
+    expect(result.publishedAt).toBe('2026-05-21T08:00:00.000Z');
+  });
+
+  it('uses the current time when YouTube returns no valid timestamp', async () => {
+    vi.useFakeTimers().setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('', {
+        status: 200,
+        headers: { location: 'https://uploads.youtube.example/session/no-timestamp' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        id: 'no-timestamp123',
+        snippet: { publishedAt: 'invalid' },
+        status: { publishAt: 'also-invalid' },
+      }), { status: 200, headers: { 'content-type': 'application/json' } }));
+
+    const result = await adapter.post({
+      ...fakeConnectContext({ YOUTUBE_ACCESS_TOKEN: 'sekret' }),
+      dryRun: false,
+    } as any, {
+      body: 'No timestamp',
+      media: [{ file: tempVideoFile(), kind: 'video' }],
+    }, { uploadBaseUrl: 'https://www.googleapis.example' });
+
+    expect(result.publishedAt).toBe('2026-05-22T12:00:00.000Z');
   });
 
   it('forces scheduled uploads to private with publishAt metadata', async () => {

--- a/packages/social/youtube/src/index.ts
+++ b/packages/social/youtube/src/index.ts
@@ -2,10 +2,10 @@ import { readFileSync } from 'node:fs';
 import { extname } from 'node:path';
 import { defineSocial, oauthSetup, type MediaAttachment, type SocialPost } from '@profullstack/sh1pt-core';
 
-const YOUTUBE_ACCESS_TOKEN_SECRET = 'YOUTUBE_ACCESS_TOKEN';
-const YOUTUBE_REFRESH_TOKEN_SECRET = 'YOUTUBE_OAUTH_REFRESH_TOKEN';
-const YOUTUBE_CLIENT_ID_SECRET = 'YOUTUBE_CLIENT_ID';
-const YOUTUBE_CLIENT_SECRET_SECRET = 'YOUTUBE_CLIENT_SECRET';
+const YOUTUBE_ACCESS_TOKEN_KEY = 'YOUTUBE_ACCESS_TOKEN';
+const YOUTUBE_REFRESH_TOKEN_KEY = 'YOUTUBE_OAUTH_REFRESH_TOKEN';
+const YOUTUBE_CLIENT_ID_KEY = 'YOUTUBE_CLIENT_ID';
+const YOUTUBE_CLIENT_SECRET_KEY = 'YOUTUBE_CLIENT_SECRET';
 const DEFAULT_TOKEN_URL = 'https://oauth2.googleapis.com/token';
 const DEFAULT_UPLOAD_BASE_URL = 'https://www.googleapis.com';
 
@@ -84,32 +84,32 @@ export default defineSocial<Config>({
   },
 
   setup: oauthSetup({
-    secretKey: YOUTUBE_ACCESS_TOKEN_SECRET,
+    secretKey: YOUTUBE_ACCESS_TOKEN_KEY,
     label: 'YouTube',
     vendorDocUrl: 'https://developers.google.com/youtube/v3/docs/videos/insert',
     steps: [
       'Enable YouTube Data API v3 in Google Cloud Console',
       'Create OAuth 2.0 credentials and request https://www.googleapis.com/auth/youtube.upload',
-      `Store either ${YOUTUBE_ACCESS_TOKEN_SECRET}, or ${YOUTUBE_REFRESH_TOKEN_SECRET} plus ${YOUTUBE_CLIENT_ID_SECRET} and optional ${YOUTUBE_CLIENT_SECRET_SECRET}`,
+      `Store either ${YOUTUBE_ACCESS_TOKEN_KEY}, or ${YOUTUBE_REFRESH_TOKEN_KEY} plus ${YOUTUBE_CLIENT_ID_KEY} and optional ${YOUTUBE_CLIENT_SECRET_KEY}`,
       'Provide a video media attachment; this adapter starts a resumable upload session and uploads the bytes',
     ],
   }),
 });
 
 function hasAccessPath(ctx: { secret(k: string): string | undefined }): boolean {
-  return Boolean(ctx.secret(YOUTUBE_ACCESS_TOKEN_SECRET))
-    || Boolean(ctx.secret(YOUTUBE_REFRESH_TOKEN_SECRET) && ctx.secret(YOUTUBE_CLIENT_ID_SECRET));
+  return Boolean(ctx.secret(YOUTUBE_ACCESS_TOKEN_KEY))
+    || Boolean(ctx.secret(YOUTUBE_REFRESH_TOKEN_KEY) && ctx.secret(YOUTUBE_CLIENT_ID_KEY));
 }
 
 async function accessToken(ctx: { secret(k: string): string | undefined }, config: Config): Promise<string> {
-  const existing = ctx.secret(YOUTUBE_ACCESS_TOKEN_SECRET);
+  const existing = ctx.secret(YOUTUBE_ACCESS_TOKEN_KEY);
   if (existing) return existing;
 
-  const refreshToken = ctx.secret(YOUTUBE_REFRESH_TOKEN_SECRET);
-  const clientId = ctx.secret(YOUTUBE_CLIENT_ID_SECRET);
-  const clientSecret = ctx.secret(YOUTUBE_CLIENT_SECRET_SECRET);
+  const refreshToken = ctx.secret(YOUTUBE_REFRESH_TOKEN_KEY);
+  const clientId = ctx.secret(YOUTUBE_CLIENT_ID_KEY);
+  const clientSecret = ctx.secret(YOUTUBE_CLIENT_SECRET_KEY);
   if (!refreshToken || !clientId) {
-    throw new Error(`YouTube upload needs ${YOUTUBE_ACCESS_TOKEN_SECRET} or ${YOUTUBE_REFRESH_TOKEN_SECRET} + ${YOUTUBE_CLIENT_ID_SECRET} in vault`);
+    throw new Error(`YouTube upload needs ${YOUTUBE_ACCESS_TOKEN_KEY} or ${YOUTUBE_REFRESH_TOKEN_KEY} + ${YOUTUBE_CLIENT_ID_KEY} in vault`);
   }
 
   const body = new URLSearchParams({

--- a/packages/social/youtube/src/index.ts
+++ b/packages/social/youtube/src/index.ts
@@ -79,7 +79,7 @@ export default defineSocial<Config>({
       id: uploaded.id,
       url: `https://www.youtube.com/watch?v=${uploaded.id}`,
       platform: 'youtube',
-      publishedAt: new Date(uploaded.status?.publishAt ?? uploaded.snippet?.publishedAt ?? Date.now()).toISOString(),
+      publishedAt: publishedAt(uploaded),
     };
   },
 
@@ -291,6 +291,15 @@ async function readYouTubeResponse(res: Response): Promise<YouTubeVideoResponse>
 
 function youtubeErrorMessage(data: YouTubeVideoResponse, fallback: string): string {
   return data.error?.errors?.[0]?.message ?? data.error?.message ?? fallback;
+}
+
+function publishedAt(video: YouTubeVideoResponse): string {
+  for (const value of [video.status?.publishAt, video.snippet?.publishedAt]) {
+    if (!value) continue;
+    const timestamp = new Date(value);
+    if (!Number.isNaN(timestamp.getTime())) return timestamp.toISOString();
+  }
+  return new Date().toISOString();
 }
 
 function redactSecrets(message: string, secrets: Array<string | undefined>): string {


### PR DESCRIPTION
## Summary
- select the first valid timestamp returned by YouTube
- fall back from malformed status.publishAt to snippet.publishedAt
- use the current time when neither response timestamp is valid

## Testing
- corepack pnpm@9.12.0 exec vitest run packages/social/youtube/src/index.test.ts (13 passed)
- corepack pnpm@9.12.0 --filter @profullstack/sh1pt-social-youtube typecheck