### PR TITLE
fix(slack): tolerate out-of-range event timestamps

### DIFF
--- a/packages/bots/slack/src/index.test.ts
+++ b/packages/bots/slack/src/index.test.ts
@@ -1,7 +1,7 @@
 import { contractTestBot } from '@profullstack/sh1pt-core/testing';
 import { request, type Server } from 'node:http';
 import { describe, expect, it } from 'vitest';
-import bot, { slackSignature, type FetchLike } from './index.js';
+import bot, { slackSignature, slackTimestamp, type FetchLike } from './index.js';
 import type { BotCtx, BotEvent, BotHandler } from '@profullstack/sh1pt-core';
 
 contractTestBot(bot, { sampleConfig: {}, sampleChannel: 'C0123456789' });
@@ -75,6 +75,10 @@ function serverPort(server: Server): number {
 }
 
 describe('Slack bot adapter', () => {
+  it('falls back for out-of-range event timestamps', () => {
+    expect(slackTimestamp('1e20')).toBe('1970-01-01T00:00:00.000Z');
+  });
+
   it('posts proactive messages with Slack Web API JSON and bearer auth', async () => {
     const { calls, fetcher } = captureFetch([{ ok: true, ts: '1700000000.123456' }]);
 

--- a/packages/bots/slack/src/index.ts
+++ b/packages/bots/slack/src/index.ts
@@ -451,10 +451,12 @@ function firstHeader(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
 }
 
-function slackTimestamp(value: string | undefined): string {
+export function slackTimestamp(value: string | undefined): string {
   if (!value) return new Date().toISOString();
   const timestamp = Number(value);
-  return Number.isFinite(timestamp) ? new Date(timestamp * 1000).toISOString() : new Date().toISOString();
+  if (!Number.isFinite(timestamp)) return new Date().toISOString();
+  const date = new Date(timestamp * 1000);
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString();
 }
 
 async function readBody(req: IncomingMessage): Promise<string> {


### PR DESCRIPTION
## Summary\n- prevent out-of-range Slack event timestamps from throwing during normalization\n- retain the current fallback for non-numeric values\n- add regression coverage for an oversized numeric timestamp\n\n## Validation\n- git diff --check\n- Vitest and TypeScript checks are delegated to CI because the local checkout cannot satisfy the repository supply-chain lockfile policy offline.