### PR TITLE
fix(telegram): validate bot chat ids

### DIFF
--- a/packages/bots/telegram/src/index.test.ts
+++ b/packages/bots/telegram/src/index.test.ts
@@ -1,8 +1,22 @@
 import { describe, expect, it } from 'vitest';
 import { contractTestBot } from '@profullstack/sh1pt-core/testing';
-import bot, { loadConfig } from './index.js';
+import bot, { loadConfig, parseTelegramChatId } from './index.js';
 
 contractTestBot(bot, { sampleConfig: {}, sampleChannel: '1234567890' });
+
+describe('parseTelegramChatId', () => {
+  it('accepts positive user and negative group chat ids', () => {
+    expect(parseTelegramChatId('1234567890')).toBe(1234567890);
+    expect(parseTelegramChatId('-1001234567890')).toBe(-1001234567890);
+  });
+
+  it.each(['', '0', '-0', '1.5', '1e2', '0x10', ' 123 ', 'NaN', '9007199254740993'])(
+    'rejects malformed or unsafe chat id %j',
+    (value) => {
+      expect(() => parseTelegramChatId(value)).toThrow(`Invalid Telegram chat id: ${value}`);
+    },
+  );
+});
 
 describe('loadConfig', () => {
   it('accepts positive integer env values', () => {

--- a/packages/bots/telegram/src/index.ts
+++ b/packages/bots/telegram/src/index.ts
@@ -117,6 +117,15 @@ function parsePositiveIntegerEnv(value: string | undefined, fallback: number): n
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+export function parseTelegramChatId(value: string): number {
+  if (!/^-?\d+$/.test(value)) throw new Error(`Invalid Telegram chat id: ${value}`);
+  const chatId = Number(value);
+  if (!Number.isSafeInteger(chatId) || chatId === 0) {
+    throw new Error(`Invalid Telegram chat id: ${value}`);
+  }
+  return chatId;
+}
+
 function toBotEvent(msg: IncomingMessage): BotEvent {
   return {
     type: "message",
@@ -161,8 +170,7 @@ export default defineBot<Partial<Config>>({
     ctx.log(`bot-telegram · send → chat=${channel}`);
     if (ctx.dryRun) return { id: "dry-run" };
 
-    const chatId = Number(channel);
-    if (!Number.isFinite(chatId)) throw new Error(`Invalid Telegram chat id: ${channel}`);
+    const chatId = parseTelegramChatId(channel);
     const bot = new TelegramBot(configSchema.parse({ ...config, botToken: token }));
     await bot.send(chatId, reply.text ?? "");
     return { id: `tg_${Date.now()}` };


### PR DESCRIPTION
## Summary
- require Telegram bot destinations to be decimal integer chat IDs
- preserve negative group IDs while rejecting zero, fractions, alternate numeric syntax, whitespace, and unsafe integers
- prevent Number coercion and rounding from sending to the wrong chat

## Verification
- `corepack pnpm@9.12.0 exec vitest run packages/bots/telegram/src/index.test.ts` (15 passed)
- `corepack pnpm@9.12.0 --filter @profullstack/sh1pt-bot-telegram typecheck`
- `git diff --check`