### PR TITLE
fix(packaging): declare engines.node on published packages — Node 16 installs then fails on global fetch

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,6 +19,9 @@
     "devtools"
   ],
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "bin": {
     "sh1pt": "./bin/sh1pt.js"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,9 @@
     "adapter"
   ],
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/policy/package.json
+++ b/packages/policy/package.json
@@ -17,6 +17,9 @@
     "lint"
   ],
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
Follow-up to #972, as offered there.

## Problem

The three published packages declare no `engines` field:

| package | engines |
|---|---|
| `@profullstack/sh1pt` | *(none)* |
| `@profullstack/sh1pt-core` | *(none)* |
| `@profullstack/sh1pt-policy` | *(none)* |

The CLI relies on **global `fetch`**, which Node only exposes from v18:

- `packages/cli/src/commands/login.ts` — `/api/v1/cli/pair`, `/api/v1/cli/claim`
- `packages/cli/src/commands/build.ts` — HEAD/GET probes
- `packages/cli/src/cloud-vault.ts` — `authedFetch`
- `packages/core/src/setup-helpers.ts` — OAuth token exchange

Without `engines`, npm and pnpm cannot warn. A user on Node 16 gets a clean install and then
`ReferenceError: fetch is not defined` on first run — an error that points at nothing actionable.

## Fix

Declare `"engines": { "node": ">=20" }` on the three published packages.

Why `>=20` rather than `>=18` or `>=22`:

- `>=18` is the bare functional floor (global fetch) but Node 18 is out of maintenance.
- `>=20` is the oldest maintained LTS with global fetch, and matches the ES2022 output target.
- `mise.toml` pins Node 22 and the workflows run 22 (`threatcrush-scan` uses 20), so every
  environment the project already builds and tests in satisfies `>=20`.

Happy to change it to `>=22` so the declared floor matches `mise.toml` exactly — one-line edit,
just say which you prefer.

## Scope

Three `package.json` files, additive only. The private root package is untouched. No source,
dependency, or build changes. Existing key order and formatting preserved.
