### PR TITLE
fix(discord): validate integer env values strictly

### DIFF
--- a/packages/bots/discord/src/index.test.ts
+++ b/packages/bots/discord/src/index.test.ts
@@ -17,4 +17,17 @@ describe('loadConfig', () => {
     expect(config.maxOutputLength).toBe(2000);
     expect(config.maxConcurrentSessions).toBe(5);
   });
+
+  it.each(['1e3', '0x10', ' 10 ', '+10', '10.5', '9007199254740992'])('rejects non-decimal integer env value %s', (value) => {
+    const config = loadConfig({
+      DISCORD_BOT_TOKEN: 'discord-token',
+      SESSION_TIMEOUT_MS: value,
+      MAX_OUTPUT_LENGTH: value,
+      MAX_CONCURRENT_SESSIONS: value,
+    });
+
+    expect(config.sessionTimeoutMs).toBe(1800000);
+    expect(config.maxOutputLength).toBe(2000);
+    expect(config.maxConcurrentSessions).toBe(5);
+  });
 });

--- a/packages/bots/discord/src/index.ts
+++ b/packages/bots/discord/src/index.ts
@@ -164,9 +164,9 @@ export function loadConfig(env: Record<string, string | undefined>): Config {
 }
 
 function parsePositiveIntegerEnv(value: string | undefined, fallback: number): number {
-  if (!value) return fallback;
+  if (!value || !/^\d+$/.test(value)) return fallback;
   const parsed = Number(value);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 interface SendableChannel {


### PR DESCRIPTION
## Summary
- require Discord integer environment values to use decimal digits only
- reject exponent, hexadecimal, signed, fractional, whitespace-padded, and unsafe values
- preserve existing safe fallback behavior for invalid configuration

## Validation
- `vitest run packages/bots/discord/src/index.test.ts` (10 tests passed)
- `tsc -p packages/bots/discord/tsconfig.json --noEmit`
- `git diff --check`