### PR TITLE
fix(actions/vu1nz-scan): retry the install, and stop reporting unscanned diffs as clean

### DIFF
--- a/packages/actions/vu1nz-scan/sh1pt.actionpack.yaml
+++ b/packages/actions/vu1nz-scan/sh1pt.actionpack.yaml
@@ -2,7 +2,7 @@ schemaVersion: 1
 id: vu1nz-scan
 name: vu1nz Security Scan
 description: AI-powered pull request vulnerability scanning with vu1nz.
-version: 1.0.1
+version: 1.0.2
 publisher: profullstack
 visibility: public
 license: MIT

--- a/packages/actions/vu1nz-scan/workflow.yml
+++ b/packages/actions/vu1nz-scan/workflow.yml
@@ -20,8 +20,23 @@ jobs:
         with:
           python-version: "{{pythonVersion}}"
 
+      # `pip install` from a git URL is an unretried network call to
+      # github.com. Run 30799615944 died on an `RPC failed; HTTP 503` during
+      # clone, which failed the job and skipped every step after it — the
+      # review, the comment, and the exit-code gate. A transient 503 at a
+      # forge is not a security signal, and it should not read like one.
       - name: Install vu1nz
-        run: pip install --quiet {{vu1nzPackageSpec}}
+        run: |
+          for attempt in 1 2 3; do
+            if pip install --quiet {{vu1nzPackageSpec}}; then
+              exit 0
+            fi
+            delay=$((attempt * 10))
+            echo "::warning::vu1nz install attempt ${attempt}/3 failed; retrying in ${delay}s"
+            sleep "${delay}"
+          done
+          echo "::error::vu1nz install failed after 3 attempts"
+          exit 1
 
       - name: Load env file
         env:
@@ -34,13 +49,21 @@ jobs:
           if [ -n "$ANTHROPIC_API_KEY" ]; then
             echo "::add-mask::$ANTHROPIC_API_KEY"
             echo "ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" >> "$GITHUB_ENV"
+            echo "VU1NZ_READY=true" >> "$GITHUB_ENV"
             echo "ANTHROPIC_API_KEY found and exported"
           else
-            echo "::warning::ANTHROPIC_API_KEY not found in ENV_FILE"
+            # Deliberately not a hard failure — a repo that has not configured
+            # the secret yet should not have its PRs blocked. But it must not
+            # report "0 findings" either: an unexamined diff is not a clean
+            # one, and "no issues found" is the most expensive lie a security
+            # tool can tell. VU1NZ_READY carries that distinction downstream.
+            echo "VU1NZ_READY=false" >> "$GITHUB_ENV"
+            echo "::warning::ANTHROPIC_API_KEY not found in ENV_FILE — review will report NOT RUN"
           fi
 
       - name: Review PR
         id: review
+        if: env.VU1NZ_READY == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NO_COLOR: "1"
@@ -73,6 +96,29 @@ jobs:
 
           review_file = os.environ.get("RUNNER_TEMP", "") + "/vu1nz-review.json"
           comment_file = os.environ.get("RUNNER_TEMP", "") + "/vu1nz-comment.md"
+
+          # The review step is skipped when ANTHROPIC_API_KEY is absent. Say so
+          # in the comment. Every other branch below reports a *result*; this
+          # one has to report the absence of one, because rendering "no issues
+          # found" for a scan that never ran is worse than rendering nothing.
+          if os.environ.get("VU1NZ_READY") != "true":
+              with open(comment_file, "w") as f:
+                  f.write(
+                      "## vu1nz Security Review\n\n"
+                      "**NOT RUN** — `ANTHROPIC_API_KEY` was not found in the `ENV_FILE` secret, "
+                      "so no review was performed. This is not a clean result; this diff was not "
+                      "examined.\n\n"
+                      "Add `ANTHROPIC_API_KEY=…` to the repository's `ENV_FILE` secret to enable "
+                      "the review.\n"
+                  )
+              out_path = os.environ.get("GITHUB_OUTPUT", "")
+              if out_path:
+                  with open(out_path, "a") as out:
+                      out.write("total=0\n")
+                      out.write("has_high_critical=false\n")
+                      out.write("status=not_run\n")
+              print("::warning::vu1nz review NOT RUN — ANTHROPIC_API_KEY missing")
+              sys.exit(0)
 
           try:
               with open(review_file) as f:


### PR DESCRIPTION
## Why

Both problems observed on [moshcoder/moshcode run 30799615944](https://github.com/moshcoder/moshcode/actions/runs/30799615944).

**1. The job died on a transient 503.** `pip install git+https://github.com/profullstack/vu1nz-gh-actions.git` is an unretried network call to a forge:

```
error: RPC failed; HTTP 503 curl 22 The requested URL returned error: 503
ERROR: Failed to build 'git+https://github.com/profullstack/vu1nz-gh-actions.git'
##[error]Process completed with exit code 1
```

Everything after it — `Load env file`, `Review PR`, `Build PR comment` — was skipped. A five-second blip at github.com decided the outcome of a security gate.

**2. The re-run passed without reviewing anything.** The same run warned `ANTHROPIC_API_KEY not found in ENV_FILE`, then posted `vu1nz review: 0 finding(s), no high/critical issues`. The review never ran. "No security issues found" for an unexamined diff is the most expensive thing a security tool can say, because it is indistinguishable from a real clean result.

## What changed

- **Install retries** 3× with 10/20/30s backoff, then fails loudly.
- **`VU1NZ_READY`** is set by the env-file step. Without the key the review step is skipped and the PR comment reports **NOT RUN**, with the reason and the fix. Deliberately still not a hard failure — a repo that hasn't configured the secret shouldn't have its PRs blocked — but it no longer reads as clean.
- Pack version `1.0.1` → `1.0.2`.

## Verification

- Rendered the pre-change template through the fleet renderer and confirmed it reproduces `moshcoder/moshcode`'s committed `.github/workflows/vu1nz-scan.yml` **byte-for-byte**, so the substitution/hash pipeline used here is the real one.
- Rendered output parses as YAML; the `Install vu1nz` shell passes `bash -n`; the embedded `Build PR comment` Python passes `compile()`.

Consumer re-render for moshcode goes out separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)