### PR TITLE
fix(cli): persist auto-scale rules in JSON mode

### DIFF
--- a/packages/cli/src/commands/scale.test.ts
+++ b/packages/cli/src/commands/scale.test.ts
@@ -382,6 +382,28 @@ describe('auto-scale rules', () => {
     expect(rules.targetCpuPercent).toBe(65);
     expect(rules.cooldownSeconds).toBe(300);
   });
+
+  it('persists rules when --json is used without --dry-run', async () => {
+    const dir = makeTempDir();
+    const previousHome = process.env.HOME;
+    const previousUserProfile = process.env.USERPROFILE;
+    process.env.HOME = dir;
+    process.env.USERPROFILE = dir;
+
+    try {
+      const auto = scaleCmd.commands.find(command => command.name() === 'auto');
+      await auto?.parseAsync(['--min', '2', '--max', '4', '--json'], { from: 'user' });
+
+      const saved = JSON.parse(readFileSync(join(dir, '.sh1pt', 'auto-scale.json'), 'utf-8'));
+      expect(saved.minInstances).toBe(2);
+      expect(saved.maxInstances).toBe(4);
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = previousUserProfile;
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/commands/scale.ts
+++ b/packages/cli/src/commands/scale.ts
@@ -543,25 +543,27 @@ scaleCmd
       updatedAt: new Date().toISOString(),
     };
 
-    if (opts.json) {
-      console.log(JSON.stringify({ rules }, null, 2));
-      return;
+    if (!opts.json) {
+      console.log(kleur.bold('\n📊 Auto-Scale Rules'));
+      console.log(kleur.dim('─'.repeat(52)));
+      console.log(`${kleur.cyan('Min instances:'.padEnd(20))} ${min}`);
+      console.log(`${kleur.cyan('Max instances:'.padEnd(20))} ${max}`);
+      console.log(`${kleur.cyan('Target CPU:'.padEnd(20))} ${targetCpu}%`);
+      console.log(`${kleur.cyan('Cooldown:'.padEnd(20))} ${cooldown}s (${(cooldown / 60).toFixed(1)} min)`);
+      console.log(kleur.dim('─'.repeat(52)));
     }
 
-    console.log(kleur.bold('\n📊 Auto-Scale Rules'));
-    console.log(kleur.dim('─'.repeat(52)));
-    console.log(`${kleur.cyan('Min instances:'.padEnd(20))} ${min}`);
-    console.log(`${kleur.cyan('Max instances:'.padEnd(20))} ${max}`);
-    console.log(`${kleur.cyan('Target CPU:'.padEnd(20))} ${targetCpu}%`);
-    console.log(`${kleur.cyan('Cooldown:'.padEnd(20))} ${cooldown}s (${(cooldown / 60).toFixed(1)} min)`);
-    console.log(kleur.dim('─'.repeat(52)));
-
     if (opts.dryRun) {
-      console.log(kleur.dim('Dry-run — rules not saved.'));
+      if (opts.json) console.log(JSON.stringify({ rules }, null, 2));
+      else console.log(kleur.dim('Dry-run — rules not saved.'));
       return;
     }
 
     saveAutoScaleRules(rules);
+    if (opts.json) {
+      console.log(JSON.stringify({ rules }, null, 2));
+      return;
+    }
     console.log(kleur.green('✅ Auto-scale rules saved.'));
     console.log(kleur.dim(`Config file: ${AUTO_SCALE_FILE}`));
     console.log(kleur.dim('sh1pt cloud will poll metrics and scale up/down based on these rules.'));


### PR DESCRIPTION
## What
- keep JSON mode as an output-format choice instead of an implicit dry-run
- persist auto-scale rules before emitting JSON when `--dry-run` is absent
- preserve non-mutating behavior for `--json --dry-run`
- add an integration regression test that verifies the config file is written

## Why
`sh1pt scale auto --json` returned the requested rules and exited before `saveAutoScaleRules()`. Automation saw a successful JSON response even though no configuration file existed, so the requested auto-scale policy was silently discarded.

## Reproduction
Before this change, the command printed valid JSON but `.sh1pt/auto-scale.json` did not exist. After the change, the same command writes the file; adding `--dry-run` still skips the write.

## Testing
- `pnpm exec vitest run packages/cli/src/commands/scale.test.ts` (55 passed)
- isolated CLI reproduction before/after using a temporary home directory
- `pnpm --filter @profullstack/sh1pt... build`
- `pnpm --filter @profullstack/sh1pt typecheck`