### PR TITLE
fix(cli): sh1pt remove silently uninstalls nothing on non-TTY stdin

### DIFF
--- a/packages/cli/src/commands/self.test.ts
+++ b/packages/cli/src/commands/self.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const promptsMock = vi.fn();
+vi.mock('prompts', () => ({
+  default: (...args: unknown[]) => promptsMock(...args),
+}));
+
+const detectPackageManagerMock = vi.fn(() => 'npm' as const);
+vi.mock('../installer.js', () => ({
+  detectPackageManager: () => detectPackageManagerMock(),
+}));
+
+const runCommandMock = vi.fn(() => 0);
+vi.mock('../run-command.js', () => ({
+  runCommand: (...args: unknown[]) => runCommandMock(...args),
+}));
+
+const rmMock = vi.fn(async () => undefined);
+vi.mock('node:fs', () => ({
+  promises: { rm: (...args: unknown[]) => rmMock(...args) },
+}));
+
+vi.mock('@profullstack/sh1pt-core', () => ({
+  configDir: () => '/fake/home/.config/sh1pt',
+}));
+
+import { removeCmd } from './self.js';
+
+// Regression guard for `sh1pt remove` (uninstall) on non-interactive stdin.
+//
+// The "also delete ~/.config/sh1pt/?" prompt used to run *before* the actual
+// `run(argv)` uninstall call. `prompts()` reads keystrokes from stdin; when stdin
+// is not a TTY (CI, `< /dev/null`, a piped uninstall script) it never receives
+// input that resolves or cancels the prompt, and once nothing else is keeping
+// the event loop alive Node exits on its own — abandoning the pending prompt
+// *before* `run(argv)` ever executes. `sh1pt remove` therefore used to silently
+// uninstall nothing at all in a non-interactive shell, while still exiting 0.
+describe('removeCmd (sh1pt remove/uninstall)', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let originalIsTTY: boolean | undefined;
+
+  beforeEach(() => {
+    promptsMock.mockReset();
+    detectPackageManagerMock.mockReset().mockReturnValue('npm');
+    runCommandMock.mockReset().mockReturnValue(0);
+    rmMock.mockReset().mockResolvedValue(undefined);
+    originalIsTTY = process.stdin.isTTY;
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.stdin.isTTY = originalIsTTY;
+    vi.restoreAllMocks();
+  });
+
+  it('still runs the actual uninstall command when stdin is not a TTY', async () => {
+    process.stdin.isTTY = undefined;
+
+    await removeCmd.parseAsync([], { from: 'user' });
+
+    expect(promptsMock).not.toHaveBeenCalled();
+    expect(runCommandMock).toHaveBeenCalledTimes(1);
+    expect(runCommandMock).toHaveBeenCalledWith(['npm', 'uninstall', '-g', '@profullstack/sh1pt']);
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('keeps ~/.config/sh1pt/ by default when it cannot ask (no TTY)', async () => {
+    process.stdin.isTTY = undefined;
+
+    await removeCmd.parseAsync([], { from: 'user' });
+
+    expect(rmMock).not.toHaveBeenCalled();
+  });
+
+  it('still prompts and honors the answer when stdin is a TTY', async () => {
+    process.stdin.isTTY = true;
+    promptsMock.mockResolvedValue({ confirm: true });
+
+    await removeCmd.parseAsync([], { from: 'user' });
+
+    expect(promptsMock).toHaveBeenCalledTimes(1);
+    expect(runCommandMock).toHaveBeenCalledTimes(1);
+    expect(rmMock).toHaveBeenCalledWith('/fake/home/.config/sh1pt', { recursive: true, force: true });
+  });
+
+  it('skips the prompt entirely when --keep-config is passed, TTY or not', async () => {
+    process.stdin.isTTY = undefined;
+
+    await removeCmd.parseAsync(['--keep-config'], { from: 'user' });
+
+    expect(promptsMock).not.toHaveBeenCalled();
+    expect(runCommandMock).toHaveBeenCalledTimes(1);
+    expect(rmMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/self.ts
+++ b/packages/cli/src/commands/self.ts
@@ -59,13 +59,24 @@ export const removeCmd = new Command('remove')
 
     let deleteConfig = false;
     if (!opts.keepConfig) {
-      const { confirm } = await prompts({
-        type: 'confirm',
-        name: 'confirm',
-        message: 'Also delete ~/.config/sh1pt/ (adapter configs + stored secrets)?',
-        initial: false,
-      });
-      deleteConfig = Boolean(confirm);
+      if (!process.stdin.isTTY) {
+        // `prompts` reads keystrokes from stdin. When stdin is not a TTY (CI, `< /dev/null`,
+        // a piped uninstall script) it never receives input that resolves or cancels the
+        // prompt, and once nothing else is keeping the event loop alive Node exits on its
+        // own — abandoning the still-pending `await prompts(...)` below *before* `run(argv)`
+        // further down ever executes. `sh1pt remove` used to silently not uninstall anything
+        // at all in that case, while still exiting 0. Skip the prompt and keep its safe
+        // default (`initial: false`) instead of hanging in front of the actual uninstall.
+        console.log(kleur.dim('No TTY detected — keeping ~/.config/sh1pt/ (run interactively, or pass --keep-config, to silence this note).'));
+      } else {
+        const { confirm } = await prompts({
+          type: 'confirm',
+          name: 'confirm',
+          message: 'Also delete ~/.config/sh1pt/ (adapter configs + stored secrets)?',
+          initial: false,
+        });
+        deleteConfig = Boolean(confirm);
+      }
     }
 
     const code = run(argv);


### PR DESCRIPTION
## Bug

`sh1pt remove` (alias `uninstall`) asks "Also delete ~/.config/sh1pt/ ...?" via `prompts()` **before** calling `run(argv)` — the line that actually shells out to `npm`/`pnpm`/etc. to uninstall the package. On non-TTY stdin (CI, `< /dev/null`, a piped uninstall script) `prompts()` never resolves for the same reason described in #992: it never receives input that would resolve or cancel it, and once nothing else is keeping the event loop alive Node exits on its own — abandoning the pending prompt *before* `run(argv)` ever runs.

Net effect: `sh1pt remove` in a non-interactive shell exits `0` having **uninstalled nothing at all**, silently.

## Fix

Skip the prompt when there's no TTY and keep its existing safe default (`initial: false`, same as passing `--keep-config`) instead of hanging in front of the actual uninstall — so the primary effect of the command (actually uninstalling) still happens, and the config directory is conservatively kept rather than guessed at.

## Tests

Added `packages/cli/src/commands/self.test.ts` (4 tests, mocking `prompts`, `../installer.js`, `../run-command.js`, `node:fs`, `@profullstack/sh1pt-core`, and `process.exit` — no real package-manager command or filesystem delete is ever executed):
- non-TTY → `run(argv)` still executes, `prompts` never called
- non-TTY → `~/.config/sh1pt/` is kept (not deleted) by default
- TTY → still prompts and honors the answer (existing behavior preserved)
- `--keep-config` → skips the prompt entirely regardless of TTY

`pnpm test` → 716/716 test files, 3619/3620 tests passing (1 pre-existing unrelated skip). `pnpm --filter @profullstack/sh1pt typecheck` passes clean.

Related: #992 (same root cause, different command — `sh1pt init`).