### PR TITLE
fix(threatcrush-scan): drop install scripts and the checkout token

### DIFF
--- a/packages/actions/threatcrush-scan/README.md
+++ b/packages/actions/threatcrush-scan/README.md
@@ -14,7 +14,7 @@ sh1pt actions install threatcrush-scan --repo owner/name --pr
 | --- | --- | --- |
 | `scanPath` | `.` | Path to scan, relative to the repository root. |
 | `nodeVersion` | `20` | See *Node 20, deliberately*, below. |
-| `threatcrushPackageSpec` | `@profullstack/threatcrush@latest` | npm spec used to install the CLI. |
+| `threatcrushPackageSpec` | `@profullstack/threatcrush@0.11.0` | npm spec used to install the CLI. Must be an exact version — a floating spec installs unreviewed code on someone else's runner, and static analysis fails the workflow for it. |
 | `failOn` | *(empty)* | Comma-separated severities that fail the job, e.g. `critical,high`. Empty is report-only. |
 | `uploadSarif` | `true` | Upload to the Security tab. |
 

--- a/packages/actions/threatcrush-scan/README.md
+++ b/packages/actions/threatcrush-scan/README.md
@@ -14,7 +14,7 @@ sh1pt actions install threatcrush-scan --repo owner/name --pr
 | --- | --- | --- |
 | `scanPath` | `.` | Path to scan, relative to the repository root. |
 | `nodeVersion` | `20` | See *Node 20, deliberately*, below. |
-| `threatcrushPackageSpec` | `@profullstack/threatcrush@0.11.0` | npm spec used to install the CLI. Must be an exact version — a floating spec installs unreviewed code on someone else's runner, and static analysis fails the workflow for it. |
+| `threatcrushPackageSpec` | `@profullstack/threatcrush@0.11.0` | npm spec used to install the CLI. Pinned rather than `@latest` so one bad publish cannot break every consumer at once; bump it in a pack release. |
 | `failOn` | *(empty)* | Comma-separated severities that fail the job, e.g. `critical,high`. Empty is report-only. |
 | `uploadSarif` | `true` | Upload to the Security tab. |
 

--- a/packages/actions/threatcrush-scan/sh1pt.actionpack.yaml
+++ b/packages/actions/threatcrush-scan/sh1pt.actionpack.yaml
@@ -34,13 +34,12 @@ inputs:
     type: string
     default: '@profullstack/threatcrush@0.11.0'
     description: >-
-      npm spec used to install the CLI. An exact version, not a range and not
-      `@latest`: a floating spec means the workflow committed to a repository
-      today installs something nobody reviewed tomorrow, and static analysis
-      reads it as exactly that — SonarQube's githubactions:S8543 fails a
-      quality gate on it. Whoever installs the pack should render the version
-      current at install time; from then on the repository upgrades when it
-      decides to, which is the whole point of a pin.
+      npm spec used to install the CLI. Pinned, not `@latest`: a scanner that
+      runs on every pull request is a dependency, and `@latest` means one bad
+      publish breaks CI in every repo that installed this pack at once — which
+      is exactly what a `workspace:` protocol slip in 0.7.0/0.7.1 did. Bump this
+      deliberately, in a pack release, so the fleet re-syncs consumers to a
+      version that was checked first.
   failOn:
     type: string
     default: ''

--- a/packages/actions/threatcrush-scan/sh1pt.actionpack.yaml
+++ b/packages/actions/threatcrush-scan/sh1pt.actionpack.yaml
@@ -5,7 +5,7 @@ description: >-
   Scans pull requests for hardcoded credentials, injection, SSRF, unsafe
   deserialisation and dependency tampering, and uploads SARIF to the Security
   tab.
-version: 1.1.0
+version: 1.2.0
 publisher: profullstack
 visibility: public
 license: MIT
@@ -32,8 +32,15 @@ inputs:
       that fails without a full toolchain.
   threatcrushPackageSpec:
     type: string
-    default: '@profullstack/threatcrush@latest'
-    description: npm spec used to install the CLI.
+    default: '@profullstack/threatcrush@0.11.0'
+    description: >-
+      npm spec used to install the CLI. An exact version, not a range and not
+      `@latest`: a floating spec means the workflow committed to a repository
+      today installs something nobody reviewed tomorrow, and static analysis
+      reads it as exactly that — SonarQube's githubactions:S8543 fails a
+      quality gate on it. Whoever installs the pack should render the version
+      current at install time; from then on the repository upgrades when it
+      decides to, which is the whole point of a pin.
   failOn:
     type: string
     default: ''

