### PR TITLE
fix(cli): preserve Windows login URLs

### DIFF
--- a/packages/cli/src/commands/login.test.ts
+++ b/packages/cli/src/commands/login.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { loginCmd } from './login.js';
+import { browserOpenCommand, loginCmd } from './login.js';
 
 // Regression guard for the `--no-browser` flag.
 //
@@ -25,5 +25,21 @@ describe('login command --no-browser option', () => {
   it('sets browser to false when --no-browser is passed', () => {
     loginCmd.parseOptions(['--no-browser']);
     expect(loginCmd.opts().browser).toBe(false);
+  });
+});
+
+describe('browser open command', () => {
+  const url = 'https://sh1pt.com/cli/pair?code=abc&redirect=/done';
+
+  it('passes the complete URL directly to the Windows shell opener', () => {
+    expect(browserOpenCommand(url, 'win32')).toEqual({
+      command: 'explorer.exe',
+      args: [url],
+    });
+  });
+
+  it('keeps the native macOS and Linux openers', () => {
+    expect(browserOpenCommand(url, 'darwin')).toEqual({ command: 'open', args: [url] });
+    expect(browserOpenCommand(url, 'linux')).toEqual({ command: 'xdg-open', args: [url] });
   });
 });

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -97,14 +97,21 @@ export const logoutCmd = new Command('logout')
     console.log(kleur.dim('signed out — credentials cleared.'));
   });
 
-function tryOpenBrowser(url: string): void {
+export function browserOpenCommand(
+  url: string,
+  platform: NodeJS.Platform = process.platform,
+): { command: string; args: string[] } {
   const cmd =
-    process.platform === 'darwin' ? 'open' :
-    process.platform === 'win32'  ? 'cmd' :
+    platform === 'darwin' ? 'open' :
+    platform === 'win32'  ? 'explorer.exe' :
     'xdg-open';
-  const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url];
+  return { command: cmd, args: [url] };
+}
+
+function tryOpenBrowser(url: string): void {
+  const { command, args } = browserOpenCommand(url);
   try {
-    const child = spawn(cmd, args, { stdio: 'ignore', detached: true });
+    const child = spawn(command, args, { stdio: 'ignore', detached: true });
     child.unref();
   } catch {
     // Headless or no browser available — the URL is already printed,


### PR DESCRIPTION
## Summary
- stop routing Windows login URLs through cmd /c start
- pass the complete URL directly to explorer.exe so query separators are not interpreted as shell commands
- keep the existing native open and xdg-open behavior on macOS and Linux

## Reproduction
The pairing URL contains query parameters. On Windows, cmd /c treats an unquoted ampersand as a command separator: a URL such as https://sh1pt.com/cli/pair?code=abc&redirect=/done is truncated after code=abc and cmd tries to execute redirect=/done. That breaks browser pairing and can misinterpret later query text as commands.

## Validation
- pnpm exec vitest run packages/cli/src/commands/login.test.ts (5 passed)
- pnpm --filter @profullstack/sh1pt typecheck
- pnpm --filter '@profullstack/sh1pt...' build
- git diff --check