### PR TITLE
fix(telegram): tolerate invalid message timestamps

### DIFF
--- a/packages/bots/telegram/src/index.test.ts
+++ b/packages/bots/telegram/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { contractTestBot } from '@profullstack/sh1pt-core/testing';
-import bot, { loadConfig } from './index.js';
+import bot, { loadConfig, toBotEvent } from './index.js';
 
 contractTestBot(bot, { sampleConfig: {}, sampleChannel: '1234567890' });
 
@@ -29,5 +29,26 @@ describe('loadConfig', () => {
     expect(config.sessionTimeoutMs).toBe(1800000);
     expect(config.maxOutputLength).toBe(4000);
     expect(config.maxConcurrentSessions).toBe(5);
+  });
+});
+
+describe('toBotEvent', () => {
+  const message = (timestamp: number) => ({
+    source: 'user-1',
+    sourceName: 'User',
+    text: 'hello',
+    timestamp,
+    chatId: 123,
+    isGroup: false,
+    attachments: [],
+    raw: {},
+  });
+
+  it('preserves valid message timestamps', () => {
+    expect(toBotEvent(message(Date.UTC(2026, 0, 1))).timestamp).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('falls back when the provider supplies an invalid timestamp', () => {
+    expect(toBotEvent(message(Number.NaN)).timestamp).toBe('1970-01-01T00:00:00.000Z');
   });
 });

--- a/packages/bots/telegram/src/index.ts
+++ b/packages/bots/telegram/src/index.ts
@@ -117,7 +117,8 @@ function parsePositiveIntegerEnv(value: string | undefined, fallback: number): n
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-function toBotEvent(msg: IncomingMessage): BotEvent {
+export function toBotEvent(msg: IncomingMessage): BotEvent {
+  const date = new Date(msg.timestamp);
   return {
     type: "message",
     channel: String(msg.chatId),
@@ -127,7 +128,7 @@ function toBotEvent(msg: IncomingMessage): BotEvent {
     },
     text: msg.text,
     attachments: msg.attachments.map((a) => ({ url: a.url, filename: a.filename })),
-    timestamp: new Date(msg.timestamp).toISOString(),
+    timestamp: Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString(),
     raw: msg.raw,
   };
 }


### PR DESCRIPTION
## Summary\n- prevent malformed Telegram timestamps from crashing event normalization\n- preserve valid timestamps and fall back to the Unix epoch for invalid dates\n- add regression coverage for both paths\n\n## Validation\n- git diff --check\n- Vitest and TypeScript checks are delegated to CI because the local checkout cannot satisfy the repository supply-chain lockfile policy offline.