### PR TITLE
fix(cli): add JSON output to secret list

### DIFF
--- a/packages/cli/src/commands/secrets.test.ts
+++ b/packages/cli/src/commands/secrets.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../local-vault.js', () => ({
+  deleteSecretFromLocal: vi.fn(),
+  getSecretFromLocal: vi.fn(),
+  listSecretsLocal: vi.fn(async () => [{ key: 'LOCAL_TOKEN' }]),
+  localVaultPath: vi.fn(() => '/tmp/sh1pt/secrets.json'),
+  setSecretInLocal: vi.fn(),
+}));
+
+vi.mock('../cloud-vault.js', () => ({
+  deleteSecretFromCloud: vi.fn(),
+  getSecretFromCloud: vi.fn(),
+  isSignedIn: vi.fn(async () => false),
+  listSecretsFromCloud: vi.fn(async () => [
+    { key: 'CLOUD_TOKEN', updated_at: '2026-08-30T00:00:00Z' },
+  ]),
+  setSecretInCloud: vi.fn(),
+}));
+
+import { secretsCmd } from './secrets.js';
+
+describe('secret list --json', () => {
+  let stdout: string[];
+
+  beforeEach(() => {
+    stdout = [];
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      stdout.push(args.map(String).join(' '));
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('emits local keys without exposing values', async () => {
+    const listCmd = secretsCmd.commands.find((command) => command.name() === 'list')!;
+    await listCmd.parseAsync(['--local', '--json'], { from: 'user' });
+
+    expect(JSON.parse(stdout.join('\n'))).toEqual({
+      local: [{ key: 'LOCAL_TOKEN' }],
+    });
+  });
+
+  it('emits cloud keys and timestamps as JSON', async () => {
+    const listCmd = secretsCmd.commands.find((command) => command.name() === 'list')!;
+    await listCmd.parseAsync(['--cloud', '--json'], { from: 'user' });
+
+    expect(JSON.parse(stdout.join('\n'))).toEqual({
+      cloud: [{ key: 'CLOUD_TOKEN', updated_at: '2026-08-30T00:00:00Z' }],
+    });
+  });
+});

--- a/packages/cli/src/commands/secrets.ts
+++ b/packages/cli/src/commands/secrets.ts
@@ -28,6 +28,7 @@ import {
 interface ScopeOpts {
   local?: boolean;
   cloud?: boolean;
+  json?: boolean;
 }
 
 export const secretsCmd = new Command('secret')
@@ -115,29 +116,41 @@ secretsCmd
   .description('List secret keys (never values)')
   .option('--local', 'list only the local vault')
   .option('--cloud', 'list only the cloud vault')
+  .option('--json', 'emit machine-readable JSON')
   .action(async (opts: ScopeOpts) => {
     const showLocal = !opts.cloud;
     const showCloud = opts.cloud || (!opts.local && (await isSignedIn()));
+    const output: {
+      local?: Array<{ key: string }>;
+      cloud?: Array<{ key: string; updated_at: string }>;
+    } = {};
 
     if (showLocal) {
       const entries = await listSecretsLocal();
-      console.log(kleur.bold(`local (${localVaultPath()})`));
-      if (entries.length === 0) {
-        console.log(kleur.dim('  (empty)'));
-      } else {
-        for (const e of entries) console.log(`  ${kleur.cyan(e.key)}`);
+      output.local = entries;
+      if (!opts.json) {
+        console.log(kleur.bold(`local (${localVaultPath()})`));
+        if (entries.length === 0) {
+          console.log(kleur.dim('  (empty)'));
+        } else {
+          for (const e of entries) console.log(`  ${kleur.cyan(e.key)}`);
+        }
       }
     }
     if (showCloud) {
-      if (showLocal) console.log();
-      console.log(kleur.bold('cloud (sh1pt.com vault)'));
       const entries = await listSecretsFromCloud();
-      if (entries.length === 0) {
-        console.log(kleur.dim('  (empty)'));
-      } else {
-        for (const e of entries) console.log(`  ${kleur.cyan(e.key)}  ${kleur.dim(e.updated_at)}`);
+      output.cloud = entries;
+      if (!opts.json) {
+        if (showLocal) console.log();
+        console.log(kleur.bold('cloud (sh1pt.com vault)'));
+        if (entries.length === 0) {
+          console.log(kleur.dim('  (empty)'));
+        } else {
+          for (const e of entries) console.log(`  ${kleur.cyan(e.key)}  ${kleur.dim(e.updated_at)}`);
+        }
       }
     }
+    if (opts.json) console.log(JSON.stringify(output, null, 2));
   });
 
 secretsCmd


### PR DESCRIPTION
## Summary

- add `--json` support to `sh1pt secret list`
- preserve local/cloud scoping without exposing secret values
- cover local and cloud JSON shapes with focused tests

## Verification

- `pnpm exec vitest run packages/cli/src` (280 tests)
- `pnpm --filter @profullstack/sh1pt typecheck`
- `pnpm --filter "@profullstack/sh1pt..." build`