### PR TITLE
fix(openapi): normalize trace operations instead of dropping them

### DIFF
--- a/packages/openapi/src/core/normalize.test.ts
+++ b/packages/openapi/src/core/normalize.test.ts
@@ -101,6 +101,19 @@ describe('normalize', () => {
     expect(ir.operations[0]?.responses[0]?.contentType).toBe('application/json');
   });
 
+  it('keeps trace operations instead of silently dropping them', () => {
+    const ir = normalize({
+      openapi: '3.0.0',
+      info: { title: 'Trace', version: '1' },
+      paths: {
+        '/debug': { trace: { operationId: 'traceDebug', responses: { '200': { description: 'ok' } } } },
+      },
+    });
+    expect(ir.operations).toHaveLength(1);
+    expect(ir.operations[0]?.method).toBe('trace');
+    expect(ir.operations[0]?.id).toBe('traceDebug');
+  });
+
   it('auto-generates operationId when missing', () => {
     const ir = normalize({
       openapi: '3.0.0',

--- a/packages/openapi/src/core/normalize.ts
+++ b/packages/openapi/src/core/normalize.ts
@@ -8,7 +8,9 @@ import type {
   SecurityScheme,
 } from './types.js';
 
-const METHODS: HttpMethod[] = ['get', 'post', 'put', 'delete', 'patch', 'head', 'options'];
+// `trace` is part of the OpenAPI 3 Operations Object — without it, trace
+// operations are silently dropped from the IR and every generator output.
+const METHODS: HttpMethod[] = ['get', 'post', 'put', 'delete', 'patch', 'head', 'options', 'trace'];
 
 // Walks a parsed OpenAPI 3.x document and produces our internal IR.
 // $ref resolution is intentionally shallow: we only resolve refs that point

--- a/packages/openapi/src/core/types.ts
+++ b/packages/openapi/src/core/types.ts
@@ -3,7 +3,7 @@
 // keep JSON Schema as a pass-through `unknown` to avoid reimplementing it;
 // generators that need richer typing can walk it themselves.
 
-export type HttpMethod = 'get' | 'post' | 'put' | 'delete' | 'patch' | 'head' | 'options';
+export type HttpMethod = 'get' | 'post' | 'put' | 'delete' | 'patch' | 'head' | 'options' | 'trace';
 
 export interface Parameter {
   name: string;


### PR DESCRIPTION
## Problem

`trace` is part of the OpenAPI 3 Operations Object (alongside get / post / put / delete / patch / head / options — see [spec](https://spec.openapis.org/oas/v3.0.3#operation-object)), but `METHODS` in `normalize()` omitted it.

Any spec with a `trace` operation silently lost it: no IR entry, no SDK method, no MCP tool, no docs page — with no error or warning.

## Fix

Add `trace` to `HttpMethod` and the `METHODS` walker.

## Tests

New test asserts a spec with `/debug: { trace: … }` produces exactly one operation with `method: 'trace'` and the correct auto/explicit id.