### PR TITLE
fix(vscode): keep marketplace PAT out of argv

### DIFF
--- a/packages/targets/plugin-vscode/src/index.test.ts
+++ b/packages/targets/plugin-vscode/src/index.test.ts
@@ -109,4 +109,30 @@ describe('plugin-vscode target adapter', () => {
 
     expect(execMock).not.toHaveBeenCalled();
   });
+
+  it('passes the marketplace PAT through the child environment instead of argv', async () => {
+    execMock.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+    const token = 'secret-marketplace-pat';
+    const ctx = fakeShipContext({
+      artifact: '/repo/.sh1pt/out/sample-extension-1.2.3.vsix',
+      version: '1.2.3',
+      dryRun: false,
+      secret: (key: string) => key === 'VSCE_TOKEN' ? token : undefined,
+    });
+
+    await adapter.ship(ctx as any, sampleConfig);
+
+    expect(execMock).toHaveBeenCalledWith('npx', [
+      '--yes',
+      'vsce',
+      'publish',
+      '--packagePath',
+      '/repo/.sh1pt/out/sample-extension-1.2.3.vsix',
+    ], {
+      env: { VSCE_PAT: token },
+      log: ctx.log,
+      throwOnNonZero: true,
+    });
+    expect(execMock.mock.calls[0]?.[1]).not.toContain(token);
+  });
 });

--- a/packages/targets/plugin-vscode/src/index.ts
+++ b/packages/targets/plugin-vscode/src/index.ts
@@ -97,7 +97,8 @@ export default defineTarget<Config>({
       throw new Error('VSCE_TOKEN not set. Run: sh1pt secret set VSCE_TOKEN <pat>');
     }
 
-    await exec('npx', ['--yes', 'vsce', 'publish', '--pat', token, '--packagePath', ctx.artifact], {
+    await exec('npx', ['--yes', 'vsce', 'publish', '--packagePath', ctx.artifact], {
+      env: { VSCE_PAT: token },
       log: ctx.log,
       throwOnNonZero: true,
     });


### PR DESCRIPTION
## Summary
- pass the VS Code Marketplace PAT through the official `VSCE_PAT` environment variable
- remove `--pat <token>` from the spawned command arguments
- add a regression that proves the token never appears in argv

## Bug
The target supplied `VSCE_TOKEN` as a `--pat` command argument. On a non-zero exit, sh1pt core includes the complete argument list in the thrown error, exposing the Marketplace PAT in logs and CI output. The official `@vscode/vsce` CLI defaults its PAT from `VSCE_PAT`, so the token does not need to be present in argv.

## Validation
- failing-before test captured the PAT in argv
- `pnpm exec vitest run packages/targets/plugin-vscode/src/index.test.ts --reporter=dot` (7/7)
- `pnpm --filter @profullstack/sh1pt-target-plugin-vscode typecheck`
- `git diff --check`

Official behavior: https://github.com/microsoft/vscode-vsce/blob/main/src/main.ts