### PR TITLE
fix(discord): tolerate invalid message timestamps

### DIFF
--- a/packages/social/discord/src/index.test.ts
+++ b/packages/social/discord/src/index.test.ts
@@ -10,6 +10,7 @@ contractTestSocial(adapter, {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.useRealTimers();
 });
 
 describe('social-discord posting', () => {
@@ -62,6 +63,29 @@ describe('social-discord posting', () => {
 
     await expect(adapter.post(ctx as any, { body: 'Release shipped' }, {}))
       .rejects.toThrow('Invalid Form Body');
+  });
+
+  it('falls back to the current time when Discord returns a malformed timestamp', async () => {
+    vi.useFakeTimers().setSystemTime(new Date('2026-08-01T19:30:00.000Z'));
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: '123456789',
+        channel_id: '222',
+        guild_id: '111',
+        timestamp: 'not-a-date',
+      }),
+    } as any);
+
+    const ctx = {
+      ...fakeConnectContext({ DISCORD_WEBHOOK_URL: 'https://discord.com/api/webhooks/1/token' }),
+      dryRun: false,
+    };
+
+    const result = await adapter.post(ctx as any, { body: 'Release shipped' }, {});
+
+    expect(result.publishedAt).toBe('2026-08-01T19:30:00.000Z');
   });
 
   it('replaces an existing wait query parameter while preserving thread routing', async () => {

--- a/packages/social/discord/src/index.ts
+++ b/packages/social/discord/src/index.ts
@@ -39,7 +39,7 @@ export default defineSocial<Config>({
       id: message.id,
       url: messageUrl(message),
       platform: 'discord',
-      publishedAt: new Date(message.timestamp).toISOString(),
+      publishedAt: publishedAt(message.timestamp),
     };
   },
 
@@ -61,6 +61,11 @@ interface DiscordMessage {
   channel_id: string;
   guild_id?: string;
   timestamp: string;
+}
+
+function publishedAt(value: string): string {
+  const timestamp = new Date(value);
+  return Number.isNaN(timestamp.getTime()) ? new Date().toISOString() : timestamp.toISOString();
 }
 
 function formatDiscordPost(post: SocialPost, config: Config): unknown {


### PR DESCRIPTION
## Summary
- preserve successful Discord webhook posts when the response timestamp is malformed
- fall back to the current time for a valid `publishedAt` value
- add regression coverage for malformed Discord timestamps

## Verification
- `corepack pnpm@9.12.0 exec vitest run packages/social/discord/src/index.test.ts` (7 passed)
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-social-discord typecheck`
- `git diff --check`