### PR TITLE
fix(discord): tolerate out-of-range message timestamps

### DIFF
--- a/packages/bots/discord/src/index.test.ts
+++ b/packages/bots/discord/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { contractTestBot } from '@profullstack/sh1pt-core/testing';
-import bot, { loadConfig } from './index.js';
+import bot, { loadConfig, toBotEvent } from './index.js';
 
 contractTestBot(bot, { sampleConfig: {}, sampleChannel: '1234567890' });
 
@@ -16,5 +16,21 @@ describe('loadConfig', () => {
     expect(config.sessionTimeoutMs).toBe(1800000);
     expect(config.maxOutputLength).toBe(2000);
     expect(config.maxConcurrentSessions).toBe(5);
+  });
+});
+
+describe('toBotEvent', () => {
+  it('falls back when Discord provides an out-of-range timestamp', () => {
+    expect(toBotEvent({
+      source: 'user-1',
+      sourceName: 'User',
+      text: 'hello',
+      timestamp: Number.NEGATIVE_INFINITY,
+      channelId: 'channel-1',
+      guildId: null,
+      isGuild: false,
+      attachments: [],
+      raw: undefined as never,
+    }).timestamp).toBe('1970-01-01T00:00:00.000Z');
   });
 });

--- a/packages/bots/discord/src/index.ts
+++ b/packages/bots/discord/src/index.ts
@@ -178,7 +178,8 @@ function isTextChannel(channel: unknown): channel is SendableChannel {
   return !!channel && typeof channel === "object" && "send" in channel;
 }
 
-function toBotEvent(msg: IncomingMessage): BotEvent {
+export function toBotEvent(msg: IncomingMessage): BotEvent {
+  const date = new Date(msg.timestamp);
   return {
     type: "message",
     channel: msg.channelId,
@@ -192,7 +193,7 @@ function toBotEvent(msg: IncomingMessage): BotEvent {
       filename: a.filename,
       mimeType: a.contentType,
     })),
-    timestamp: new Date(msg.timestamp).toISOString(),
+    timestamp: Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString(),
     raw: msg.raw,
   };
 }


### PR DESCRIPTION
## Summary
- prevent malformed Discord timestamps from crashing event normalization
- preserve valid timestamps and fall back to the Unix epoch for invalid dates
- add regression coverage for an out-of-range value

## Validation
- git diff --check`n- full tests delegated to GitHub CI