### PR TITLE
fix(cj): reject invalid commission date windows

### DIFF
--- a/packages/affiliates/cj/src/index.test.ts
+++ b/packages/affiliates/cj/src/index.test.ts
@@ -171,6 +171,17 @@ describe('CJ affiliate adapter', () => {
       accountId: 'affiliate-cj',
     });
   });
+  it('rejects invalid and reversed commission date windows before calling CJ', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(adapter.stats?.(ctx(), '123', { accountId: '45628', from: 'not-a-date', to: '2026-05-20' }))
+      .rejects.toThrow('requires valid from/to dates');
+    await expect(adapter.stats?.(ctx(), '123', { accountId: '45628', from: '2026-05-20', to: '2026-05-01' }))
+      .rejects.toThrow('requires to >= from');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
 });
 
 function xmlResponse(body: string) {

--- a/packages/affiliates/cj/src/index.ts
+++ b/packages/affiliates/cj/src/index.ts
@@ -218,7 +218,12 @@ function isoDateTime(value: string, endOfDay: boolean): string {
 function ensureSupportedWindow(from: string, to: string): void {
   const start = Date.parse(from);
   const end = Date.parse(to);
-  if (!Number.isFinite(start) || !Number.isFinite(end)) return;
+  if (!Number.isFinite(start) || !Number.isFinite(end)) {
+    throw new Error('CJ Commission Detail API requires valid from/to dates');
+  }
+  if (end < start) {
+    throw new Error('CJ Commission Detail API requires to >= from');
+  }
   const days = (end - start) / 86_400_000;
   if (days > 31) throw new Error('CJ Commission Detail API supports a maximum 31-day date range per query');
 }


### PR DESCRIPTION
Fixes a CJ stats failure path where malformed or reversed `from`/`to` values bypassed the local range guard and were sent to the provider.

The adapter now rejects unparseable dates and `to < from` before any network request. A regression test covers both cases and asserts `fetch` is untouched.

Local `git diff --check` passes. The current host does not expose pnpm, so I am relying on the repository CI for the package test rather than installing another runtime.

This PR is submitted for the open uGig sh1pt bug-fix bounty.