### PR TITLE
fix(telegram): tolerate out-of-range message timestamps

### DIFF
--- a/packages/bots/telegram/src/index.test.ts
+++ b/packages/bots/telegram/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { contractTestBot } from '@profullstack/sh1pt-core/testing';
-import bot, { loadConfig, parseTelegramChatId } from './index.js';
+import bot, { loadConfig, parseTelegramChatId, toBotEvent } from './index.js';
 
 contractTestBot(bot, { sampleConfig: {}, sampleChannel: '1234567890' });
 
@@ -43,5 +43,20 @@ describe('loadConfig', () => {
     expect(config.sessionTimeoutMs).toBe(1800000);
     expect(config.maxOutputLength).toBe(4000);
     expect(config.maxConcurrentSessions).toBe(5);
+  });
+});
+
+describe('toBotEvent', () => {
+  it('falls back when Telegram provides an out-of-range timestamp', () => {
+    expect(toBotEvent({
+      source: 'user-1',
+      sourceName: 'User',
+      text: 'hello',
+      timestamp: Number.NEGATIVE_INFINITY,
+      chatId: 1234567890,
+      isGroup: false,
+      attachments: [],
+      raw: undefined as never,
+    }).timestamp).toBe('1970-01-01T00:00:00.000Z');
   });
 });

--- a/packages/bots/telegram/src/index.ts
+++ b/packages/bots/telegram/src/index.ts
@@ -126,7 +126,8 @@ export function parseTelegramChatId(value: string): number {
   return chatId;
 }
 
-function toBotEvent(msg: IncomingMessage): BotEvent {
+export function toBotEvent(msg: IncomingMessage): BotEvent {
+  const date = new Date(msg.timestamp);
   return {
     type: "message",
     channel: String(msg.chatId),
@@ -136,7 +137,7 @@ function toBotEvent(msg: IncomingMessage): BotEvent {
     },
     text: msg.text,
     attachments: msg.attachments.map((a) => ({ url: a.url, filename: a.filename })),
-    timestamp: new Date(msg.timestamp).toISOString(),
+    timestamp: Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString(),
     raw: msg.raw,
   };
 }


### PR DESCRIPTION
## Summary
- Prevent malformed Telegram timestamps from crashing event normalization
- Preserve valid timestamps and fall back to the Unix epoch for invalid dates
- Add regression coverage for an out-of-range value

This mirrors the landed fixes for **discord (#933)** and **signal (#932)**: the Telegram integration was the only remaining `packages/bots/*` bot whose `toBotEvent` still used the unsafe `new Date(msg.timestamp).toISOString()` (found via `grep -rn "new Date(msg.timestamp).toISOString()"`).

## Why it matters
A NaN/Infinity/invalid timestamp from a malformed Telegram payload would throw inside `new Date(...).toISOString()` and crash event normalization. Discord and Signal already guard against this; Telegram did not.

## Validation
- `corepack pnpm --filter @profullstack/sh1pt-core build` then `--filter @profullstack/sh1pt-bot-telegram build` → clean
- `npx vitest run packages/bots/telegram` → **16 tests pass** (15 existing + 1 new regression test)
- git diff --check clean

## ⚠️ Rebase
I have enabled **"Allow edits from maintainers"** so the auto-rebase bot can push (the earlier Telegram attempt #929 failed only because the fork blocked maintainer pushes).