### PR TITLE
chore(cli): 0.3.1 — ship the netcup adapter in the command tree

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@profullstack/sh1pt",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "One codebase → every store, registry, CDN, and channel. Build. Promote. Scale. Iterate.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump only. Both packages are already published to npm:

- `@profullstack/sh1pt-cloud-netcup@0.1.15` (new package)
- `@profullstack/sh1pt@0.3.1`

`sh1pt cloud netcup` is built from `CATEGORIES` in `adapter-registry.ts`, so
0.3.0 had no netcup subcommand even though #968 merged the adapter. This lands
the version the registry actually reflects.

Published from local as `moshcoder` — the tag-triggered release workflow still
can't publish (`NPM_TOKEN` returns 404 on PUT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)