### PR TITLE
fix: rollback plan shows new fleet IPs instead of old fleet

### DIFF
--- a/packages/cli/src/commands/scale.test.ts
+++ b/packages/cli/src/commands/scale.test.ts
@@ -16,6 +16,7 @@ import {
   parsePositiveNumber,
   parsePercentage,
   aggregateFleetCosts,
+  rollbackPlanIps,
 } from './scale.js';
 
 // Helper to create a temp dir and override CREDS_FILE path
@@ -373,5 +374,50 @@ describe('auto-scale rules', () => {
     expect(rules.maxInstances).toBe(20);
     expect(rules.targetCpuPercent).toBe(65);
     expect(rules.cooldownSeconds).toBe(300);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rollbackPlanIps — rollback plan must list the OLD fleet, not the new one
+// ---------------------------------------------------------------------------
+
+describe('rollbackPlanIps', () => {
+  const fleet: FleetState = {
+    instances: [
+      { id: 'inst-0001', provider: 'aws', status: 'stopped', createdAt: '', hourlyRate: 0.1, publicIp: '10.0.0.1' },
+      { id: 'inst-0002', provider: 'aws', status: 'stopped', createdAt: '', hourlyRate: 0.1, publicIp: '10.0.0.2' },
+      { id: 'inst-0003', provider: 'aws', status: 'running', createdAt: '', hourlyRate: 0.1, publicIp: '10.1.0.1' },
+    ],
+  };
+  const rollout: RolloutRecord = {
+    id: 'roll-1',
+    version: 'v2',
+    strategy: 'blue-green',
+    status: 'completed',
+    startedAt: '2026-08-08T00:00:00.000Z',
+    newInstanceIds: ['inst-0003'],
+    oldInstanceIds: ['inst-0001', 'inst-0002'],
+  };
+
+  it('lists the old (pre-rollout) instances, not the new ones', () => {
+    const ips = rollbackPlanIps(fleet, rollout);
+    expect(ips).toEqual(['10.0.0.1', '10.0.0.2']);
+    expect(ips).not.toContain('10.1.0.1');
+  });
+
+  it('falls back to privateIp when publicIp is missing', () => {
+    const fleetNoPub: FleetState = {
+      instances: [
+        { id: 'inst-0001', provider: 'aws', status: 'stopped', createdAt: '', hourlyRate: 0.1, privateIp: '172.16.0.5' },
+      ],
+    };
+    expect(rollbackPlanIps(fleetNoPub, rollout)).toEqual(['172.16.0.5']);
+  });
+
+  it('returns placeholder for instances without any ip', () => {
+    const fleetNoIp: FleetState = {
+      instances: [{ id: 'inst-0001', provider: 'aws', status: 'stopped', createdAt: '', hourlyRate: 0.1 }],
+    };
+    expect(rollbackPlanIps(fleetNoIp, rollout)).toEqual(['?.?.?.?']);
   });
 });

--- a/packages/cli/src/commands/scale.ts
+++ b/packages/cli/src/commands/scale.ts
@@ -215,6 +215,13 @@ export function aggregateFleetCosts(
   return providerMap;
 }
 
+/** Resolve the IPs of the old (pre-rollout) fleet for a rollback plan display. */
+export function rollbackPlanIps(fleet: FleetState, target: RolloutRecord): string[] {
+  return fleet.instances
+    .filter(i => target.oldInstanceIds.includes(i.id))
+    .map(i => i.publicIp || i.privateIp || '?.?.?.?');
+}
+
 export const scaleCmd = new Command('scale')
   .description('Provision + scale cloud infra. DNS round-robin, rollouts, rightsizing — all the capacity ops.')
   .option('--from <input>', 'existing live url, repo, or local path to probe + propose scaling for')
@@ -728,9 +735,7 @@ scaleCmd
         process.exit(1);
       }
       const fleet = loadFleet();
-      const oldIps = fleet.instances
-        .filter(i => target.newInstanceIds.includes(i.id))
-        .map(i => i.publicIp || i.privateIp || '?.?.?.?');
+      const oldIps = rollbackPlanIps(fleet, target);
       console.log(kleur.bold('\\n⏮ Rollback Plan'));
       console.log(kleur.dim('─'.repeat(56)));
       console.log(`${kleur.cyan('Rollout ID:'.padEnd(20))} ${target.id.slice(0, 8)} (v${target.version})`);


### PR DESCRIPTION
## Bug

In `sh1pt scale rollout --rollback <id>`, the rollback plan displayed `oldIps` by filtering the fleet against `target.newInstanceIds`:

```ts
const oldIps = fleet.instances
  .filter(i => target.newInstanceIds.includes(i.id))   // BUG: filters NEW ids
  .map(i => i.publicIp || i.privateIp || '?.?.?.?');
```

The plan therefore showed the IPs of the **new** instances being torn down, while the actual rollback action (lines below) correctly reactivates `target.oldInstanceIds` for blue-green. The displayed IPs list contradicted what the command did.

## Fix

Extract a tested `rollbackPlanIps()` helper that filters against `target.oldInstanceIds`, and use it in the rollback plan. Adds regression tests for publicIp, privateIp fallback, and the missing-IP placeholder.

## Verification

- `pnpm vitest run packages/cli/src/commands/scale.test.ts` → 53 tests passed (3 new)
- Typecheck: only pre-existing errors in `build-actions.ts`/`ship.ts` (missing built workspace packages), unchanged by this PR