### PR TITLE
fix(core): show stdout tail in exec() failure message when stderr is empty

### DIFF
--- a/packages/core/src/exec.test.ts
+++ b/packages/core/src/exec.test.ts
@@ -41,6 +41,20 @@ describe('exec', () => {
       'quoted "value"',
     ]);
   });
+
+  it('falls back to the last stdout line in the failure message when stderr is empty', async () => {
+    await expect(exec('sh', ['-c', 'echo useful-diagnostic-on-stdout; exit 3'], {
+      log: () => {},
+      throwOnNonZero: true,
+    })).rejects.toThrow('failed (exit 3): useful-diagnostic-on-stdout');
+  });
+
+  it('prefers the last non-empty stderr line in the failure message', async () => {
+    await expect(exec('sh', ['-c', 'echo noisy >&2; echo real-error >&2; exit 2'], {
+      log: () => {},
+      throwOnNonZero: true,
+    })).rejects.toThrow('failed (exit 2): real-error');
+  });
 });
 
 describe('ensureCli', () => {

--- a/packages/core/src/exec.ts
+++ b/packages/core/src/exec.ts
@@ -72,7 +72,11 @@ export async function exec(cmd: string, args: string[], opts: ExecOptions): Prom
     child.on('close', (exitCode) => {
       const result: ExecResult = { exitCode: exitCode ?? -1, stdout, stderr };
       if (throwOnNonZero && result.exitCode !== 0) {
-        const tail = stderr.trim().split('\n').pop() ?? stdout.trim().split('\n').pop() ?? '';
+        // Prefer the last non-empty stderr line; fall back to stdout. Note
+        // `''.trim().split('\n').pop()` returns '' (not undefined), so a plain
+        // ??-chain never reaches the stdout fallback when stderr is empty.
+        const lastLine = (s: string) => s.trim().split('\n').filter(Boolean).pop() ?? '';
+        const tail = lastLine(stderr) || lastLine(stdout);
         reject(new Error(`${cmd} ${args.join(' ')} failed (exit ${result.exitCode}): ${tail}`));
       } else {
         resolve(result);


### PR DESCRIPTION
## Problem

`exec()`'s non-zero-exit error message picks its tail with:

```ts
const tail = stderr.trim().split('\n').pop() ?? stdout.trim().split('\n').pop() ?? '';
```

But `''.trim().split('\n')` is `['']`, so `.pop()` returns `''` — **not** `undefined`. The `??` fallback to stdout never fires.

Many CLIs write their diagnostics to stdout (and nothing to stderr), so failures looked like:

```
sh -c echo useful-diagnostic-on-stdout; exit 3 failed (exit 3): 
```

— the actual diagnostic was dropped from the error the user sees.

### Verified before this patch

```
> exec('sh', ['-c', 'echo useful-diagnostic-on-stdout; exit 3'])
Error: sh -c ... failed (exit 3):         // stdout content missing
```

## Fix

Pick the last **non-empty** stderr line; fall back to the last non-empty stdout line.

```
Error: sh -c echo useful-diagnostic-on-stdout; exit 3 failed (exit 3): useful-diagnostic-on-stdout
```

## Tests

- empty stderr → stdout tail appears in the message
- multi-line stderr → last non-empty stderr line wins