### PR TITLE
fix(firebase): keep deployment token out of argv

### DIFF
--- a/packages/targets/deploy-firebase/src/index.test.ts
+++ b/packages/targets/deploy-firebase/src/index.test.ts
@@ -2,12 +2,26 @@ import { fakeBuildContext, fakeShipContext, smokeTest } from '@profullstack/sh1p
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { execMock } = vi.hoisted(() => ({
+  execMock: vi.fn(),
+}));
+
+vi.mock('@profullstack/sh1pt-core', async () => ({
+  ...(await vi.importActual<typeof import('@profullstack/sh1pt-core')>('@profullstack/sh1pt-core')),
+  exec: execMock,
+}));
+
 import adapter from './index.js';
 
 smokeTest(adapter, { idPrefix: 'deploy', requireKind: true });
 
 const tempDirs: string[] = [];
+
+beforeEach(() => {
+  execMock.mockReset();
+});
 
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
@@ -100,5 +114,22 @@ describe('Firebase deployment target', () => {
     }) as any, {
       projectId: 'my-firebase-project',
     })).rejects.toThrow('FIREBASE_TOKEN not in vault');
+  });
+
+  it('passes the Firebase token through the child environment, not argv', async () => {
+    execMock.mockResolvedValue({ exitCode: 0, stdout: '{}', stderr: '' });
+
+    await adapter.ship(fakeShipContext({
+      dryRun: false,
+      secret: (key: string) => key === 'FIREBASE_TOKEN' ? 'firebase-secret-token' : undefined,
+    }) as any, {
+      projectId: 'my-firebase-project',
+    });
+
+    const [bin, args, options] = execMock.mock.calls[0] ?? [];
+    expect(bin).toBe('npx');
+    expect(args).not.toContain('firebase-secret-token');
+    expect(args).not.toContain('--token');
+    expect(options.env.FIREBASE_TOKEN).toBe('firebase-secret-token');
   });
 });

--- a/packages/targets/deploy-firebase/src/index.ts
+++ b/packages/targets/deploy-firebase/src/index.ts
@@ -51,14 +51,13 @@ function configPath(ctx: { projectDir: string }, config: Config): string | undef
   return isAbsolute(config.config) ? config.config : join(ctx.projectDir, config.config);
 }
 
-function deployArgs(ctx: { projectDir: string }, config: Config, token?: string): string[] {
+function deployArgs(ctx: { projectDir: string }, config: Config): string[] {
   config = normalizedConfig(config);
   const args = ['--yes', 'firebase-tools', 'deploy', '--project', config.projectId, '--json'];
   if (config.only?.length) args.push('--only', config.only.join(','));
   const firebaseConfig = configPath(ctx, config);
   if (firebaseConfig) args.push('--config', firebaseConfig);
   if (config.message) args.push('--message', config.message);
-  if (token) args.push('--token', token);
   return args;
 }
 
@@ -109,7 +108,7 @@ export default defineTarget<Config>({
       throw new Error('FIREBASE_TOKEN not in vault - run: sh1pt secret set FIREBASE_TOKEN <token>');
     }
 
-    const result = await exec('npx', deployArgs(ctx, config, token), {
+    const result = await exec('npx', deployArgs(ctx, config), {
       cwd: ctx.projectDir,
       env: { ...ctx.env, FIREBASE_TOKEN: token },
       log: ctx.log,


### PR DESCRIPTION
## Summary
- authenticate Firebase CLI through its supported `FIREBASE_TOKEN` environment variable
- stop putting the long-lived deployment token in process arguments
- add a regression test asserting the secret is absent from argv

Firebase documents both authentication paths and warns that these tokens are extremely sensitive long-lived credentials. Keeping the token out of argv avoids exposure through process inspection and captured command errors.

## Verification
- `pnpm exec vitest run packages/targets/deploy-firebase/src/index.test.ts` (8/8)
- `pnpm --filter @profullstack/sh1pt-target-deploy-firebase typecheck`
- `git diff --check`