### PR TITLE
fix(cli): sh1pt init exits 0 without writing config on non-TTY stdin

### DIFF
--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const accessMock = vi.fn();
+const writeFileMock = vi.fn();
+vi.mock('node:fs/promises', () => ({
+  access: (...args: unknown[]) => accessMock(...args),
+  writeFile: (...args: unknown[]) => writeFileMock(...args),
+}));
+
+const promptsMock = vi.fn();
+vi.mock('prompts', () => ({
+  default: (...args: unknown[]) => promptsMock(...args),
+}));
+
+import { initAction, initCmd } from './init.js';
+
+// Regression guard for `sh1pt init` on non-interactive stdin.
+//
+// `prompts` reads keystrokes from stdin. When stdin is not a TTY (CI, `< /dev/null`, a piped
+// script with no bytes) it never receives input that resolves or cancels the prompt, and once
+// nothing else is keeping the event loop alive Node exits on its own — abandoning the pending
+// `await prompts(...)` without ever running the code after it. That used to make `sh1pt init`
+// exit 0 without writing sh1pt.config.ts, so a script/CI step had no way to tell it had failed.
+// `initAction` must now fail fast (non-zero exit code, no prompt call) instead of awaiting a
+// prompt that can never settle, and `--name` must be able to skip the prompt entirely.
+describe('initAction', () => {
+  let originalIsTTY: boolean | undefined;
+
+  beforeEach(() => {
+    accessMock.mockReset().mockRejectedValue(new Error('ENOENT'));
+    writeFileMock.mockReset().mockResolvedValue(undefined);
+    promptsMock.mockReset();
+    originalIsTTY = process.stdin.isTTY;
+    process.exitCode = undefined;
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.stdin.isTTY = originalIsTTY;
+    process.exitCode = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it('fails with a non-zero exit code and never calls prompts() when stdin is not a TTY and no --name is given', async () => {
+    process.stdin.isTTY = undefined;
+
+    await initAction({});
+
+    expect(promptsMock).not.toHaveBeenCalled();
+    expect(writeFileMock).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('writes the config straight from --name without prompting, even without a TTY', async () => {
+    process.stdin.isTTY = undefined;
+
+    await initAction({ name: 'coolapp' });
+
+    expect(promptsMock).not.toHaveBeenCalled();
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    const contents = writeFileMock.mock.calls[0][1] as string;
+    expect(contents).toContain('name: "coolapp"');
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('still prompts interactively when stdin is a TTY and no --name is given', async () => {
+    process.stdin.isTTY = true;
+    promptsMock.mockResolvedValue({ name: 'from-prompt' });
+
+    await initAction({});
+
+    expect(promptsMock).toHaveBeenCalledTimes(1);
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    const contents = writeFileMock.mock.calls[0][1] as string;
+    expect(contents).toContain('name: "from-prompt"');
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('fails with a non-zero exit code when the interactive prompt is cancelled', async () => {
+    process.stdin.isTTY = true;
+    promptsMock.mockResolvedValue({});
+
+    await initAction({});
+
+    expect(writeFileMock).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('does not overwrite an existing sh1pt.config.ts, even with --name', async () => {
+    accessMock.mockResolvedValue(undefined);
+
+    await initAction({ name: 'ignored' });
+
+    expect(promptsMock).not.toHaveBeenCalled();
+    expect(writeFileMock).not.toHaveBeenCalled();
+  });
+
+  it('wires --name through the commander option to initAction', async () => {
+    process.stdin.isTTY = undefined;
+
+    await initCmd.parseAsync(['--name', 'from-flag'], { from: 'user' });
+
+    expect(promptsMock).not.toHaveBeenCalled();
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    const contents = writeFileMock.mock.calls[0][1] as string;
+    expect(contents).toContain('name: "from-flag"');
+  });
+});

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -15,11 +15,15 @@ export default defineConfig({
 });
 `;
 
+export interface InitOptions {
+  name?: string;
+}
+
 /**
  * Shared init action — scaffolds sh1pt.config.ts in the current project.
  * Used by both `sh1pt init` (top-level) and `sh1pt ship init` (sub-command).
  */
-export async function initAction(): Promise<void> {
+export async function initAction(opts: InitOptions = {}): Promise<void> {
   const cfgPath = join(process.cwd(), 'sh1pt.config.ts');
   try {
     await access(cfgPath);
@@ -28,13 +32,42 @@ export async function initAction(): Promise<void> {
   } catch {
     // expected — file does not exist
   }
-  const { name } = await prompts({
-    type: 'text',
-    name: 'name',
-    message: 'Project name',
-    initial: basename(process.cwd()) || 'my-app',
-  });
-  if (!name) return;
+
+  let name = opts.name;
+  if (!name) {
+    if (!process.stdin.isTTY) {
+      // `prompts` reads keystrokes from stdin. When stdin is not a TTY (CI, `< /dev/null`,
+      // a piped script with no bytes) it never receives input that resolves or cancels the
+      // prompt, and once nothing else is keeping the event loop alive Node exits on its own —
+      // abandoning the still-pending `await prompts(...)` below without ever running the code
+      // after it. That used to exit 0 without writing sh1pt.config.ts, so a script/CI step had
+      // no way to tell init had failed. Fail fast instead of awaiting a prompt that can never
+      // settle; `--name` is the non-interactive escape hatch.
+      console.error(
+        kleur.red(
+          'sh1pt init needs an interactive terminal to ask for the project name — no TTY detected (running in CI or a piped script?). Pass --name <name> to run non-interactively.',
+        ),
+      );
+      process.exitCode = 1;
+      return;
+    }
+    const answer = await prompts({
+      type: 'text',
+      name: 'name',
+      message: 'Project name',
+      initial: basename(process.cwd()) || 'my-app',
+    });
+    name = answer.name;
+  }
+  if (!name) {
+    // `prompts` resolves to `{}` (no `name` key) instead of rejecting when the
+    // prompt is cancelled — e.g. Ctrl+C. Returning here silently used to exit 0
+    // without writing sh1pt.config.ts, so a script or CI step could not tell
+    // init had failed.
+    console.error(kleur.red('sh1pt.config.ts not written — no project name provided (prompt cancelled).'));
+    process.exitCode = 1;
+    return;
+  }
   await writeFile(cfgPath, CONFIG_TEMPLATE(name), 'utf8');
   console.log(kleur.green('✓ wrote sh1pt.config.ts'));
   console.log(`  next: ${kleur.cyan('sh1pt ship target add <id>')}`);
@@ -46,4 +79,5 @@ export async function initAction(): Promise<void> {
  */
 export const initCmd = new Command('init')
   .description('Scaffold sh1pt.config.ts in the current project')
+  .option('--name <name>', 'Project name — skips the interactive prompt')
   .action(initAction);

--- a/packages/cli/src/commands/ship.ts
+++ b/packages/cli/src/commands/ship.ts
@@ -73,6 +73,7 @@ export const shipCmd = new Command('ship')
 shipCmd
   .command('init')
   .description('Scaffold sh1pt.config.ts in the current project')
+  .option('--name <name>', 'Project name — skips the interactive prompt')
   .action(initAction);
 
 shipCmd


### PR DESCRIPTION
## Bug

`sh1pt init` (and `sh1pt ship init`) silently does nothing and still exits `0` when stdin is not a TTY — e.g. run in CI, with `< /dev/null`, or in any piped/non-interactive script.

Repro:
```sh
mkdir /tmp/repro && cd /tmp/repro
sh1pt init < /dev/null
echo "exit code: $?"
ls   # sh1pt.config.ts was never written
```
`exit code: 0`, no file written, no error printed.

## Root cause

`prompts()` reads keystrokes from stdin. When stdin is not a TTY and produces no data before EOF, it never receives input that resolves or cancels the prompt. Once nothing else is keeping the event loop alive, Node exits on its own — abandoning the still-pending `await prompts(...)` before `initAction`'s own `if (!name) return;` guard (added for the Ctrl+C-cancel case) ever runs. A script or CI step has no way to tell `init` failed.

## Fix

- `initAction` now checks `process.stdin.isTTY` **before** calling `prompts()`. If there's no TTY, it fails fast with a clear message and `process.exitCode = 1` instead of awaiting a promise that can never settle.
- Added a `--name <name>` option (on both `sh1pt init` and `sh1pt ship init`) so non-interactive callers can skip the prompt entirely: `sh1pt init --name myapp`.
- The existing "prompt cancelled" guard (Ctrl+C in a real TTY) is unchanged.

## Tests

Added `packages/cli/src/commands/init.test.ts` (6 new tests, mocking `prompts` and `node:fs/promises`):
- non-TTY + no `--name` → exit code 1, `prompts`/`writeFile` never called
- non-TTY + `--name` → writes config directly, no prompt, exit code unchanged
- TTY + no `--name` → still prompts interactively (existing behavior preserved)
- TTY + prompt cancelled → exit code 1
- existing `sh1pt.config.ts` → aborts without overwriting, even with `--name`
- `--name` is correctly wired through the commander option on `initCmd`

Full suite: `pnpm test` → 715/715 test files, 3615/3616 tests passing (1 pre-existing skip, unrelated). `pnpm --filter @profullstack/sh1pt typecheck` passes clean.