### PR TITLE
fix(netlify): keep auth token out of argv

### DIFF
--- a/packages/targets/deploy-netlify/src/index.test.ts
+++ b/packages/targets/deploy-netlify/src/index.test.ts
@@ -2,12 +2,26 @@ import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1p
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { execMock } = vi.hoisted(() => ({
+  execMock: vi.fn(),
+}));
+
+vi.mock('@profullstack/sh1pt-core', async () => ({
+  ...(await vi.importActual<typeof import('@profullstack/sh1pt-core')>('@profullstack/sh1pt-core')),
+  exec: execMock,
+}));
+
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'deploy', requireKind: true });
 
 const tempDirs: string[] = [];
+
+beforeEach(() => {
+  execMock.mockReset();
+});
 
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
@@ -95,5 +109,22 @@ describe('Netlify deployment target', () => {
     }) as any, {
       siteId: 'site-123',
     })).rejects.toThrow('NETLIFY_AUTH_TOKEN not in vault');
+  });
+
+  it('passes the Netlify token through the child environment, not argv', async () => {
+    execMock.mockResolvedValue({ exitCode: 0, stdout: '{"deploy_id":"deploy-1"}', stderr: '' });
+
+    await adapter.ship(fakeShipContext({
+      dryRun: false,
+      secret: (key: string) => key === 'NETLIFY_AUTH_TOKEN' ? 'netlify-secret-token' : undefined,
+    }) as any, {
+      siteId: 'site-1',
+    });
+
+    const [bin, args, options] = execMock.mock.calls[0] ?? [];
+    expect(bin).toBe('npx');
+    expect(args).not.toContain('netlify-secret-token');
+    expect(args).not.toContain('--auth');
+    expect(options.env.NETLIFY_AUTH_TOKEN).toBe('netlify-secret-token');
   });
 });

--- a/packages/targets/deploy-netlify/src/index.ts
+++ b/packages/targets/deploy-netlify/src/index.ts
@@ -42,7 +42,7 @@ function deployDir(ctx: { projectDir: string }, config: Config): string {
   return isAbsolute(config.dir) ? config.dir : join(ctx.projectDir, config.dir);
 }
 
-function deployArgs(ctx: { channel: string; projectDir: string; version: string }, config: Config, token?: string): string[] {
+function deployArgs(ctx: { channel: string; projectDir: string; version: string }, config: Config): string[] {
   config = normalizedConfig(config);
   const prod = config.prod ?? ctx.channel === 'stable';
   const args = ['--yes', 'netlify-cli', 'deploy', '--json', '--dir', deployDir(ctx, config)];
@@ -50,7 +50,6 @@ function deployArgs(ctx: { channel: string; projectDir: string; version: string 
   if (config.siteId) args.push('--site', config.siteId);
   if (config.message) args.push('--message', config.message);
   else args.push('--message', `sh1pt ${ctx.version}`);
-  if (token) args.push('--auth', token);
   return args;
 }
 
@@ -106,7 +105,7 @@ export default defineTarget<Config>({
       throw new Error('NETLIFY_AUTH_TOKEN not in vault — run: sh1pt secret set NETLIFY_AUTH_TOKEN <token>');
     }
 
-    const result = await exec('npx', deployArgs(ctx, config, token), {
+    const result = await exec('npx', deployArgs(ctx, config), {
       cwd: ctx.projectDir,
       env: { ...ctx.env, NETLIFY_AUTH_TOKEN: token },
       log: ctx.log,


### PR DESCRIPTION
## Summary
- authenticate Netlify CLI through its supported `NETLIFY_AUTH_TOKEN` environment variable
- stop putting the deployment token in process arguments
- add a regression test asserting the secret is absent from argv

Netlify documents `NETLIFY_AUTH_TOKEN` as the CI authentication path. Keeping the token out of argv avoids exposure through process inspection and captured command errors.

## Verification
- `pnpm exec vitest run packages/targets/deploy-netlify/src/index.test.ts` (8/8)
- `pnpm --filter @profullstack/sh1pt-target-deploy-netlify typecheck`
- `git diff --check`