### PR TITLE
fix(scale): avoid instance ID precision collisions

### DIFF
--- a/packages/cli/src/commands/scale.test.ts
+++ b/packages/cli/src/commands/scale.test.ts
@@ -58,6 +58,13 @@ describe('getNextId', () => {
     expect(getNextId(instances)).toBe('inst-0100');
   });
 
+  it('increments ids beyond the safe integer range without collisions', () => {
+    const instances: FleetEntry[] = [
+      { id: 'inst-9007199254740992', provider: 'aws', status: 'running', createdAt: '', hourlyRate: 0.096 },
+    ];
+    expect(getNextId(instances)).toBe('inst-9007199254740993');
+  });
+
   it('ignores ids that do not match the inst- pattern', () => {
     const instances: FleetEntry[] = [
       { id: 'custom-id', provider: 'aws', status: 'running', createdAt: '', hourlyRate: 0.096 },

--- a/packages/cli/src/commands/scale.ts
+++ b/packages/cli/src/commands/scale.ts
@@ -116,9 +116,9 @@ export function getNextId(instances: FleetEntry[]): string {
   const nums = instances
     .map((i) => /^inst-(\d+)$/.exec(i.id)?.[1])
     .filter((value): value is string => value !== undefined)
-    .map((value) => Number.parseInt(value, 10));
-  const max = nums.length > 0 ? Math.max(...nums) : 0;
-  return `inst-${String(max + 1).padStart(4, '0')}`;
+    .map((value) => BigInt(value));
+  const max = nums.reduce((highest, value) => value > highest ? value : highest, 0n);
+  return `inst-${String(max + 1n).padStart(4, '0')}`;
 }
 
 export function parsePositiveInteger(value: string): number {


### PR DESCRIPTION
Fixes #949.

## What changed

- keep parsed `inst-*` numeric suffixes as `BigInt` values while finding the maximum
- increment the maximum without JavaScript `Number` precision loss
- add a regression test above `Number.MAX_SAFE_INTEGER`

## Why

`getNextId` previously parsed suffixes with `Number.parseInt`. For an existing ID such as `inst-9007199254740992`, adding one rounded back to the same value, so the function returned an ID that was already present in the fleet.

The generated identifier now remains exact and advances to `inst-9007199254740993` while preserving the existing zero-padded format for normal IDs.

## Impact

Scale and rollout operations no longer risk duplicate generated instance IDs when a fleet snapshot contains a numeric suffix outside JavaScript's safe integer range.

## Validation

- `corepack pnpm exec vitest run packages/cli/src/commands/scale.test.ts --reporter=verbose` (54 tests passed)
- `corepack pnpm --filter @profullstack/sh1pt... build` (CLI and six workspace dependencies built successfully)
- `git diff --check`
