### PR TITLE
fix(cli): ignore string braces when editing targets

### DIFF
--- a/packages/cli/src/commands/ship.test.ts
+++ b/packages/cli/src/commands/ship.test.ts
@@ -82,6 +82,29 @@ export default defineConfig({
     expect(config).toContain('"deploy-vercel": { use: "deploy-vercel", config: {} },');
   });
 
+  it('adds a target after entries whose config strings contain braces', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'sh1pt-target-add-braces-'));
+    const file = join(dir, 'sh1pt.config.ts');
+    await writeFile(file, `export default {
+  name: 'demo',
+  version: '0.0.0',
+  targets: {
+    "deploy-netlify": {
+      use: "deploy-netlify",
+      config: { successMessage: "deployed }" },
+    },
+  },
+};
+`);
+
+    addTargetToConfig(file, 'deploy-vercel');
+
+    const config = await readFile(file, 'utf8');
+    const manifest = await loadManifest(file);
+    expect(config).toContain('"deploy-vercel": { use: "deploy-vercel", config: {} },');
+    expect(manifest.targets).toHaveProperty('deploy-vercel');
+  });
+
   it('removes target entries that were added by the CLI', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'sh1pt-target-remove-'));
     const file = join(dir, 'sh1pt.config.ts');

--- a/packages/cli/src/commands/ship.ts
+++ b/packages/cli/src/commands/ship.ts
@@ -216,12 +216,13 @@ function targetEntriesFromSource(source: string, configPath: string): Record<str
 }
 
 function findTargetsObject(source: string): { open: number; close: number } | undefined {
-  const targets = /targets\s*:\s*{/.exec(source);
+  const structural = maskStringsAndComments(source);
+  const targets = /targets\s*:\s*{/.exec(structural);
   if (!targets) return undefined;
   const open = targets.index + targets[0].lastIndexOf('{');
   let depth = 0;
-  for (let i = open; i < source.length; i++) {
-    const char = source[i];
+  for (let i = open; i < structural.length; i++) {
+    const char = structural[i];
     if (char === '{') depth++;
     if (char === '}') {
       depth--;
@@ -229,6 +230,64 @@ function findTargetsObject(source: string): { open: number; close: number } | un
     }
   }
   return undefined;
+}
+
+function maskStringsAndComments(source: string): string {
+  const masked = source.split('');
+  let quote: '"' | "'" | '`' | undefined;
+
+  for (let i = 0; i < source.length; i++) {
+    const char = source[i]!;
+    const next = source[i + 1];
+
+    if (quote) {
+      if (char !== '\n' && char !== '\r') masked[i] = ' ';
+      if (char === quote && !isEscapedAt(source, i)) quote = undefined;
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      masked[i] = ' ';
+      continue;
+    }
+
+    if (char === '/' && next === '/') {
+      masked[i] = ' ';
+      masked[i + 1] = ' ';
+      i += 2;
+      while (i < source.length && source[i] !== '\n' && source[i] !== '\r') {
+        masked[i] = ' ';
+        i++;
+      }
+      i--;
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      masked[i] = ' ';
+      masked[i + 1] = ' ';
+      i += 2;
+      while (i < source.length) {
+        if (source[i] === '*' && source[i + 1] === '/') {
+          masked[i] = ' ';
+          masked[i + 1] = ' ';
+          i++;
+          break;
+        }
+        if (source[i] !== '\n' && source[i] !== '\r') masked[i] = ' ';
+        i++;
+      }
+    }
+  }
+
+  return masked.join('');
+}
+
+function isEscapedAt(source: string, index: number): boolean {
+  let slashCount = 0;
+  for (let i = index - 1; i >= 0 && source[i] === '\\'; i--) slashCount++;
+  return slashCount % 2 === 1;
 }
 
 function targetPropertyPattern(id: string): RegExp {


### PR DESCRIPTION
## Summary

- mask string and comment contents before locating the targets object boundary
- keep newly added targets at the top level when existing config values contain braces
- add a regression test that reloads the edited manifest and verifies the target is enabled

## Tests

- `pnpm exec vitest run packages/cli/src/commands/ship.test.ts`
- `pnpm --filter @profullstack/sh1pt typecheck`