### PR TITLE
fix(threatcrush-scan): report the pull request, not the whole backlog

### DIFF
--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -44,5 +44,8 @@
   },
   "dependencies": {
     "@profullstack/sh1pt-actions-fleet-core": "workspace:^"
+  },
+  "devDependencies": {
+    "yaml": "^2.6.0"
   }
 }

--- a/packages/actions/src/index.test.ts
+++ b/packages/actions/src/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { parse as parseYaml } from 'yaml';
 import { renderPack } from '@profullstack/sh1pt-actions-fleet-core';
 import { loadBuiltinPacks } from './index.js';
 
@@ -179,6 +180,78 @@ describe('built-in packs', () => {
     // Empty by default, so a first install reports rather than blocks.
     expect(file?.content).toContain('FAIL_ON=""');
     expect(file?.content).toContain('# Managed by sh1pt Actions Fleet');
+  });
+
+  it('scopes the pull request comment to the files the pull request changes', async () => {
+    // qryptchat-web#258 changed two files and was handed 91 findings, five of
+    // them HIGH, none of them from the diff under review. The scan still
+    // covers the whole tree and the Security tab still receives all of it —
+    // but the comment leads with the change being reviewed, and the standing
+    // backlog goes behind a fold.
+    const catalog = await loadBuiltinPacks();
+    const entry = catalog.get('threatcrush-scan');
+    if (!entry) throw new Error('threatcrush-scan not in catalog');
+    const result = await renderPack({
+      packDir: entry.packDir,
+      manifest: entry.manifest,
+      inputs: {},
+    });
+    const content = result.files[0]?.content ?? '';
+
+    // The merge ref's parents are what identify the diff, so the checkout has
+    // to be deep enough to have them.
+    expect(content).toContain('fetch-depth: 2');
+    expect(content).toContain('git diff --name-only HEAD^1 HEAD');
+    expect(content).toContain('SCAN_SCOPED: ${{ steps.changed.outputs.scoped }}');
+    expect(content).toContain('pre-existing finding(s) elsewhere in the');
+
+    // A conflicted pull request has no merge ref, and `HEAD^1` would then
+    // answer a different question. That case must report everything rather
+    // than scope to the wrong set of files.
+    expect(content).toContain('echo "scoped=false" >> "$GITHUB_OUTPUT"');
+  });
+
+  it('still renders valid YAML with the report steps in place', async () => {
+    // The report builder is a heredoc'd Python program inside a `run:` block,
+    // so an indentation slip there produces a workflow GitHub refuses to load
+    // — and every assertion above would still pass on the broken file.
+    const catalog = await loadBuiltinPacks();
+    const entry = catalog.get('threatcrush-scan');
+    if (!entry) throw new Error('threatcrush-scan not in catalog');
+
+    const variants = [
+      {},
+      { failOn: 'critical,high', commentOnPr: 'true', uploadSarif: 'true' },
+      // Both outputs off is the minimum-permission install, and it renders a
+      // different `permissions:` block — so it is a different YAML document.
+      { commentOnPr: 'false', uploadSarif: 'false' },
+    ];
+    for (const inputs of variants) {
+      const result = await renderPack({ packDir: entry.packDir, manifest: entry.manifest, inputs });
+      const workflow = parseYaml(result.files[0]?.content ?? '');
+      const steps = workflow?.jobs?.scan?.steps ?? [];
+      const names = steps.map((step: { name?: string }) => step?.name);
+      expect(names).toContain('Determine which files this pull request touches');
+      expect(names).toContain('Build the report');
+    }
+  });
+
+  it('orders the report by severity rather than by file', async () => {
+    // The 50-row cap used to be applied in SARIF order, which is file order,
+    // so which findings survived truncation was decided by where they sat in
+    // the tree — a HIGH in the last file scanned could be cut while fifty
+    // notes from the first were printed in full.
+    const catalog = await loadBuiltinPacks();
+    const entry = catalog.get('threatcrush-scan');
+    if (!entry) throw new Error('threatcrush-scan not in catalog');
+    const result = await renderPack({
+      packDir: entry.packDir,
+      manifest: entry.manifest,
+      inputs: {},
+    });
+    const content = result.files[0]?.content ?? '';
+    expect(content).toContain('RANK = {"error": 0, "warning": 1, "note": 2}');
+    expect(content).toContain('results.sort(key=lambda r:');
   });
 
   it('renders threatcrush-scan with a failure gate when asked', async () => {

--- a/packages/actions/threatcrush-scan/README.md
+++ b/packages/actions/threatcrush-scan/README.md
@@ -27,6 +27,41 @@ fires on everything gets switched off within a day, and a gate that is off is
 worse than one that was never installed. Tighten it to `critical,high` once the
 backlog is triaged.
 
+## The comment is scoped to the pull request; the scan is not
+
+The scan always covers the whole tree, and the Security tab always receives all
+of it. A credential three directories away is still committed, and narrowing
+what gets *scanned* would be a real loss of coverage.
+
+The **comment** is a different artifact. It is part of a review, and a review is
+about the change under review. Reporting the repository's whole standing backlog
+on every pull request means an author who touched two files is handed ninety
+findings they did not write and cannot action — and the one that is theirs is
+somewhere in the middle of it. That is how a scanner teaches a team to scroll
+past it.
+
+So the comment leads with findings in the files the pull request changes, and
+folds the rest into one `<details>` line with its severity counts. Nothing is
+hidden: the fold lists the most serious twenty, and the Security tab has
+everything.
+
+The diff comes from `HEAD^1..HEAD`. `refs/pull/N/merge` has the base branch as
+its first parent and the pull request head as its second, so that range is
+exactly the pull request — no API call, no token, no extra permission. It needs
+`fetch-depth: 2`, which is why checkout asks for it.
+
+A conflicted pull request has no merge ref. Checkout then falls back to the head
+commit, where `HEAD^1` means "the previous commit on this branch" — a
+plausible-looking answer to a different question. The workflow checks that HEAD
+really has two parents before trusting the range, and when it does not, it
+reports every finding unscoped and says so in the log. Scoping to the wrong set
+of files is worse than not scoping.
+
+Within each section, findings are ordered **most severe first**. They used to
+print in SARIF order, which is file order, so the 50-row cap was decided by where
+a finding sat in the tree: a `high` in the last file scanned could be truncated
+away while fifty `note`s from the first file printed in full.
+
 ## Two output paths, chosen up front
 
 The workflow checks `threatcrush scan --help` for `--format` **before**

--- a/packages/actions/threatcrush-scan/sh1pt.actionpack.yaml
+++ b/packages/actions/threatcrush-scan/sh1pt.actionpack.yaml
@@ -5,7 +5,7 @@ description: >-
   Scans pull requests for hardcoded credentials, injection, SSRF, unsafe
   deserialisation and dependency tampering, and uploads SARIF to the Security
   tab.
-version: 1.5.1
+version: 1.6.0
 publisher: profullstack
 visibility: public
 license: MIT

--- a/packages/actions/threatcrush-scan/workflow.yml
+++ b/packages/actions/threatcrush-scan/workflow.yml
@@ -31,6 +31,43 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
+          # Two commits, so the merge ref's own parents are present and the
+          # report can tell this pull request's files from the rest of the
+          # repository. See "Determine which files this pull request touches".
+          fetch-depth: 2
+
+      # Which findings belong to this review?
+      #
+      # The scan covers the whole tree, and it should: a credential three
+      # directories away is still committed. But a *pull request comment* is a
+      # review artifact, and a review is about the change under review. Posting
+      # the repository's entire standing backlog on every pull request means an
+      # author who changed two files is handed ninety findings they did not
+      # write, cannot action, and did not ask about — and the one finding that
+      # is theirs sits somewhere in the middle of it.
+      #
+      # `refs/pull/N/merge` has the base branch as its first parent and the
+      # pull request head as its second, so `HEAD^1..HEAD` is exactly this
+      # pull request's diff, with no API call and no token.
+      #
+      # That identity only holds for a real merge ref. When the pull request
+      # has conflicts GitHub cannot produce one, checkout falls back to the
+      # head commit, and `HEAD^1` silently becomes "the previous commit on the
+      # branch" — a plausible-looking answer to a different question. So the
+      # shape is verified before it is trusted, and a failure falls back to
+      # reporting everything unscoped rather than scoping to the wrong set.
+      - name: Determine which files this pull request touches
+        id: changed
+        run: |
+          if [ "$(git rev-list --parents --max-count=1 HEAD | wc -w)" -eq 3 ]; then
+            git diff --name-only HEAD^1 HEAD > "$RUNNER_TEMP/threatcrush-changed.txt"
+            echo "scoped=true" >> "$GITHUB_OUTPUT"
+            echo "Scoping the report to $(wc -l < "$RUNNER_TEMP/threatcrush-changed.txt") changed file(s)."
+          else
+            : > "$RUNNER_TEMP/threatcrush-changed.txt"
+            echo "scoped=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No merge ref (conflicted pull request?) — reporting every finding, unscoped."
+          fi
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -254,54 +291,122 @@ jobs:
                   "This is not a clean result. See the job log.",
               ]
           else:
-              counts = {"error": 0, "warning": 0, "note": 0}
-              for result in results:
-                  level = result.get("level", "warning")
-                  if level in counts:
-                      counts[level] += 1
+              LABELS = {"error": "HIGH", "warning": "MEDIUM", "note": "LOW"}
+              # Most serious first. The old order was SARIF's, which is file
+              # order — so the 50-row cap was decided by where a finding sat in
+              # the tree, and a `high` in the last file scanned could be cut
+              # while fifty `note`s from the first file were printed in full.
+              RANK = {"error": 0, "warning": 1, "note": 2}
 
-              lines.append(f"**{len(results)}** finding(s)")
-              lines.append("")
+              def locate(result):
+                  locations = result.get("locations") or []
+                  physical = (locations[0] if locations else {}).get("physicalLocation", {})
+                  uri = physical.get("artifactLocation", {}).get("uri", "")
+                  return uri, physical.get("region", {}).get("startLine", 1)
 
-              if results:
-                  badges = []
+              def tally(rows):
+                  counts = {"error": 0, "warning": 0, "note": 0}
+                  for row in rows:
+                      level = row.get("level", "warning")
+                      if level in counts:
+                          counts[level] += 1
+                  return counts
+
+              def badges(counts):
+                  out = []
                   if counts["error"]:
-                      badges.append(f"**HIGH/CRITICAL**: {counts['error']}")
+                      out.append(f"**HIGH/CRITICAL**: {counts['error']}")
                   if counts["warning"]:
-                      badges.append(f"**MEDIUM**: {counts['warning']}")
+                      out.append(f"**MEDIUM**: {counts['warning']}")
                   if counts["note"]:
-                      badges.append(f"**LOW**: {counts['note']}")
-                  if badges:
-                      lines += [" | ".join(badges), ""]
+                      out.append(f"**LOW**: {counts['note']}")
+                  return " | ".join(out)
 
-                  lines += ["| Severity | Rule | Location |", "|---|---|---|"]
-                  for result in results[:50]:
+              def table(rows, limit):
+                  out = ["| Severity | Rule | Location |", "|---|---|---|"]
+                  for result in rows[:limit]:
                       # SARIF permits a result with no locations, and the native
                       # --format sarif path is written by the CLI rather than by
                       # the converter beside this file. Indexing [0] there threw
                       # out of the enclosing try, so the report file was never
                       # written and the comment fell back to "could not be read"
                       # — a message that hides real findings behind a wrong one.
-                      locations = result.get("locations") or []
-                      location = (locations[0] if locations else {}).get("physicalLocation", {})
-                      uri = location.get("artifactLocation", {}).get("uri", "(no location)")
-                      line_no = location.get("region", {}).get("startLine", 1)
-                      label = {"error": "HIGH", "warning": "MEDIUM", "note": "LOW"}.get(
-                          result.get("level", "warning"), "INFO"
-                      )
-                      lines.append(f"| {label} | `{result.get('ruleId','?')}` | `{uri}`:{line_no} |")
-                  if len(results) > 50:
+                      uri, line_no = locate(result)
+                      label = LABELS.get(result.get("level", "warning"), "INFO")
+                      where = f"`{uri}`:{line_no}" if uri else "_(no location)_"
+                      out.append(f"| {label} | `{result.get('ruleId','?')}` | {where} |")
+                  if len(rows) > limit:
                       # Say so. A silent truncation reads as "that was everything".
-                      lines += ["", f"_…and {len(results) - 50} more. Full results in the Security tab._"]
-                  lines += ["", "Snippets are redacted; ThreatCrush never prints matched credential material."]
+                      out += ["", f"_…and {len(rows) - limit} more. Full results in the Security tab._"]
+                  return out
+
+              try:
+                  with open(os.environ["RUNNER_TEMP"] + "/threatcrush-changed.txt") as handle:
+                      changed = {entry.strip() for entry in handle if entry.strip()}
+              except Exception:
+                  changed = set()
+
+              scoped = os.environ.get("SCAN_SCOPED", "") == "true"
+              results.sort(key=lambda r: (RANK.get(r.get("level", "warning"), 3), locate(r)))
+
+              if scoped:
+                  touched = [r for r in results if locate(r)[0] in changed]
+                  backlog = [r for r in results if locate(r)[0] not in changed]
               else:
+                  touched, backlog = results, []
+
+              if not results:
                   lines.append("No findings.")
+              else:
+                  if scoped:
+                      lines += [
+                          f"**{len(touched)}** finding(s) in the {len(changed)} file(s) this "
+                          "pull request changes.",
+                          "",
+                      ]
+                  else:
+                      lines += [f"**{len(results)}** finding(s)", ""]
+
+                  if touched:
+                      badge_line = badges(tally(touched))
+                      if badge_line:
+                          lines += [badge_line, ""]
+                      lines += table(touched, 50)
+                  elif scoped:
+                      lines.append("Nothing in the files this pull request changes.")
+
+                  # The rest of the repository is reported, but not *at* the
+                  # author of an unrelated change. It is a standing backlog, it
+                  # was there before this branch, and it belongs behind a fold
+                  # — not in ninety rows above the review.
+                  if backlog:
+                      summary = badges(tally(backlog)) or "no severities"
+                      lines += [
+                          "",
+                          "<details>",
+                          f"<summary>{len(backlog)} pre-existing finding(s) elsewhere in the "
+                          f"repository — {summary}</summary>",
+                          "",
+                          "Not introduced by this pull request. The full set is in the "
+                          "Security tab.",
+                          "",
+                      ]
+                      lines += table(backlog, 20)
+                      lines += ["", "</details>"]
+
+                  lines += [
+                      "",
+                      "Snippets are redacted; ThreatCrush never prints matched credential material.",
+                  ]
 
           with open(os.environ["RUNNER_TEMP"] + "/threatcrush-comment.md", "w") as handle:
               handle.write("\n".join(lines) + "\n")
           PYEOF
         env:
           SCAN_STATUS: ${{ steps.scan.outputs.status }}
+          # Empty when the changed-file step was skipped or could not identify
+          # a merge ref, which reads as "not scoped" and reports everything.
+          SCAN_SCOPED: ${{ steps.changed.outputs.scoped }}
 
       - name: Write report to job summary
         if: always()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,10 @@ importers:
       '@profullstack/sh1pt-actions-fleet-core':
         specifier: workspace:^
         version: link:../actions-fleet-core
+    devDependencies:
+      yaml:
+        specifier: ^2.6.0
+        version: 2.9.0
 
   packages/actions-fleet-core:
     dependencies:


### PR DESCRIPTION
## What prompted this

[qryptchat-web#258](https://github.com/profullstack/qryptchat-web/pull/258#issuecomment-5305838682) changed **two files** and received a ThreatCrush comment with **91 findings** — 76 LOW, 10 MEDIUM, 5 HIGH — none of them from the diff under review.

I reproduced it exactly and hand-verified every HIGH and MEDIUM against the source. **One of the 91 was real** (a nested quantifier in a URL validator). The rest were false positives, and they're being fixed separately in [profullstack/threatcrush#148](https://github.com/profullstack/threatcrush/pull/148).

But even with a perfect scanner, this comment would still have been wrong to post. A repository with a legacy backlog hands every author the whole backlog on every pull request. That is how a scanner teaches a team to scroll past it.

## What changes

The scan still covers the whole tree, and the Security tab still receives all of it. Narrowing what gets *scanned* would be a real loss of coverage.

The **comment** is a review artifact, and a review is about the change under review. So:

- **Lead with findings in the files the pull request touches.** The rest folds into one `<details>` line carrying its severity counts, listing the twenty most serious.
- **Order by severity.** The 50-row cap was previously applied in SARIF order, which is file order — so which findings survived truncation was decided by where they sat in the tree. A `high` in the last file scanned could be cut while fifty `note`s from the first printed in full.

Same repository, same scan, rendered through the new builder:

```
## ThreatCrush Security Scan

**2** finding(s) in the 2 file(s) this pull request changes.

**MEDIUM**: 2

| Severity | Rule | Location |
|---|---|---|
| MEDIUM | `js-unescaped-html-sink` | `src/app/layout.jsx`:92 |
| MEDIUM | `js-unescaped-html-sink` | `src/app/layout.jsx`:96 |

<details>
<summary>89 pre-existing finding(s) elsewhere in the repository — **HIGH/CRITICAL**: 5 | **MEDIUM**: 8 | **LOW**: 76</summary>
...
</details>
```

## How the diff is identified

`refs/pull/N/merge` has the base branch as its first parent and the pull request head as its second, so `HEAD^1..HEAD` is exactly the pull request — no API call, no token, no added permission. It needs `fetch-depth: 2`, which checkout now requests.

A conflicted pull request has no merge ref. Checkout falls back to the head commit, where `HEAD^1` means "the previous commit on this branch" — a plausible-looking answer to a different question. The workflow verifies HEAD really has two parents before trusting the range; when it doesn't, it reports everything unscoped and says so in the log. **Scoping to the wrong set of files is worse than not scoping.**

## Verification

- Rendered the real 91-finding SARIF from qryptchat-web through the extracted report builder, scoped and unscoped.
- Edge cases exercised: clean scan, scoped-but-nothing-touched, a SARIF result with no location, and the fail-closed `NOT RUN` path (all still correct).
- `pnpm vitest run packages/actions` — **84 passed**, including new assertions for the scoping, the ordering, the unscoped fallback, and that the rendered workflow is **valid YAML** across three input variants. That last one matters: the report builder is a heredoc'd Python program inside a `run:` block, where an indentation slip yields a workflow GitHub refuses to load while every content assertion still passes.
- `pnpm --filter @profullstack/sh1pt-action-packs typecheck` clean.
- The repo-wide `pnpm vitest run` has 662 suites failing to resolve workspace `dist/` in a fresh worktree. Confirmed pre-existing by stashing this branch and reproducing the identical failure on the base commit.

Pack version `1.5.1` → `1.6.0`, so consumers re-sync.

## Note for whoever lands this

qryptchat-web installs `@profullstack/threatcrush@latest` (pack v1.1.0). npm is at `0.11.1`, which equals threatcrush HEAD — so merging #148 will not change that PR comment until a release is cut, and re-syncing qryptchat to pack 1.6.0 moves it onto the pinned `0.11.0` spec with an integrity hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)