### PR TITLE
fix(whatsapp): tolerate invalid event timestamps

### DIFF
--- a/packages/bots/whatsapp/src/index.test.ts
+++ b/packages/bots/whatsapp/src/index.test.ts
@@ -1,8 +1,26 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { contractTestBot } from '@profullstack/sh1pt-core/testing';
-import bot, { loadConfig } from './index.js';
+import bot, { loadConfig, toIsoTimestamp } from './index.js';
 
 contractTestBot(bot, { sampleConfig: {}, sampleChannel: '15551234567@s.whatsapp.net' });
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('toIsoTimestamp', () => {
+  it('preserves a valid millisecond timestamp', () => {
+    expect(toIsoTimestamp(Date.UTC(2026, 7, 1, 19, 30))).toBe('2026-08-01T19:30:00.000Z');
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_VALUE])(
+    'falls back to the current time for invalid timestamp %s',
+    (value) => {
+      vi.useFakeTimers().setSystemTime(new Date('2026-08-01T20:00:00.000Z'));
+      expect(toIsoTimestamp(value)).toBe('2026-08-01T20:00:00.000Z');
+    },
+  );
+});
 
 describe('loadConfig', () => {
   it('accepts positive integer environment limits', () => {

--- a/packages/bots/whatsapp/src/index.ts
+++ b/packages/bots/whatsapp/src/index.ts
@@ -136,6 +136,11 @@ function parsePositiveSafeIntegerEnv(value: string | undefined, fallback: number
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+export function toIsoTimestamp(value: number): string {
+  const timestamp = new Date(value);
+  return Number.isNaN(timestamp.getTime()) ? new Date().toISOString() : timestamp.toISOString();
+}
+
 function toBotEvent(msg: IncomingMessage): BotEvent {
   return {
     type: "message",
@@ -146,7 +151,7 @@ function toBotEvent(msg: IncomingMessage): BotEvent {
     },
     text: msg.text,
     attachments: msg.attachments.map((a) => ({ url: a.url, filename: a.filename })),
-    timestamp: new Date(msg.timestamp).toISOString(),
+    timestamp: toIsoTimestamp(msg.timestamp),
     raw: msg.raw,
   };
 }


### PR DESCRIPTION
## Summary
- convert WhatsApp event timestamps through a validity-checked helper
- fall back to the current time when Baileys supplies a malformed or out-of-range value
- add regression coverage for valid, non-finite, and out-of-range timestamps

## Verification
- `corepack pnpm@9.12.0 exec vitest run packages/bots/whatsapp/src/index.test.ts` (10 passed)
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-bot-whatsapp typecheck`
- `git diff --check`