### PR TITLE
fix(cli): match exact payment property names

### DIFF
--- a/packages/cli/src/commands/config-payments.ts
+++ b/packages/cli/src/commands/config-payments.ts
@@ -142,18 +142,22 @@ function findMatchingBrace(source: string, open: number): number {
 }
 
 function readStringProperty(source: string, key: string): string | undefined {
-  const match = new RegExp(`${propertyKeyPattern(key)}\\s*:\\s*['"]([^'"]+)['"]`).exec(source);
+  const match = new RegExp(`${propertyEntryPattern(key)}\\s*:\\s*['"]([^'"]+)['"]`).exec(source);
   return match?.[1];
 }
 
 function readNumberProperty(source: string, key: string): number | undefined {
-  const match = new RegExp(`${propertyKeyPattern(key)}\\s*:\\s*(\\d+)\\s*(?=,|})`).exec(source);
+  const match = new RegExp(`${propertyEntryPattern(key)}\\s*:\\s*(\\d+)\\s*(?=,|})`).exec(source);
   return match?.[1] ? Number(match[1]) : undefined;
 }
 
 function readBooleanProperty(source: string, key: string): boolean | undefined {
-  const match = new RegExp(`${propertyKeyPattern(key)}\\s*:\\s*(true|false)`).exec(source);
+  const match = new RegExp(`${propertyEntryPattern(key)}\\s*:\\s*(true|false)`).exec(source);
   return match?.[1] === undefined ? undefined : match[1] === 'true';
+}
+
+function propertyEntryPattern(key: string): string {
+  return `(?:^|[,{\\s])${propertyKeyPattern(key)}`;
 }
 
 function propertyKeyPattern(key: string): string {

--- a/packages/cli/src/commands/config.test.ts
+++ b/packages/cli/src/commands/config.test.ts
@@ -109,4 +109,25 @@ describe('parsePaymentsSummary', () => {
 
     expect(summary?.platformFeeBps).toBeUndefined();
   });
+
+  it('does not treat longer config property names as provider fields', () => {
+    const summary = parsePaymentsSummary(`
+      export default defineConfig({
+        payments: {
+          defaultProvider: 'coinpay',
+          providers: {
+            coinpay: {
+              config: { reuse: 'payment-wrong', notenabled: false },
+              use: 'payment-coinpay',
+              enabled: true,
+            },
+          },
+        },
+      });
+    `);
+
+    expect(summary?.providers).toEqual([
+      { key: 'coinpay', use: 'payment-coinpay', enabled: true, isDefault: true },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

- require payment summary fields to match complete property names
- prevent adapter options such as `reuse` and `notenabled` from overriding provider `use` and `enabled` values
- add a regression test covering both false matches

## Verification

- `./node_modules/.bin/vitest run packages/cli/src` (307 passed, 1 skipped)
- `./node_modules/.bin/tsc -p packages/cli/tsconfig.json --noEmit`
- `git diff --check`