--- a/packages/actions/threatcrush-scan/workflow.yml
+++ b/packages/actions/threatcrush-scan/workflow.yml
@@ -15,7 +15,14 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      # persist-credentials: false because nothing here pushes. Left at the
+      # default, checkout leaves a credential in .git/config for the rest of
+      # the job — and the rest of this job runs a scanner installed from the
+      # network over the contents of a pull request. A token that no step
+      # needs should not be sitting in the working tree while that happens.
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -25,10 +32,17 @@ jobs:
       # whether a security gate runs at all. Retry before giving up; a
       # transient registry blip is not a security signal and should not read
       # like one.
+      #
+      # --ignore-scripts because a lifecycle script is arbitrary code from the
+      # dependency tree, and this job holds `pull-requests: write` and
+      # `security-events: write`. The CLI does not need them: it declares no
+      # install hook of its own, and `scan` was verified to run correctly from
+      # an --ignore-scripts install. A security gate that opens a shell for
+      # its own supply chain is not a gate.
       - name: Install ThreatCrush
         run: |
           for attempt in 1 2 3; do
-            if npm install -g "{{threatcrushPackageSpec}}"; then
+            if npm install -g --ignore-scripts "{{threatcrushPackageSpec}}"; then
               exit 0
             fi
             delay=$((attempt * 10))


### PR DESCRIPTION
The `threatcrush-scan` pack fails security review on the repositories it is installed into — a bad look for any workflow, a fatal one for a workflow whose subject is security.

SonarCloud's quality gate on [NeptuneHub/AudioMuse-AI#856](https://github.com/NeptuneHub/AudioMuse-AI/pull/856) failed with a **C security rating on new code**, both findings on the install line:

```
githubactions:S6505  Omitting "--ignore-scripts" allows lifecycle scripts to run
                     during package installation.
githubactions:S8543  Using dependencies without locking resolved versions is
                     security-sensitive.
```

CodeRabbit reached the same conclusion independently on [chrisleekr/binance-trading-bot#732](https://github.com/chrisleekr/binance-trading-bot/pull/732), scoring the PR 🟡 Moderate because it "gives an unpinned scanner access to a write-scoped job and retained checkout credentials".

**S8543 is already fixed on master** — #952 pinned `threatcrushPackageSpec` to `0.11.0` while this branch was open, with a better reason than the one this branch originally carried: the `workspace:` protocol slip in 0.7.0/0.7.1 is what `@latest` actually cost. Both sides reached the same default, so the manifest and README here are now byte-identical to master's, which also un-conflicts the branch.

## What is left, which master does not have

The job holds `pull-requests: write` and `security-events: write`, and it still runs the install with lifecycle scripts enabled and a checkout credential in `.git/config`.

- **`--ignore-scripts` on the install** (S6505). A lifecycle script is arbitrary code from the dependency tree; the CLI declares no install hook of its own, so this costs nothing it needs.
- **`persist-credentials: false` on checkout.** Nothing in this job pushes, so the token should not sit in the working tree while a network-installed scanner reads a pull request diff.

## Verified

`--ignore-scripts` skips `better-sqlite3`'s native install hook, so this is the change that could plausibly have broken the scan. It does not:

```
$ npm install -g --prefix ./prefix --ignore-scripts @profullstack/threatcrush@0.11.0
added 208 packages in 10s
$ ./prefix/bin/threatcrush --version
0.11.0
$ ./prefix/bin/threatcrush scan ./fixture
  CRITICAL  AWS Access Key         app.js:1  secret-aws-access-key · CWE-798
  [HIGH]    Hardcoded Credential   app.js:1  secret-generic-credential · CWE-798
  [MEDIUM]  dynamic code execution app.js:3  js-dynamic-code-execution · CWE-95
  3 issue(s) found across 1 files
```

Both YAML files still parse, and the rendered workflow carries the changes through:

```
      - uses: actions/checkout@v4
          persist-credentials: false
            if npm install -g --ignore-scripts "@profullstack/threatcrush@0.11.0"; then
```

Rendered into AudioMuse-AI#856, SonarCloud went from 2 MAJOR vulnerabilities to **0 open issues** and the gate passes.

Consumer side is profullstack/threatcrush#121; wider discussion of the 0-for-6 first batch is profullstack/threatcrush#120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
