### PR TITLE
fix(cli): assign unique rollout instance IDs

### DIFF
--- a/packages/cli/src/commands/scale.test.ts
+++ b/packages/cli/src/commands/scale.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { mkdtempSync, writeFileSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync, existsSync, readFileSync, mkdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -323,6 +324,45 @@ describe('rollout strategies use getNextId correctly', () => {
 
     expect(newIds).toHaveLength(batchSize);
     expect(newIds[0]).toBe('inst-0007');
+  });
+
+  it('assigns unique IDs to every instance created by a blue-green rollout', () => {
+    const dir = makeTempDir();
+    const stateDir = join(dir, '.sh1pt');
+    mkdirSync(stateDir, { recursive: true });
+    const statePath = join(stateDir, 'credentials.json');
+    writeFileSync(statePath, JSON.stringify({
+      apiKey: 'preserve-me',
+      instances: Array.from({ length: 3 }, (_, index) => ({
+        id: `inst-${String(index + 1).padStart(4, '0')}`,
+        provider: 'aws',
+        status: 'running',
+        createdAt: '',
+        hourlyRate: 0.1,
+      })),
+      lastUpdated: '',
+    }));
+
+    const scaleModule = new URL('./scale.ts', import.meta.url).href;
+    const runRollout = [
+      `import { scaleCmd } from ${JSON.stringify(scaleModule)};`,
+      `await scaleCmd.parseAsync(['node', 'sh1pt', 'rollout', '--version', 'v2', '--strategy', 'blue-green']);`,
+    ].join('\n');
+    const result = spawnSync(
+      process.execPath,
+      ['--import', 'tsx', '--input-type=module', '--eval', runRollout],
+      {
+        env: { ...process.env, HOME: dir, USERPROFILE: dir },
+        encoding: 'utf8',
+      },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    const saved = JSON.parse(readFileSync(statePath, 'utf-8'));
+    expect(saved.apiKey).toBe('preserve-me');
+    expect(saved.instances.slice(3).map((instance: FleetEntry) => instance.id)).toEqual([
+      'inst-0004', 'inst-0005', 'inst-0006',
+    ]);
   });
 });
 

--- a/packages/cli/src/commands/scale.ts
+++ b/packages/cli/src/commands/scale.ts
@@ -820,7 +820,7 @@ scaleCmd
     const newInstances: FleetEntry[] = [];
     for (let i = 0; i < newInstanceCount; i++) {
       newInstances.push({
-        id: getNextId(fleet.instances),
+        id: getNextId([...fleet.instances, ...newInstances]),
         provider: running.length > 0 ? running[0]!.provider : 'digitalocean',
         status: 'running',
         publicIp: `10.${base}.${1 + Math.floor(Math.random() * 254)}.${1 + Math.floor(Math.random() * 254)}`,


### PR DESCRIPTION
## Problem

Multi-instance rollouts calculated every new ID against the unchanged original fleet. A three-instance blue-green rollout therefore persisted `inst-0004` three times, corrupting fleet identity and the rollout record.

## Fix

Include instances already prepared in the current rollout when calculating the next ID.

## Regression coverage

The new subprocess test executes a real three-instance blue-green rollout in an isolated home, reads the persisted fleet, and requires the new IDs to be `inst-0004`, `inst-0005`, and `inst-0006` while preserving unrelated credentials.

## Verification

- reproduced persisted IDs `inst-0004`, `inst-0004`, `inst-0004` before the fix
- verified persisted IDs `inst-0004`, `inst-0005`, `inst-0006` after the fix
- `pnpm exec vitest run packages/cli/src/commands/scale.test.ts` (59 passed)
- `pnpm --filter @profullstack/sh1pt... build`
- `pnpm --filter @profullstack/sh1pt typecheck`