### PR TITLE
fix(cli): parse strings ending in escaped backslashes

### DIFF
--- a/packages/cli/src/commands/config-payments.ts
+++ b/packages/cli/src/commands/config-payments.ts
@@ -123,9 +123,8 @@ function findMatchingBrace(source: string, open: number): number {
   let quote: '"' | "'" | '`' | undefined;
   for (let i = open; i < source.length; i += 1) {
     const ch = source[i];
-    const prev = source[i - 1];
     if (quote) {
-      if (ch === quote && prev !== '\\') quote = undefined;
+      if (ch === quote && !isEscaped(source, i)) quote = undefined;
       continue;
     }
     if (ch === '"' || ch === "'" || ch === '`') {

--- a/packages/cli/src/commands/config.test.ts
+++ b/packages/cli/src/commands/config.test.ts
@@ -109,4 +109,26 @@ describe('parsePaymentsSummary', () => {
 
     expect(summary?.platformFeeBps).toBeUndefined();
   });
+
+  it('parses providers after a string ending with an escaped backslash', () => {
+    const summary = parsePaymentsSummary(`
+      export default defineConfig({
+        payments: {
+          defaultProvider: 'stripe',
+          providers: {
+            coinpay: {
+              use: 'payment-coinpay',
+              config: { outputDirectory: 'C:\\\\payments\\\\' },
+            },
+            stripe: { use: 'payment-stripe' },
+          },
+        },
+      });
+    `);
+
+    expect(summary?.providers).toEqual([
+      { key: 'coinpay', use: 'payment-coinpay', enabled: true, isDefault: false },
+      { key: 'stripe', use: 'payment-stripe', enabled: true, isDefault: true },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

- treat a quote as escaped only when it is preceded by an odd number of backslashes
- keep payment provider parsing intact when config strings end in a literal backslash
- add a regression test covering a Windows-style output directory

## Verification

- `./node_modules/.bin/vitest run packages/cli/src/commands/config.test.ts` (7 tests)
- `./node_modules/.bin/tsc -p packages/cli/tsconfig.json --noEmit`
- `git diff --check`