### PR TITLE
fix(cli): validate scheduled post timestamps strictly

### DIFF
--- a/packages/cli/src/commands/promote.test.ts
+++ b/packages/cli/src/commands/promote.test.ts
@@ -14,9 +14,17 @@ import {
 describe('promote schedule option parser', () => {
   it('parses a valid ISO timestamp', () => {
     expect(parseSchedule('2026-08-01T18:30:00Z').toISOString()).toBe('2026-08-01T18:30:00.000Z');
+    expect(parseSchedule('2026-08-01T18:30:00+08:00').toISOString()).toBe('2026-08-01T10:30:00.000Z');
   });
 
-  it.each(['not-a-date', '2026-99-99T18:30:00Z', ''])('rejects invalid timestamp %j', (value) => {
+  it.each([
+    'not-a-date',
+    '2026-99-99T18:30:00Z',
+    '2026-02-30T18:30:00Z',
+    '2026-08-01T18:30:00',
+    '2026-08-01T25:00:00Z',
+    '',
+  ])('rejects invalid or timezone-ambiguous timestamp %j', (value) => {
     expect(() => parseSchedule(value)).toThrow('valid ISO timestamp');
   });
 });

--- a/packages/cli/src/commands/promote.ts
+++ b/packages/cli/src/commands/promote.ts
@@ -829,9 +829,32 @@ function inferMediaKind(file: string): 'image' | 'video' | 'gif' {
 }
 
 export function parseSchedule(value: string): Date {
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(Z|[+-]\d{2}:\d{2})$/.exec(value);
+  if (!match) {
+    throw new InvalidArgumentError('must be a valid ISO timestamp with a timezone');
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  const timezone = match[7]!;
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  const timezoneParts = timezone === 'Z' ? undefined : /^([+-])(\d{2}):(\d{2})$/.exec(timezone);
+
+  if (
+    month < 1 || month > 12 || day < 1 || day > daysInMonth
+    || hour > 23 || minute > 59 || second > 59
+    || (timezoneParts && (Number(timezoneParts[2]) > 23 || Number(timezoneParts[3]) > 59))
+  ) {
+    throw new InvalidArgumentError('must be a valid ISO timestamp with a timezone');
+  }
+
   const schedule = new Date(value);
   if (Number.isNaN(schedule.getTime())) {
-    throw new InvalidArgumentError('must be a valid ISO timestamp');
+    throw new InvalidArgumentError('must be a valid ISO timestamp with a timezone');
   }
   return schedule;
 }


### PR DESCRIPTION
## Summary

- reject timezone-ambiguous values passed to `promote social post --schedule`
- reject calendar rollovers such as February 30 and out-of-range times
- keep accepting ISO timestamps with `Z` or an explicit UTC offset

This prevents scheduled posts from running at different instants depending on the machine timezone.

## Tests

- `pnpm --filter @profullstack/sh1pt build`
- `pnpm exec vitest run packages/cli/src/commands/promote.test.ts` (33 passed)