### PR TITLE
fix(promo-posthog): allow credential-free dry runs

### DIFF
--- a/packages/promo/posthog/src/index.test.ts
+++ b/packages/promo/posthog/src/index.test.ts
@@ -42,7 +42,7 @@ describe('PostHog experiment API integration', () => {
     expect(calls[0]!.init.method).toBe('POST');
   });
 
-  it('returns dry-run result without hitting the API', async () => {
+  it('returns dry-run result without credentials or an API call', async () => {
     vi.stubGlobal('fetch', async () => {
       throw new Error('should not call fetch in dry-run');
     });
@@ -56,7 +56,7 @@ describe('PostHog experiment API integration', () => {
         start: new Date(),
         objective: 'awareness',
         creatives: [],
-        secret: (k) => (k === 'POSTHOG_PERSONAL_API_KEY' ? 'phx_secret' : undefined),
+        secret: () => undefined,
         log: () => {},
         dryRun: true,
       },

--- a/packages/promo/posthog/src/index.ts
+++ b/packages/promo/posthog/src/index.ts
@@ -67,11 +67,11 @@ export default defineAdPlatform<Config>({
   },
 
   async start(ctx, config) {
-    const key = ctx.secret(POSTHOG_KEY_SECRET) ?? config.personalApiKey;
-    if (!key) throw new Error(`${POSTHOG_KEY_SECRET} not in vault`);
     if (!config.projectId) throw new Error('projectId required to create experiments');
     ctx.log(`posthog experiment create · project=${config.projectId} · objective=${ctx.objective}`);
     if (ctx.dryRun) return { id: 'dry-run' };
+    const key = ctx.secret(POSTHOG_KEY_SECRET) ?? config.personalApiKey;
+    if (!key) throw new Error(`${POSTHOG_KEY_SECRET} not in vault`);
 
     const creative = ctx.creatives[0];
     const experiment = await phPost<ExperimentResponse>(


### PR DESCRIPTION
## Bug

`promo-posthog.start()` resolves and validates `POSTHOG_PERSONAL_API_KEY` before checking `ctx.dryRun`. As a result, previewing a valid PostHog experiment fails for users who have not configured credentials, even though dry-run never calls PostHog. This also conflicts with the ad-platform dry-run contract, whose fake campaign context has an empty vault.

## Reproduction

Call `adapter.start()` with:

- `dryRun: true`
- `secret: () => undefined`
- config `{ projectApiKey: 'ph_proj', projectId: '99' }`
- a `fetch` stub that throws if called

Before this fix, the call rejects with:

```
POSTHOG_PERSONAL_API_KEY not in vault
```

The existing dry-run test did not catch this because it supplied a fake personal API key.

## Fix

Keep `projectId` validation for a meaningful preview, then return the dry-run campaign result before resolving the credential. Non-dry-run starts still require the personal API key before making the API request.

The regression test now uses an empty vault and retains the throwing `fetch` stub, proving both credential-free and network-free dry-run behavior.

## Verification

```
corepack pnpm exec vitest run packages/promo/posthog/src/index.test.ts --reporter=verbose
# 1 file passed, 5 tests passed

corepack pnpm --filter @profullstack/sh1pt-promo-posthog typecheck
# passed

corepack pnpm exec vitest run packages/promo --reporter=dot
# 15 files passed, 34 tests passed
```
