### PR TITLE
fix(spotify): honor base URL during connect

### DIFF
--- a/packages/social/spotify/src/index.test.ts
+++ b/packages/social/spotify/src/index.test.ts
@@ -30,6 +30,21 @@ describe('social-spotify playlist publishing', () => {
     });
   });
 
+  it('uses the configured API base URL when connecting', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ id: 'spotify_user_123' }),
+    } as Response);
+
+    await adapter.connect(
+      fakeConnectContext({ SPOTIFY_ACCESS_TOKEN: 'spotify-token' }),
+      { baseUrl: 'https://spotify-proxy.example/v1/' },
+    );
+
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://spotify-proxy.example/v1/me');
+  });
+
   it('creates a public playlist and appends normalized Spotify items', async () => {
     const fetchMock = vi.spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce({

--- a/packages/social/spotify/src/index.ts
+++ b/packages/social/spotify/src/index.ts
@@ -36,10 +36,10 @@ export default defineSocial<Config>({
   label: 'Spotify',
   requires: { maxBodyChars: 300, maxHashtags: 0, hashtagsInBody: true },
 
-  async connect(ctx) {
+  async connect(ctx, config) {
     const token = ctx.secret('SPOTIFY_ACCESS_TOKEN');
     if (!token) throw new Error('SPOTIFY_ACCESS_TOKEN not in vault');
-    const data = await spotifyFetch<SpotifyUserResponse>(token, '/me');
+    const data = await spotifyFetch<SpotifyUserResponse>(token, '/me', config);
     if (!data.id) throw new Error('Spotify profile response did not include a user id');
     return { accountId: data.id };
   },


### PR DESCRIPTION
## Summary
- pass the Spotify adapter config through `connect()`
- honor `baseUrl` for the `/me` profile check, matching playlist create/update requests
- add a regression test for custom API proxies and test doubles

Without this, `post()` used a configured Spotify API base URL while `connect()` silently called production at `https://api.spotify.com/v1/me`.

## Validation
- `pnpm vitest run packages/social/spotify/src/index.test.ts --reporter=verbose` (10 passed)
- `pnpm --filter @profullstack/sh1pt-social-spotify typecheck`