### PR TITLE
fix(promote): validate scheduled post timestamps

### DIFF
--- a/packages/cli/src/commands/promote.test.ts
+++ b/packages/cli/src/commands/promote.test.ts
@@ -7,8 +7,19 @@ import {
   loadCampaignSnapshots,
   parseNonNegativeInteger,
   parsePositiveInteger,
+  parseSchedule,
   stopCampaigns,
 } from './promote.js';
+
+describe('promote schedule option parser', () => {
+  it('parses a valid ISO timestamp', () => {
+    expect(parseSchedule('2026-08-01T18:30:00Z').toISOString()).toBe('2026-08-01T18:30:00.000Z');
+  });
+
+  it.each(['not-a-date', '2026-99-99T18:30:00Z', ''])('rejects invalid timestamp %j', (value) => {
+    expect(() => parseSchedule(value)).toThrow('valid ISO timestamp');
+  });
+});
 
 describe('promote numeric option parsers', () => {
   it('accepts decimal positive integers', () => {

--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -828,6 +828,14 @@ function inferMediaKind(file: string): 'image' | 'video' | 'gif' {
   return 'image';
 }
 
+export function parseSchedule(value: string): Date {
+  const schedule = new Date(value);
+  if (Number.isNaN(schedule.getTime())) {
+    throw new InvalidArgumentError('must be a valid ISO timestamp');
+  }
+  return schedule;
+}
+
 socialCmd
   .command('post')
   .description('Cross-post to every connected platform with per-platform adaptation')
@@ -837,7 +845,7 @@ socialCmd
   .option('--media <path...>', 'images and/or videos — adapters enforce kind requirements')
   .option('--link <url>', 'CTA URL')
   .option('--platform <id...>', 'subset; default: all connected')
-  .option('--schedule <iso>', 'publish at ISO timestamp; omit for now')
+  .option('--schedule <iso>', 'publish at ISO timestamp; omit for now', parseSchedule)
   .option('--dry-run')
   .action(async (opts: {
     body: string;
@@ -846,7 +854,7 @@ socialCmd
     media?: string[];
     link?: string;
     platform?: string[];
-    schedule?: string;
+    schedule?: Date;
     dryRun?: boolean;
   }) => {
     const post: SocialPost = {
@@ -855,7 +863,7 @@ socialCmd
       hashtags: opts.hashtags ? opts.hashtags.split(',').map((h) => h.trim()).filter(Boolean) : undefined,
       media: opts.media?.map((file) => ({ file, kind: inferMediaKind(file) })),
       link: opts.link,
-      schedule: opts.schedule ? new Date(opts.schedule) : undefined,
+      schedule: opts.schedule,
     };
 
     const names = (opts.platform ?? SOCIAL_PLATFORMS).map(stripSocialPrefix).filter(Boolean);


### PR DESCRIPTION
## Summary
- validate social post schedule values during CLI option parsing
- pass a validated Date through to the posting flow
- add coverage for valid and malformed timestamps

## Verification
- `corepack pnpm@9.12.0 exec vitest run packages/cli/src/commands/promote.test.ts` (30 passed)
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt typecheck`
- `git diff --check`