### PR TITLE
chore(threatcrush-scan): pin 0.11.3, and pack 2.0.1 to re-sync consumers

### DIFF
--- a/packages/actions/threatcrush-scan/README.md
+++ b/packages/actions/threatcrush-scan/README.md
@@ -14,8 +14,8 @@ sh1pt actions install threatcrush-scan --repo owner/name --pr
 | --- | --- | --- |
 | `scanPath` | `.` | Path to scan, relative to the repository root. |
 | `nodeVersion` | `20` | See *Node 20, deliberately*, below. |
-| `threatcrushPackageSpec` | `@profullstack/threatcrush@0.11.2` | npm spec used to install the CLI. Pinned rather than `@latest` so one bad publish cannot break every consumer at once; bump it in a pack release. |
-| `threatcrushIntegrity` | *(sha512 of 0.11.2)* | SRI hash of that tarball. The workflow downloads, hashes and compares before installing, and refuses to install on a mismatch. Bump it with the spec — read it from `npm view <spec> dist.integrity`. Empty skips the check. |
+| `threatcrushPackageSpec` | `@profullstack/threatcrush@0.11.3` | npm spec used to install the CLI. Pinned rather than `@latest` so one bad publish cannot break every consumer at once; bump it in a pack release. |
+| `threatcrushIntegrity` | *(sha512 of 0.11.3)* | SRI hash of that tarball. The workflow downloads, hashes and compares before installing, and refuses to install on a mismatch. Bump it with the spec — read it from `npm view <spec> dist.integrity`. Empty skips the check. |
 | `failOn` | *(empty)* | Comma-separated severities that fail the job, e.g. `critical,high`. Empty is report-only. |
 | `uploadSarif` | `true` | Upload to the Security tab. Emits `security-events: write`. |
 | `commentOnPr` | `true` | Post the report as a pull request comment. Emits `pull-requests: write`. |

--- a/packages/actions/threatcrush-scan/sh1pt.actionpack.yaml
+++ b/packages/actions/threatcrush-scan/sh1pt.actionpack.yaml
@@ -5,7 +5,7 @@ description: >-
   Scans pull requests for hardcoded credentials, injection, SSRF, unsafe
   deserialisation and dependency tampering, and uploads SARIF to the Security
   tab.
-version: 2.0.0
+version: 2.0.1
 publisher: profullstack
 visibility: public
 license: MIT
@@ -32,7 +32,7 @@ inputs:
       that fails without a full toolchain.
   threatcrushPackageSpec:
     type: string
-    default: '@profullstack/threatcrush@0.11.2'
+    default: '@profullstack/threatcrush@0.11.3'
     description: >-
       npm spec used to install the CLI. Pinned, not `@latest`: a scanner that
       runs on every pull request is a dependency, and `@latest` means one bad
@@ -42,7 +42,7 @@ inputs:
       version that was checked first.
   threatcrushIntegrity:
     type: string
-    default: 'sha512-8N3jqCQixK0Onc+/bvuJaNCSvGZlJYZcSAGsd1nEfRZ4kOu1Ifom7Bd1t2muYJAmAxBTPmz1iseWSay/0gg3Gw=='
+    default: 'sha512-lxWvTtLDgckiWlRB3wMSoBNfMZ/3ao0CcmwETGyKclc+5NMU5Pl0jXSr0h+QrTtfxh7TNStk4ZgP5h8xbEvIWw=='
     description: >-
       Subresource-integrity hash of the tarball named by threatcrushPackageSpec,
       in npm's own `sha512-<base64>` form. The workflow downloads, hashes and


### PR DESCRIPTION
A scanner release is not finished until this pin moves — the property this pack's own README explains. [threatcrush v0.11.3](https://github.com/profullstack/threatcrush/releases/tag/v0.11.3) is published, so here is the other half.

## What 0.11.3 carries

- **`go-shell-exec-command` no longer fires on a fully literal argv** ([threatcrush#158](https://github.com/profullstack/threatcrush/pull/158)). `exec.Command("cmd", "/c", "ver")` re-introduces a shell but has nothing in it for anyone to influence; gosec's G204 draws the line in the same place. Concatenation, `fmt.Sprintf` and bare variables still report.
- **`js-uninitialized-buffer` no longer fires on a buffer filled before use** ([threatcrush#156](https://github.com/profullstack/threatcrush/pull/156)).

## The bump

| | from | to |
|---|---|---|
| `threatcrushPackageSpec` | `@profullstack/threatcrush@0.11.2` | `@profullstack/threatcrush@0.11.3` |
| `threatcrushIntegrity` | `sha512-8N3jqCQi…` | `sha512-lxWvTtLD…` |
| pack `version` | `2.0.0` | `2.0.1` |

Both inputs moved in the same edit, as the input's own description requires: a hash from a different version fails closed, which is the right direction to fail and a confusing one to debug. The pack version moves so the fleet re-syncs consumers.

## Verification

The hash was **not copied from `npm view`** — it was reproduced. The published tarball was downloaded and hashed independently:

```
$ curl -sL https://registry.npmjs.org/@profullstack/threatcrush/-/threatcrush-0.11.3.tgz -o tc.tgz
$ openssl dgst -sha512 -binary tc.tgz | openssl base64 -A
lxWvTtLDgckiWlRB3wMSoBNfMZ/3ao0CcmwETGyKclc+5NMU5Pl0jXSr0h+QrTtfxh7TNStk4ZgP5h8xbEvIWw==
```

Matches the manifest byte for byte.

And the behaviour was verified against the **published** package rather than a local build — installed from the registry, then re-scanned:

| repository | findings | |
|---|---|---|
| SibtainOcn/Quiesce | **0** | the Go CLI whose single finding motivated #158 |
| malware-test-prs | 99, **all 43 criticals** | detection unmoved |

Every `{{placeholder}}` in `workflow.yml` still resolves against the manifest's inputs, and the YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)