### PR TITLE
fix(pypi): keep upload token out of argv

### DIFF
--- a/packages/targets/sdk-pypi/src/index.test.ts
+++ b/packages/targets/sdk-pypi/src/index.test.ts
@@ -31,4 +31,22 @@ describe('sdk-pypi target adapter', () => {
     expect(secret).not.toHaveBeenCalled();
     expect(execMock).not.toHaveBeenCalled();
   });
+
+  it('passes PyPI credentials through the child environment, not argv', async () => {
+    execMock.mockResolvedValue({ exitCode: 0, stdout: 'uploaded', stderr: '' });
+
+    await adapter.ship(fakeShipContext({
+      dryRun: false,
+      secret: (key: string) => key === 'PYPI_TOKEN' ? 'pypi-secret-token' : undefined,
+    }) as any, {});
+
+    const [bin, args, options] = execMock.mock.calls[0] ?? [];
+    expect(bin).toBe('twine');
+    expect(args).not.toContain('pypi-secret-token');
+    expect(args).not.toContain('--password');
+    expect(options.env).toMatchObject({
+      TWINE_USERNAME: '__token__',
+      TWINE_PASSWORD: 'pypi-secret-token',
+    });
+  });
 });

--- a/packages/targets/sdk-pypi/src/index.ts
+++ b/packages/targets/sdk-pypi/src/index.ts
@@ -55,12 +55,18 @@ export default defineTarget<Config>({
       [
         'upload',
         ...repoFlag,
-        '--username', '__token__',
-        '--password', token,
         '--non-interactive',
         `${ctx.artifact}/*`,
       ],
-      { log: ctx.log, throwOnNonZero: true }
+      {
+        env: {
+          ...ctx.env,
+          TWINE_USERNAME: '__token__',
+          TWINE_PASSWORD: token,
+        },
+        log: ctx.log,
+        throwOnNonZero: true,
+      }
     );
 
     return {


### PR DESCRIPTION
## Summary
- authenticate Twine through its supported `TWINE_USERNAME` and `TWINE_PASSWORD` environment variables
- stop putting the PyPI API token in process arguments
- add a regression test asserting the secret is absent from argv

Twine documents environment variables as its CI-friendly credential mechanism. Keeping the token out of argv avoids exposure through process inspection and captured command errors.

## Verification
- `pnpm exec vitest run packages/targets/sdk-pypi/src/index.test.ts` (2/2)
- `pnpm --filter @profullstack/sh1pt-target-sdk-pypi typecheck`
- `git diff --check`