### PR TITLE
fix(cli): serialize concurrent credential writes on Windows

### DIFF
--- a/packages/cli/src/credentials.ts
+++ b/packages/cli/src/credentials.ts
@@ -12,6 +12,7 @@ import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
 const FILE_NAME = 'credentials.json';
+let credentialsWriteQueue: Promise<void> = Promise.resolve();
 
 export interface Credentials {
   access_token: string;
@@ -43,7 +44,16 @@ export async function readCredentials(): Promise<Credentials | null> {
   }
 }
 
-export async function writeCredentials(creds: Credentials): Promise<void> {
+export function writeCredentials(creds: Credentials): Promise<void> {
+  // Concurrent renames to the same destination can fail with EPERM on Windows,
+  // even when every writer uses its own temporary file. Keep the atomic
+  // tmp+rename operation, but serialize replacements within this process.
+  const write = credentialsWriteQueue.then(() => writeCredentialsAtomic(creds));
+  credentialsWriteQueue = write.catch(() => {});
+  return write;
+}
+
+async function writeCredentialsAtomic(creds: Credentials): Promise<void> {
   const path = credentialsPath();
   // Mode 0o700 on the directory — match local-vault.ts writeVault pattern.
   await fs.mkdir(dirname(path), { recursive: true, mode: 0o700 });


### PR DESCRIPTION
## Summary
- serialize credential-file replacements within the CLI process
- preserve the existing unique temp file plus atomic rename flow
- allow concurrent login/session writes to complete reliably on Windows

## Bug
The existing concurrent-write regression test fails on Windows with `EPERM` when multiple unique temp files are renamed to `credentials.json` at the same time. Windows permits a sequential rename over the destination, but concurrent replacements race on the destination.

## Verification
- Before: `pnpm exec vitest run packages/cli/src/credentials.test.ts` failed in `supports concurrent atomic writes without sharing a temporary file` with `EPERM` from `rename`.
- After: the focused test file passed 20 consecutive runs on Windows, 3 tests per run.
- `pnpm exec tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --types node packages/cli/src/credentials.ts` passed.

The package-wide typecheck is still blocked by existing unresolved workspace build outputs such as `@profullstack/sh1pt-core`; this change adds no new type errors.