### PR TITLE
fix(threatcrush-scan): pin the CLI install spec instead of @latest

### DIFF
--- a/packages/actions/threatcrush-scan/README.md
+++ b/packages/actions/threatcrush-scan/README.md
@@ -14,7 +14,7 @@ sh1pt actions install threatcrush-scan --repo owner/name --pr
 | --- | --- | --- |
 | `scanPath` | `.` | Path to scan, relative to the repository root. |
 | `nodeVersion` | `20` | See *Node 20, deliberately*, below. |
-| `threatcrushPackageSpec` | `@profullstack/threatcrush@latest` | npm spec used to install the CLI. |
+| `threatcrushPackageSpec` | `@profullstack/threatcrush@0.11.0` | npm spec used to install the CLI. Pinned rather than `@latest` so one bad publish cannot break every consumer at once; bump it in a pack release. |
 | `failOn` | *(empty)* | Comma-separated severities that fail the job, e.g. `critical,high`. Empty is report-only. |
 | `uploadSarif` | `true` | Upload to the Security tab. |
 

--- a/packages/actions/threatcrush-scan/sh1pt.actionpack.yaml
+++ b/packages/actions/threatcrush-scan/sh1pt.actionpack.yaml
@@ -5,7 +5,7 @@ description: >-
   Scans pull requests for hardcoded credentials, injection, SSRF, unsafe
   deserialisation and dependency tampering, and uploads SARIF to the Security
   tab.
-version: 1.1.0
+version: 1.2.0
 publisher: profullstack
 visibility: public
 license: MIT
@@ -32,8 +32,14 @@ inputs:
       that fails without a full toolchain.
   threatcrushPackageSpec:
     type: string
-    default: '@profullstack/threatcrush@latest'
-    description: npm spec used to install the CLI.
+    default: '@profullstack/threatcrush@0.11.0'
+    description: >-
+      npm spec used to install the CLI. Pinned, not `@latest`: a scanner that
+      runs on every pull request is a dependency, and `@latest` means one bad
+      publish breaks CI in every repo that installed this pack at once — which
+      is exactly what a `workspace:` protocol slip in 0.7.0/0.7.1 did. Bump this
+      deliberately, in a pack release, so the fleet re-syncs consumers to a
+      version that was checked first.
   failOn:
     type: string
     default: ''


### PR DESCRIPTION
## The problem

The `threatcrush-scan` action pack installs the CLI with `threatcrushPackageSpec` defaulting to `@profullstack/threatcrush@latest`, and that spec is baked into every consumer's workflow at install time. So a scanner that runs on every PR is an **unpinned dependency shared across the whole fleet** — one bad publish breaks CI in every repo that installed the pack, simultaneously.

That is not hypothetical. A `workspace:` protocol slip shipped in `@profullstack/threatcrush` 0.7.0 and 0.7.1 made `npm install` fail with `EUNSUPPORTEDPROTOCOL`, and every `@latest` consumer's scan errored on it — ~28 repos plus the testbed's own CI — on a registry problem that had nothing to do with their diff. The retry loop in the workflow can't help: a broken publish fails deterministically, not transiently.

## The fix

Pin the default install spec to a known-good version (`@0.11.0`) instead of `@latest`, and bump the pack `1.1.0 → 1.2.0` so the fleet re-syncs consumers off the unpinned spec.

- New installs pin automatically.
- A future bad `@latest` publish can no longer cascade — consumers are on a version that was checked first.
- Updating is now a deliberate pack release: bump the pinned default to a reviewed version, and the fleet propagates it. That is the whole point of a centrally-managed pack — deliberate, reviewed rollout rather than "whatever the registry served this morning."

Consumers that want to track a different version still override `threatcrushPackageSpec` per-repo.

Two files: the pack default + description, and the README's input table.

_Follow-up for whoever runs the fleet: existing consumers keep the `@latest` value baked in until they re-sync to pack 1.2.0 — a fleet re-apply propagates the pin to the ~28 repos already installed._
