### PR TITLE
fix(sdk-pypi): allow dry-run without token

### DIFF
--- a/packages/targets/sdk-pypi/src/index.test.ts
+++ b/packages/targets/sdk-pypi/src/index.test.ts
@@ -1,0 +1,34 @@
+import { fakeShipContext } from '@profullstack/sh1pt-core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { execMock } = vi.hoisted(() => ({
+  execMock: vi.fn(),
+}));
+
+vi.mock('@profullstack/sh1pt-core', async () => ({
+  ...await vi.importActual<typeof import('@profullstack/sh1pt-core')>('@profullstack/sh1pt-core'),
+  exec: execMock,
+}));
+
+import adapter from './index.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('sdk-pypi target adapter', () => {
+  it('does not require a token or invoke twine for dry-run shipping', async () => {
+    const secret = vi.fn(() => undefined);
+
+    await expect(adapter.ship(fakeShipContext({
+      dryRun: true,
+      secret,
+    }) as any, {})).resolves.toEqual({
+      id: 'dry-run',
+      meta: { repository: 'https://upload.pypi.org/legacy/' },
+    });
+
+    expect(secret).not.toHaveBeenCalled();
+    expect(execMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/targets/sdk-pypi/src/index.ts
+++ b/packages/targets/sdk-pypi/src/index.ts
@@ -34,22 +34,22 @@ export default defineTarget<Config>({
   },
 
   async ship(ctx, config) {
-    const token = ctx.secret('PYPI_TOKEN');
-    if (!token) {
-      throw new Error('PYPI_TOKEN not set. Run: sh1pt secret set PYPI_TOKEN <token>');
-    }
-
     const repository = config.repository ?? 'https://upload.pypi.org/legacy/';
-    const repoFlag = config.repository === 'testpypi'
-      ? ['--repository', 'testpypi']
-      : ['--repository-url', repository];
-
-    ctx.log(`pypi: uploading to ${repository}`);
     if (ctx.dryRun) {
       ctx.log('pypi: dry-run — would upload distribution');
       return { id: 'dry-run', meta: { repository } };
     }
 
+    const token = ctx.secret('PYPI_TOKEN');
+    if (!token) {
+      throw new Error('PYPI_TOKEN not set. Run: sh1pt secret set PYPI_TOKEN <token>');
+    }
+
+    const repoFlag = config.repository === 'testpypi'
+      ? ['--repository', 'testpypi']
+      : ['--repository-url', repository];
+
+    ctx.log(`pypi: uploading to ${repository}`);
     const { stdout } = await exec(
       'twine',
       [


### PR DESCRIPTION
## Reproduction

On current `master`, call `adapter.ship(fakeShipContext({ dryRun: true, secret: () => undefined }), {})`. Instead of returning the dry-run preview, `sdk-pypi` rejects with `PYPI_TOKEN not set` because it reads and validates the token before checking `ctx.dryRun`. It therefore cannot preview a PyPI upload without credentials, unlike the other target adapters’ side-effect-free dry-run behavior.

## Fix

Resolve the repository and return the existing dry-run result before reading `PYPI_TOKEN`. Real uploads still require the token and retain the same Twine arguments.

## Regression coverage

Added a focused test that supplies `dryRun: true` with an empty vault and verifies that:

- shipping resolves to the existing dry-run metadata;
- the secret vault is not read; and
- Twine is not invoked.

Verification:

- `corepack pnpm exec vitest run packages/targets/sdk-pypi/src/index.test.ts` — 1 test passed
- `corepack pnpm --filter @profullstack/sh1pt-target-sdk-pypi typecheck` — passed
- `corepack pnpm --filter @profullstack/sh1pt-target-sdk-pypi build` — passed
- `corepack pnpm exec vitest run packages/targets` — 67 files, 484 tests passed