### PR TITLE
fix(cli): allow rollout status without version

### DIFF
--- a/packages/cli/src/commands/scale.test.ts
+++ b/packages/cli/src/commands/scale.test.ts
@@ -253,6 +253,13 @@ describe('scale command registration', () => {
     expect(subcommands).toContain('cost');
     expect(subcommands).toContain('status');
   });
+
+  it('does not require --version for rollout status or rollback modes', () => {
+    const rollout = scaleCmd.commands.find(command => command.name() === 'rollout');
+    const version = rollout?.options.find(option => option.long === '--version');
+
+    expect(version?.mandatory).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/commands/scale.ts
+++ b/packages/cli/src/commands/scale.ts
@@ -682,7 +682,7 @@ scaleCmd
 scaleCmd
   .command('rollout')
   .description('Stage a new version across the fleet (canary / blue-green / rolling)')
-  .requiredOption('--version <id>', 'version identifier to deploy (e.g. v2.1.0)')
+  .option('--version <id>', 'version identifier to deploy (e.g. v2.1.0)')
   .option('--strategy <kind>', 'canary | blue-green | rolling', 'canary')
   .option('--percent <n>', 'canary only — start at N% of traffic', parsePercentage, 5)
   .option('--dry-run', 'show the plan without modifying state')


### PR DESCRIPTION
## What
- make `--version` optional at Commander registration time
- keep the existing action-level requirement for actual deployments
- add regression coverage for the rollout option contract

## Why
The command implements `--status` and `--rollback` branches before it validates a deployment version, but `.requiredOption('--version')` makes Commander exit before either branch can run. As a result, `sh1pt scale rollout --status` and rollback mode require a meaningless dummy version.

## Reproduction
Before this change:
```
sh1pt scale rollout --status
error: required option '--version <id>' not specified
```

After this change:
```
sh1pt scale rollout --status
No rollouts recorded.
```

## Testing
- `pnpm exec vitest run packages/cli/src/commands/scale.test.ts` (55 passed)
- `pnpm --filter @profullstack/sh1pt... build`
- `pnpm --filter @profullstack/sh1pt typecheck`