### PR TITLE
fix(telegram): tolerate invalid bridge dates

### DIFF
--- a/packages/bridges/telegram/src/index.test.ts
+++ b/packages/bridges/telegram/src/index.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { contractTestBridge } from '@profullstack/sh1pt-core/testing';
-import adapter from './index.js';
+import adapter, { telegramTimestamp } from './index.js';
 
 contractTestBridge(adapter, {
   sampleConfig: {},
@@ -9,6 +9,18 @@ contractTestBridge(adapter, {
 
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+describe('telegramTimestamp', () => {
+  it('maps valid Unix seconds to ISO timestamps', () => {
+    expect(telegramTimestamp(1_779_321_600)).toBe('2026-05-21T00:00:00.000Z');
+  });
+
+  it('falls back instead of throwing for invalid or out-of-range dates', () => {
+    for (const value of [undefined, Number.NaN, Number.POSITIVE_INFINITY, 1e20]) {
+      expect(telegramTimestamp(value)).toBe('1970-01-01T00:00:00.000Z');
+    }
+  });
 });
 
 describe('bridge-telegram Bot API integration', () => {

--- a/packages/bridges/telegram/src/index.ts
+++ b/packages/bridges/telegram/src/index.ts
@@ -161,9 +161,15 @@ function toBridgeMessage(message: TelegramMessage): BridgeMessage {
     text: message.text ?? message.caption ?? '',
     replyToId: message.reply_to_message?.message_id ? String(message.reply_to_message.message_id) : undefined,
     attachments: telegramAttachments(message),
-    timestamp: new Date(message.date * 1000).toISOString(),
+    timestamp: telegramTimestamp(message.date),
     originalNetwork: 'telegram',
   };
+}
+
+export function telegramTimestamp(seconds: number | undefined): string {
+  if (typeof seconds !== 'number' || !Number.isFinite(seconds)) return new Date(0).toISOString();
+  const date = new Date(seconds * 1000);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
 }
 
 function telegramUsername(user: TelegramUser | TelegramChat): string {


### PR DESCRIPTION
## Summary

- guard Telegram bridge message dates before converting them to ISO strings
- fall back to the Unix epoch for missing, non-finite, or out-of-range values
- add regression coverage for valid and invalid Bot API timestamps

## Validation

- `.\\node_modules\\.bin\\vitest.cmd run packages/bridges/telegram/src/index.test.ts`
- `.\\node_modules\\.bin\\tsc.cmd -p packages/bridges/telegram/tsconfig.json --noEmit`
- `git diff --check`
