### PR TITLE
fix(cli): avoid POSIX permission warning on Windows

### DIFF
--- a/packages/cli/src/local-vault.test.ts
+++ b/packages/cli/src/local-vault.test.ts
@@ -1,14 +1,21 @@
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
-import { getSecretFromLocal, listSecretsLocal, localVaultPath } from './local-vault.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  getSecretFromLocal,
+  hasLoosePosixPermissions,
+  listSecretsLocal,
+  loadLocalVaultSync,
+  localVaultPath,
+} from './local-vault.js';
 
 const ORIGINAL_XDG_CONFIG_HOME = process.env.XDG_CONFIG_HOME;
 let tempDir: string | undefined;
 
 describe('local vault', () => {
   afterEach(async () => {
+    vi.restoreAllMocks();
     if (ORIGINAL_XDG_CONFIG_HOME === undefined) delete process.env.XDG_CONFIG_HOME;
     else process.env.XDG_CONFIG_HOME = ORIGINAL_XDG_CONFIG_HOME;
 
@@ -34,5 +41,25 @@ describe('local vault', () => {
     expect(await getSecretFromLocal('TOKEN')).toBe('secret');
     expect(await getSecretFromLocal('COUNT')).toBeUndefined();
     expect(await listSecretsLocal()).toEqual([{ key: 'TOKEN' }]);
+  });
+
+  it('checks loose mode bits only on POSIX platforms', () => {
+    expect(hasLoosePosixPermissions(0o666, 'win32')).toBe(false);
+    expect(hasLoosePosixPermissions(0o666, 'linux')).toBe(true);
+    expect(hasLoosePosixPermissions(0o600, 'linux')).toBe(false);
+  });
+
+  it.runIf(process.platform === 'win32')('does not suggest POSIX chmod permissions on Windows', async () => {
+    tempDir = join(tmpdir(), `sh1pt-vault-${Date.now()}`);
+    process.env.XDG_CONFIG_HOME = tempDir;
+    await mkdir(join(tempDir, 'sh1pt'), { recursive: true });
+    await writeFile(localVaultPath(), JSON.stringify({
+      version: 1,
+      secrets: { TOKEN: 'secret' },
+    }));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(loadLocalVaultSync().get('TOKEN')).toBe('secret');
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/local-vault.ts
+++ b/packages/cli/src/local-vault.ts
@@ -40,6 +40,13 @@ interface LocalVault {
   secrets: Record<string, string>;
 }
 
+export function hasLoosePosixPermissions(
+  mode: number,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return platform !== 'win32' && (mode & 0o077) !== 0;
+}
+
 export function localVaultPath(): string {
   return path.join(configDir(), 'secrets.json');
 }
@@ -60,7 +67,7 @@ export function loadLocalVaultSync(): Map<string, string> {
   const file = localVaultPath();
   try {
     const stat = statSync(file);
-    if ((stat.mode & 0o077) !== 0) {
+    if (hasLoosePosixPermissions(stat.mode)) {
       console.warn(
         `⚠ ${file} has loose permissions (mode ${(stat.mode & 0o777).toString(8)}). ` +
         `Run: chmod 600 "${file}"`,


### PR DESCRIPTION
## Summary
- skip POSIX group/world mode checks on Windows, where Node reports synthetic mode bits instead of effective ACLs
- keep the existing warning unchanged on POSIX platforms
- add a Windows integration regression test plus platform-independent mode checks

## Reproduction
On Windows, a normal secrets.json created by Node reports mode 666. loadLocalVaultSync therefore warns that the file is insecure and tells the user to run chmod 600, even though chmod-style POSIX mode semantics do not apply. The regression test reproduced the exact warning before this fix.

## Validation
- pnpm exec vitest run packages/cli/src/local-vault.test.ts (3 passed)
- pnpm --filter @profullstack/sh1pt typecheck
- pnpm --filter '@profullstack/sh1pt...' build
- git diff --check