### PR TITLE
fix(signal): tolerate out-of-range event timestamps

### DIFF
--- a/packages/bots/signal/src/index.test.ts
+++ b/packages/bots/signal/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { contractTestBot } from '@profullstack/sh1pt-core/testing';
-import bot, { loadConfig } from './index.js';
+import bot, { loadConfig, toBotEvent } from './index.js';
 
 contractTestBot(bot, { sampleConfig: {}, sampleChannel: '+15551234567' });
 
@@ -48,5 +48,19 @@ describe('loadConfig', () => {
     expect(config.sessionTimeoutMs).toBe(1800000);
     expect(config.maxOutputLength).toBe(4000);
     expect(config.maxConcurrentSessions).toBe(5);
+  });
+});
+
+describe('toBotEvent', () => {
+  it('falls back when Signal provides an out-of-range timestamp', () => {
+    expect(toBotEvent({
+      source: 'user-1',
+      sourceName: 'User',
+      text: 'hello',
+      timestamp: Number.POSITIVE_INFINITY,
+      groupId: undefined,
+      attachments: [],
+      raw: {},
+    }).timestamp).toBe('1970-01-01T00:00:00.000Z');
   });
 });

--- a/packages/bots/signal/src/index.ts
+++ b/packages/bots/signal/src/index.ts
@@ -118,7 +118,8 @@ function parsePositiveSafeIntegerEnv(value: string | undefined, fallback: number
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-function toBotEvent(msg: IncomingMessage): BotEvent {
+export function toBotEvent(msg: IncomingMessage): BotEvent {
+  const date = new Date(msg.timestamp);
   return {
     type: "message",
     channel: msg.groupId ?? msg.source,
@@ -128,7 +129,7 @@ function toBotEvent(msg: IncomingMessage): BotEvent {
     },
     text: msg.text,
     attachments: msg.attachments.map((a) => ({ url: a.url, filename: a.filename })),
-    timestamp: new Date(msg.timestamp).toISOString(),
+    timestamp: Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString(),
   };
 }
 


### PR DESCRIPTION
## Summary
- prevent malformed Signal timestamps from crashing event normalization
- preserve valid timestamps and fall back to the Unix epoch for invalid dates
- add regression coverage for an out-of-range value

## Validation
- git diff --check`n- full tests delegated to GitHub CI