### PR TITLE
fix(cli): serialize concurrent iterate state writes

### DIFF
--- a/packages/cli/src/commands/iterate-atomic-write.test.ts
+++ b/packages/cli/src/commands/iterate-atomic-write.test.ts
@@ -1,0 +1,32 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { atomicWrite } from './iterate.js';
+
+let tempDir: string | undefined;
+
+describe('iterate atomic writes', () => {
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  it('does not collide when the same state file is written concurrently', async () => {
+    tempDir = await mkdtemp(path.join(tmpdir(), 'sh1pt-iterate-'));
+    const file = path.join(tempDir, 'state.json');
+
+    for (let round = 0; round < 20; round += 1) {
+      const results = await Promise.allSettled(
+        Array.from({ length: 12 }, (_, value) => atomicWrite(file, { round, value })),
+      );
+      expect(results.filter((result) => result.status === 'rejected')).toEqual([]);
+    }
+    expect(JSON.parse(await readFile(file, 'utf8'))).toEqual({
+      round: expect.any(Number),
+      value: expect.any(Number),
+    });
+  });
+});

--- a/packages/cli/src/commands/iterate.ts
+++ b/packages/cli/src/commands/iterate.ts
@@ -14,12 +14,33 @@ import { parsePositiveSafeInteger, parseQuietHours } from './iterate-options.js'
 // Shared utilities
 // ---------------------------------------------------------------------------
 
-/** Atomic write: write to .tmp then rename — same pattern as goals. */
-async function atomicWrite(file: string, data: unknown): Promise<void> {
+const atomicWriteQueues = new Map<string, Promise<void>>();
+
+/** Atomic write: write to a unique .tmp then rename. */
+async function atomicWriteOnce(file: string, data: unknown): Promise<void> {
   await fs.mkdir(path.dirname(file), { recursive: true, mode: 0o700 });
-  const tmp = `${file}.tmp`;
-  await fs.writeFile(tmp, JSON.stringify(data, null, 2) + '\n', { mode: 0o600 });
-  await fs.rename(tmp, file);
+  const tmp = `${file}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`;
+  try {
+    await fs.writeFile(tmp, JSON.stringify(data, null, 2) + '\n', { mode: 0o600 });
+    await fs.rename(tmp, file);
+  } catch (err) {
+    await fs.unlink(tmp).catch(() => {});
+    throw err;
+  }
+}
+
+export function atomicWrite(file: string, data: unknown): Promise<void> {
+  const previous = atomicWriteQueues.get(file) ?? Promise.resolve();
+  const result = previous.then(() => atomicWriteOnce(file, data));
+  const tail = result.then(
+    () => {},
+    () => {},
+  );
+  atomicWriteQueues.set(file, tail);
+  void tail.then(() => {
+    if (atomicWriteQueues.get(file) === tail) atomicWriteQueues.delete(file);
+  });
+  return result;
 }
 
 /** Generic JSON loader with ENOENT handling. */


### PR DESCRIPTION
## Summary
- give every iterate state write a unique temporary path
- serialize writes per destination file so concurrent calls cannot race during rename on Windows
- remove a temporary file when a write or rename fails

## Reproduction
A focused test starts 12 writes to the same iterate state file at once. Before the fix, 8 writes rejected with ENOENT because another writer had already renamed the shared .tmp file. Unique temporary names alone still produced EPERM rename failures on Windows. The final implementation passes 20 rounds of 12 concurrent writes without a rejection and leaves valid JSON behind.

## Validation
- pnpm exec vitest run packages/cli/src/commands/iterate.test.ts packages/cli/src/commands/iterate-atomic-write.test.ts (21 passed)
- pnpm --filter @profullstack/sh1pt typecheck
- pnpm --filter '@profullstack/sh1pt...' build
- git diff --check