### PR TITLE
feat(threatcrush-scan): ask for no write scope when nothing writes

### DIFF
--- a/packages/actions/threatcrush-scan/sh1pt.actionpack.yaml
+++ b/packages/actions/threatcrush-scan/sh1pt.actionpack.yaml
@@ -5,7 +5,7 @@ description: >-
   Scans pull requests for hardcoded credentials, injection, SSRF, unsafe
   deserialisation and dependency tampering, and uploads SARIF to the Security
   tab.
-version: 1.4.0
+version: 1.5.0
 publisher: profullstack
 visibility: public
 license: MIT

--- a/packages/actions/threatcrush-scan/sh1pt.actionpack.yaml
+++ b/packages/actions/threatcrush-scan/sh1pt.actionpack.yaml
@@ -59,6 +59,32 @@ inputs:
       but a confusing one to debug. Read it from
       `npm view <spec> dist.integrity`. Empty skips verification, for a
       consumer pointing the spec at something they build themselves.
+  commentOnPr:
+    type: string
+    default: 'true'
+    enum:
+      - 'true'
+      - 'false'
+    description: >-
+      Post the report as a pull request comment. Requires
+      `pull-requests: write`.
+
+      Set this and uploadSarif both to 'false' and the workflow requests
+      `contents: read` and nothing else — findings arrive in the job summary
+      and the SARIF artifact instead. That is the configuration for a
+      repository that wants the scan without granting a third-party CLI any
+      write scope, which is a substantial part of what reviewers decline on.
+  extraPermissions:
+    type: string
+    default: "  pull-requests: write\n  security-events: write"
+    description: >-
+      The permission lines added beneath `contents: read`, computed from
+      uploadSarif and commentOnPr rather than set by hand. Two spaces of
+      indentation per line; empty when neither output is enabled.
+
+      An input rather than a fixed block because a workflow that asks for a
+      write scope it will not use cannot argue it is least-privilege, and the
+      two scopes here only exist to serve features a consumer can switch off.
   failOn:
     type: string
     default: ''

--- a/packages/actions/threatcrush-scan/workflow.yml
+++ b/packages/actions/threatcrush-scan/workflow.yml
@@ -3,10 +3,18 @@ name: threatcrush security scan
 on:
   pull_request:
 
+# Only what the enabled outputs actually need. Both write scopes exist to
+# serve an optional feature — the Security tab upload and the PR comment — and
+# were requested unconditionally even when both were switched off.
+#
+# With uploadSarif and commentOnPr both false this reads `contents: read` and
+# nothing else, and the findings arrive in the job summary and the artifact.
+# SAG declined partly on "an externally maintained CLI ... together with PR and
+# security-reporting permissions"; a scanner that asks for write scopes it is
+# not going to use has no answer to that, and now it does not have to ask.
 permissions:
   contents: read
-  pull-requests: write
-  security-events: write
+{{extraPermissions}}
 
 jobs:
   scan:
@@ -305,7 +313,10 @@ jobs:
       # get a writable token: that event runs with repository secrets in scope
       # against a checkout of untrusted contributor code.
       - name: Comment on PR
-        if: always() && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+        if: >-
+          always() && '{{commentOnPr}}' == 'true'
+          && github.event.pull_request.head.repo.full_name == github.repository
+          && github.actor != 'dependabot[bot]'
         continue-on-error: true
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:


### PR DESCRIPTION
> Stacks on #960. Base is `sag-review`, not `master` — merge that one first.

SAG closed their request after internal review. Not on the technical items — those they'd listed and #960 fixes — but on this:

> installing and executing an externally maintained CLI in every pull-request workflow, **together with PR and security-reporting permissions**, adds supply-chain, operational, and long-term maintenance responsibilities that we are not currently prepared to adopt

Two of those three aren't answerable with code. An externally maintained CLI is externally maintained, and a dependency is a maintenance responsibility — that's the deal, and a repo is entitled to decline it.

**The middle one was answerable, and we were on the wrong side of it.**

The permission block was static and requested `pull-requests: write` and `security-events: write` unconditionally — including in the configuration where both the upload and the comment are switched off. A workflow that asks for a write scope it will not use cannot call itself least-privilege, which is awkward for one whose request body argues about supply-chain hygiene.

## What changed

`commentOnPr` joins `uploadSarif` as a switch, and `extraPermissions` carries the lines beneath `contents: read` — **computed from the two rather than set by hand**, so the block can't drift out of step with what the workflow actually does.

On the tcfeed side, `TCFEED_LEAST_PRIVILEGE=1` selects it. Not the default: the Security tab is where a scanner's output belongs and a repo that wants it shouldn't have to ask twice. But it's one variable away for repos that won't hand a third party write access on a first install.

## Verification

By parsing the rendered workflow, not reading it:

| mode | permissions |
|---|---|
| default | `{"contents":"read","pull-requests":"write","security-events":"write"}` |
| least-privilege | `{"contents":"read"}` |

Both parse as valid YAML with **0 placeholders left**, and the comment step's gate renders as `'false' == 'true'` in the second.

Pairs with profullstack/threatcrush#138. Pack to **1.5.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
