### PR TITLE
fix(core): collect fields when reusing setup token

### DIFF
--- a/packages/core/src/setup-helpers.test.ts
+++ b/packages/core/src/setup-helpers.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import { tokenSetup } from './setup-helpers.js';
+
+describe('tokenSetup', () => {
+  it('collects required config fields when reusing an existing token', async () => {
+    const prompt = vi.fn()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce('-1001234567890');
+    const setup = tokenSetup<{ chatId: string }>({
+      secretKey: 'TELEGRAM_BOT_TOKEN',
+      label: 'Telegram',
+      steps: [],
+      fields: [
+        { key: 'chatId', message: 'Chat ID:', required: true },
+      ],
+    });
+
+    const result = await setup({
+      secret: () => 'existing-token',
+      setSecret: vi.fn(),
+      prompt,
+      open: vi.fn(),
+      log: vi.fn(),
+      run: vi.fn(),
+      platform: process.platform,
+      env: process.env,
+    });
+
+    expect(result).toEqual({ ok: true, config: { chatId: '-1001234567890' } });
+    expect(prompt).toHaveBeenNthCalledWith(2, {
+      type: 'text',
+      message: 'Chat ID:',
+    });
+  });
+});

--- a/packages/core/src/setup-helpers.ts
+++ b/packages/core/src/setup-helpers.ts
@@ -157,28 +157,30 @@ export interface TokenSetupOpts<C = unknown> {
 export function tokenSetup<C = unknown>(opts: TokenSetupOpts<C>): SetupFn<C> {
   return async (ctx) => {
     const existing = ctx.secret(opts.secretKey);
+    let reuseExisting = false;
     if (existing) {
-      const reuse = await ctx.prompt<boolean>({
+      reuseExisting = await ctx.prompt<boolean>({
         type: 'confirm',
         message: `${opts.secretKey} already in vault — reuse it?`,
         initial: true,
       });
-      if (reuse) return { ok: true, config: (opts.config ?? {}) as C };
     }
 
-    ctx.log(`${opts.label} setup:`);
-    for (const line of opts.steps) ctx.log(`  ${line}`);
-    if (opts.vendorDocUrl) await ctx.open(opts.vendorDocUrl);
+    if (!reuseExisting) {
+      ctx.log(`${opts.label} setup:`);
+      for (const line of opts.steps) ctx.log(`  ${line}`);
+      if (opts.vendorDocUrl) await ctx.open(opts.vendorDocUrl);
 
-    const token = await ctx.prompt<string>({
-      type: 'password',
-      message: `Paste the ${opts.label} API token:`,
-    });
+      const token = await ctx.prompt<string>({
+        type: 'password',
+        message: `Paste the ${opts.label} API token:`,
+      });
 
-    if (!token) {
-      return { ok: false, config: (opts.config ?? {}) as C, manual: opts.steps };
+      if (!token) {
+        return { ok: false, config: (opts.config ?? {}) as C, manual: opts.steps };
+      }
+      await ctx.setSecret(opts.secretKey, token);
     }
-    await ctx.setSecret(opts.secretKey, token);
 
     const configExtras: Record<string, string> = {};
     for (const field of opts.fields ?? []) {


### PR DESCRIPTION
## Reproduction

`tokenSetup()` returns immediately after a user confirms reuse of an existing token. That skips every configured `fields` prompt. A Telegram setup with an existing `TELEGRAM_BOT_TOKEN`, for example, reports success as `{ ok: true, config: {} }` instead of collecting `chatId`; `runSetup()` then persists that empty config and subsequent sends have no chat ID. The same control flow drops GitHub/Gitea owner and repo fields and the GitLab project ID.

The new regression test reproduces this by supplying an existing token, confirming reuse, and then supplying the required Telegram chat ID. Before the fix it fails with:

```
Expected: { ok: true, config: { chatId: "-1001234567890" } }
Received: { ok: true, config: {} }
```

## Fix

Reuse now skips only the token instructions and token prompt. Setup continues through the existing field-collection loop, preserving the token while returning the required adapter configuration. Fresh-token and token-replacement paths retain their prior behavior.

## Verification

- `corepack pnpm exec vitest run packages/core/src/setup-helpers.test.ts packages/core/src/config-store.test.ts packages/core/src/exec.test.ts packages/core/src/mcp-server.test.ts` — 4 files passed, 6 tests passed, 1 platform-specific skip.
- Rebuilt core, then `corepack pnpm exec vitest run packages/core packages/vcs packages/webhooks` — 12 files passed, 59 tests passed, 1 platform-specific skip.
- `corepack pnpm --filter @profullstack/sh1pt-core typecheck` — passed.
- `git diff --check` — passed.