### PR TITLE
fix(cli): restore old fleet on blue-green rollback

### DIFF
--- a/packages/cli/src/commands/scale.test.ts
+++ b/packages/cli/src/commands/scale.test.ts
@@ -17,6 +17,7 @@ import {
   parsePercentage,
   aggregateFleetCosts,
   rollbackPlanIps,
+  applyRollback,
 } from './scale.js';
 
 // Helper to create a temp dir and override CREDS_FILE path
@@ -426,5 +427,55 @@ describe('rollbackPlanIps', () => {
       instances: [{ id: 'inst-0001', provider: 'aws', status: 'stopped', createdAt: '', hourlyRate: 0.1 }],
     };
     expect(rollbackPlanIps(fleetNoIp, rollout)).toEqual(['?.?.?.?']);
+  });
+});
+
+describe('applyRollback', () => {
+  it('reactivates the old fleet for the recorded blue-green strategy', () => {
+    const fleet: FleetState = {
+      instances: [
+        { id: 'inst-old', provider: 'aws', status: 'stopped', createdAt: '', hourlyRate: 0.1 },
+        { id: 'inst-new', provider: 'aws', status: 'running', createdAt: '', hourlyRate: 0.1 },
+      ],
+      lastUpdated: '',
+    };
+    const rollout: RolloutRecord = {
+      id: 'roll-blue-green',
+      version: 'v2',
+      strategy: 'blue-green',
+      status: 'completed',
+      startedAt: '2026-08-08T00:00:00.000Z',
+      newInstanceIds: ['inst-new'],
+      oldInstanceIds: ['inst-old'],
+    };
+
+    applyRollback(fleet, rollout);
+
+    expect(fleet.instances.find(i => i.id === 'inst-new')?.status).toBe('stopped');
+    expect(fleet.instances.find(i => i.id === 'inst-old')?.status).toBe('running');
+  });
+
+  it('leaves old instances unchanged for non-blue-green rollouts', () => {
+    const fleet: FleetState = {
+      instances: [
+        { id: 'inst-old', provider: 'aws', status: 'stopped', createdAt: '', hourlyRate: 0.1 },
+        { id: 'inst-new', provider: 'aws', status: 'running', createdAt: '', hourlyRate: 0.1 },
+      ],
+      lastUpdated: '',
+    };
+    const rollout: RolloutRecord = {
+      id: 'roll-canary',
+      version: 'v2',
+      strategy: 'canary',
+      status: 'completed',
+      startedAt: '2026-08-08T00:00:00.000Z',
+      newInstanceIds: ['inst-new'],
+      oldInstanceIds: ['inst-old'],
+    };
+
+    applyRollback(fleet, rollout);
+
+    expect(fleet.instances.find(i => i.id === 'inst-new')?.status).toBe('stopped');
+    expect(fleet.instances.find(i => i.id === 'inst-old')?.status).toBe('stopped');
   });
 });

--- a/packages/cli/src/commands/scale.ts
+++ b/packages/cli/src/commands/scale.ts
@@ -222,6 +222,22 @@ export function rollbackPlanIps(fleet: FleetState, target: RolloutRecord): strin
     .map(i => i.publicIp || i.privateIp || '?.?.?.?');
 }
 
+/** Apply the recorded rollout's state transition when rolling it back. */
+export function applyRollback(fleet: FleetState, target: RolloutRecord): void {
+  for (const inst of fleet.instances) {
+    if (target.newInstanceIds.includes(inst.id)) {
+      inst.status = 'stopped';
+    }
+  }
+  if (target.strategy === 'blue-green') {
+    for (const inst of fleet.instances) {
+      if (target.oldInstanceIds.includes(inst.id)) {
+        inst.status = 'running';
+      }
+    }
+  }
+}
+
 export const scaleCmd = new Command('scale')
   .description('Provision + scale cloud infra. DNS round-robin, rollouts, rightsizing — all the capacity ops.')
   .option('--from <input>', 'existing live url, repo, or local path to probe + propose scaling for')
@@ -746,20 +762,7 @@ scaleCmd
         console.log(kleur.dim('Dry-run — no changes made.'));
         return;
       }
-      // Mark new instances as stopped, set status
-      for (const inst of fleet.instances) {
-        if (target.newInstanceIds.includes(inst.id)) {
-          inst.status = 'stopped';
-        }
-      }
-      if (opts.strategy === 'blue-green') {
-        // Reactivate old instances
-        for (const inst of fleet.instances) {
-          if (target.oldInstanceIds.includes(inst.id)) {
-            inst.status = 'running';
-          }
-        }
-      }
+      applyRollback(fleet, target);
       saveFleet(fleet);
       target.status = 'rolled-back';
       target.completedAt = new Date().toISOString();


### PR DESCRIPTION
## What
- use the rollout record's strategy when applying rollback state
- stop the new fleet and reactivate the old fleet for blue-green rollouts
- add regression coverage for blue-green and non-blue-green behavior

## Why
`scale rollout --rollback` receives the command's default `--strategy canary` when the caller does not pass a strategy. The rollback path checked that option instead of the stored rollout record, so a completed blue-green rollback stopped the new instances but failed to reactivate the old fleet.

## Testing
- `pnpm exec vitest run packages/cli/src/commands/scale.test.ts` (56 passed)
- `pnpm --filter @profullstack/sh1pt... build`
- `pnpm --filter @profullstack/sh1pt typecheck`