### PR TITLE
feat(threatcrush-scan): ask for no write scope when nothing writes (re-target to master)

### DIFF
--- a/packages/actions/threatcrush-scan/sh1pt.actionpack.yaml
+++ b/packages/actions/threatcrush-scan/sh1pt.actionpack.yaml
@@ -5,7 +5,7 @@ description: >-
   Scans pull requests for hardcoded credentials, injection, SSRF, unsafe
   deserialisation and dependency tampering, and uploads SARIF to the Security
   tab.
-version: 1.4.0
+version: 1.5.0
 publisher: profullstack
 visibility: public
 license: MIT
@@ -59,6 +59,32 @@ inputs:
       but a confusing one to debug. Read it from
       `npm view <spec> dist.integrity`. Empty skips verification, for a
       consumer pointing the spec at something they build themselves.
+  commentOnPr:
+    type: string
+    default: 'true'
+    enum:
+      - 'true'
+      - 'false'
+    description: >-
+      Post the report as a pull request comment. Requires
+      `pull-requests: write`.
+
+      Set this and uploadSarif both to 'false' and the workflow requests
+      `contents: read` and nothing else — findings arrive in the job summary
+      and the SARIF artifact instead. That is the configuration for a
+      repository that wants the scan without granting a third-party CLI any
+      write scope, which is a substantial part of what reviewers decline on.
+  extraPermissions:
+    type: string
+    default: "  pull-requests: write\n  security-events: write"
+    description: >-
+      The permission lines added beneath `contents: read`, computed from
+      uploadSarif and commentOnPr rather than set by hand. Two spaces of
+      indentation per line; empty when neither output is enabled.
+
+      An input rather than a fixed block because a workflow that asks for a
+      write scope it will not use cannot argue it is least-privilege, and the
+      two scopes here only exist to serve features a consumer can switch off.
   failOn:
     type: string
     default: ''

--- a/packages/actions/threatcrush-scan/workflow.yml
+++ b/packages/actions/threatcrush-scan/workflow.yml
@@ -3,10 +3,18 @@ name: threatcrush security scan
 on:
   pull_request:
 
+# Only what the enabled outputs actually need. Both write scopes exist to
+# serve an optional feature — the Security tab upload and the PR comment — and
+# were requested unconditionally even when both were switched off.
+#
+# With uploadSarif and commentOnPr both false this reads `contents: read` and
+# nothing else, and the findings arrive in the job summary and the artifact.
+# SAG declined partly on "an externally maintained CLI ... together with PR and
+# security-reporting permissions"; a scanner that asks for write scopes it is
+# not going to use has no answer to that, and now it does not have to ask.
 permissions:
   contents: read
-  pull-requests: write
-  security-events: write
+{{extraPermissions}}
 
 jobs:
   scan:
@@ -305,7 +313,10 @@ jobs:
       # get a writable token: that event runs with repository secrets in scope
       # against a checkout of untrusted contributor code.
       - name: Comment on PR
-        if: always() && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+        if: >-
+          always() && '{{commentOnPr}}' == 'true'
+          && github.event.pull_request.head.repo.full_name == github.repository
+          && github.actor != 'dependabot[bot]'
         continue-on-error: true
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:


### PR DESCRIPTION
**This is #961, re-targeted at `master`.**

#961 was based on `sag-review` rather than `master`, and #960 was squash-merged. So merging #961 put the change on `sag-review` and left `master` without it.

That matters because the consumer side (profullstack/threatcrush#138) **is** already on threatcrush master. Right now `TCFEED_LEAST_PRIVILEGE=1` sets inputs the pack has no placeholders for and **silently changes nothing** — the rendered permission block is still the static one with both write scopes. The feature looks live and isn't.

Verified `master` currently has:

```
version: 1.4.0
extraPermissions: 0 occurrences
commentOnPr:      0 occurrences
```

The diff here is exactly #961's change and nothing else — #960's content is already on master, confirmed by diffing.

## The change (unchanged from #961)

The permission block requested `pull-requests: write` and `security-events: write` unconditionally, including where both the upload and the comment are switched off. A workflow that asks for a write scope it will not use cannot call itself least-privilege — awkward for one whose request body argues about supply-chain hygiene.

`commentOnPr` joins `uploadSarif` as a switch, and `extraPermissions` carries the lines beneath `contents: read`, computed from the two rather than set by hand so the block can't drift out of step with what the workflow does.

| mode | permissions |
|---|---|
| default | `{"contents":"read","pull-requests":"write","security-events":"write"}` |
| least-privilege | `{"contents":"read"}` |

Pack to **1.5.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)