### PR TITLE
chore(threatcrush-scan): pin 0.11.5, and pack 2.0.2 to re-sync consumers

### DIFF
--- a/packages/actions/threatcrush-scan/README.md
+++ b/packages/actions/threatcrush-scan/README.md
@@ -14,8 +14,8 @@ sh1pt actions install threatcrush-scan --repo owner/name --pr
 | --- | --- | --- |
 | `scanPath` | `.` | Path to scan, relative to the repository root. |
 | `nodeVersion` | `20` | See *Node 20, deliberately*, below. |
-| `threatcrushPackageSpec` | `@profullstack/threatcrush@0.11.3` | npm spec used to install the CLI. Pinned rather than `@latest` so one bad publish cannot break every consumer at once; bump it in a pack release. |
-| `threatcrushIntegrity` | *(sha512 of 0.11.3)* | SRI hash of that tarball. The workflow downloads, hashes and compares before installing, and refuses to install on a mismatch. Bump it with the spec — read it from `npm view <spec> dist.integrity`. Empty skips the check. |
+| `threatcrushPackageSpec` | `@profullstack/threatcrush@0.11.5` | npm spec used to install the CLI. Pinned rather than `@latest` so one bad publish cannot break every consumer at once; bump it in a pack release. |
+| `threatcrushIntegrity` | *(sha512 of 0.11.5)* | SRI hash of that tarball. The workflow downloads, hashes and compares before installing, and refuses to install on a mismatch. Bump it with the spec — read it from `npm view <spec> dist.integrity`. Empty skips the check. |
 | `failOn` | *(empty)* | Comma-separated severities that fail the job, e.g. `critical,high`. Empty is report-only. |
 | `uploadSarif` | `true` | Upload to the Security tab. Emits `security-events: write`. |
 | `commentOnPr` | `true` | Post the report as a pull request comment. Emits `pull-requests: write`. |

--- a/packages/actions/threatcrush-scan/sh1pt.actionpack.yaml
+++ b/packages/actions/threatcrush-scan/sh1pt.actionpack.yaml
@@ -5,7 +5,7 @@ description: >-
   Scans pull requests for hardcoded credentials, injection, SSRF, unsafe
   deserialisation and dependency tampering, and uploads SARIF to the Security
   tab.
-version: 2.0.1
+version: 2.0.2
 publisher: profullstack
 visibility: public
 license: MIT
@@ -32,7 +32,7 @@ inputs:
       that fails without a full toolchain.
   threatcrushPackageSpec:
     type: string
-    default: '@profullstack/threatcrush@0.11.3'
+    default: '@profullstack/threatcrush@0.11.5'
     description: >-
       npm spec used to install the CLI. Pinned, not `@latest`: a scanner that
       runs on every pull request is a dependency, and `@latest` means one bad
@@ -42,7 +42,7 @@ inputs:
       version that was checked first.
   threatcrushIntegrity:
     type: string
-    default: 'sha512-lxWvTtLDgckiWlRB3wMSoBNfMZ/3ao0CcmwETGyKclc+5NMU5Pl0jXSr0h+QrTtfxh7TNStk4ZgP5h8xbEvIWw=='
+    default: 'sha512-kIa0rMs/TdINhryjDDyO2butWxvk6pj4bwnARqhjpOduN6+TcbgAPeZE4cCeZlRqOpq9r0P8cNkjuzd+rN166Q=='
     description: >-
       Subresource-integrity hash of the tarball named by threatcrushPackageSpec,
       in npm's own `sha512-<base64>` form. The workflow downloads, hashes and


### PR DESCRIPTION
## What

Bumps the `threatcrush-scan` pack to ThreatCrush **0.11.5**, and the pack itself to **2.0.2** so the fleet re-syncs consumers.

```
threatcrushPackageSpec   @profullstack/threatcrush@0.11.3 -> @0.11.5
threatcrushIntegrity     sha512-lxWvTt... -> sha512-kIa0rM...
version                  2.0.1 -> 2.0.2
```

## Why

The pack pins an exact spec plus an SRI hash and refuses to install on a mismatch. That is deliberate — but it means a ThreatCrush release does **not** reach pack consumers until someone moves the pin. v0.11.5 published today, so consumers were still installing 0.11.3.

0.11.5 carries the `threatcrush restart` command plus three installer fixes: the installer now prefers npm over pnpm, removes a stale global install left behind by another package manager, and warns when PATH still resolves to an older binary instead of printing "installed successfully" next to the old version number.

## The hash

Not taken from `npm view` alone — reproduced from the published tarball, and the two agree:

```sh
curl -sL "$(npm view @profullstack/threatcrush@0.11.5 dist.tarball)" -o t.tgz
printf 'sha512-'; openssl dgst -sha512 -binary t.tgz | openssl base64 -A
# sha512-kIa0rMs/TdINhryjDDyO2butWxvk6pj4bwnARqhjpOduN6+TcbgAPeZE4cCeZlRqOpq9r0P8cNkjuzd+rN166Q==
```

That is exactly the check the workflow performs before installing, so this pin is verified against the bytes the registry actually serves.

## Testing

- `packages/actions/src/index.test.ts` — 21/21 pass (this is the suite that reads the pack's `threatcrushPackageSpec` / `threatcrushIntegrity` defaults).
- `packages/actions-fleet-core` — 69/69 pass across 6 files, including `action-pack/schema`, `render` and `catalog`.
- Prerequisite workspace packages were built first, per the usual fresh-worktree requirement.
- README's two default rows updated to match the manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3GDps1fD6ccfo93B3ePy1
