### PR TITLE
fix(build): repair three type errors that break `pnpm -r build`

### DIFF
--- a/packages/bot/core/src/index.ts
+++ b/packages/bot/core/src/index.ts
@@ -111,16 +111,7 @@ export class SessionManager {
       proc.stderr?.on("data", (chunk) => (stderr += chunk.toString()));
 
       return new Promise((resolve) => {
-        const finish = (result: {
-          type: string;
-          subtype: string;
-          is_error: boolean;
-          result: string;
-          duration_ms: number;
-          num_turns: number;
-          session_id: string;
-          total_cost_usd: number;
-        }) => {
+        const finish = (result: AIResult) => {
           session.busy = false;
           session.abortController = null;
           resolve(result);

--- a/packages/bots/core/src/index.ts
+++ b/packages/bots/core/src/index.ts
@@ -111,16 +111,7 @@ export class SessionManager {
       proc.stderr?.on("data", (chunk) => (stderr += chunk.toString()));
 
       return new Promise((resolve) => {
-        const finish = (result: {
-          type: string;
-          subtype: string;
-          is_error: boolean;
-          result: string;
-          duration_ms: number;
-          num_turns: number;
-          session_id: string;
-          total_cost_usd: number;
-        }) => {
+        const finish = (result: AIResult) => {
           session.busy = false;
           session.abortController = null;
           resolve(result);

--- a/packages/bots/signal/src/index.test.ts
+++ b/packages/bots/signal/src/index.test.ts
@@ -58,9 +58,9 @@ describe('toBotEvent', () => {
       sourceName: 'User',
       text: 'hello',
       timestamp: Number.POSITIVE_INFINITY,
-      groupId: undefined,
+      groupId: null,
+      isGroup: false,
       attachments: [],
-      raw: {},
     }).timestamp).toBe('1970-01-01T00:00:00.000Z');
   });
 });


### PR DESCRIPTION
`pnpm -r build` fails on master today. Three distinct type errors block the
workspace build at three different packages. This fixes all three.

### 1. `packages/bots/core` and `packages/bot/core` — TS2345

Both packages carry a duplicated copy of the same `SessionManager`. In each, the
local `finish` callback re-declares its parameter as an inline structural type
with widened primitives:

```ts
const finish = (result: {
  type: string;      // AIResult requires the literal "result"
  subtype: string;   // AIResult requires "success" | "error"
  ...
}) => { ... resolve(result); }
```

`AIResult` is declared a few lines above in the same file and requires string
*literals*. A widened `string` is not assignable to a literal type, so
`resolve(result)` is rejected.

Fixed by annotating the parameter with the existing `AIResult` interface rather
than restating its shape. That also deletes a hand-duplicated type which had
already drifted from its source — the drift is what allowed the mismatch, so
removing it prevents a recurrence.

### 2. `packages/bots/signal` — TS2322

The object literal in the timestamp-fallback test does not satisfy
`IncomingMessage` in three ways:

- `groupId: undefined` where the interface declares `string | null`
- required field `isGroup` missing
- excess property `raw` that is not on the interface

All three corrected, not just the one the compiler reports first. The test's
intent — an out-of-range timestamp falls back to epoch — is unchanged.

### Verification

- `tsc -p tsconfig.json --noEmit` exits `0` for each affected package, using the
  repo's own pinned `typescript@5.9.3` from the lockfile.
- `vitest run packages/bots/signal` → **7 passed (7)**.
- Full `pnpm -r build` now completes green through `sites/sh1pt.com build: Done`.

No runtime logic changed; the diff is entirely type-level, net **-22/+4**.

### Note on what I deliberately did *not* include

While investigating I also saw `TS2307 Cannot find module` for
`@profullstack/sh1pt-policy` and `@profullstack/sh1pt-action-packs` in
`packages/cli`. Those are **not** bugs — both are real workspace packages
correctly declared `workspace:^`; the errors only appear when typecheck runs
before those packages are built. Building them first clears it. Excluded from
this PR.
