### PR TITLE
Charge AI training crawlers for access (x402 gateway)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4201,6 +4201,9 @@ importers:
       '@profullstack/stack':
         specifier: ^0.1.3
         version: 0.1.3(@supabase/ssr@0.5.2(@supabase/supabase-js@2.103.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(next@15.5.15(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+      '@profullstack/x402-gateway':
+        specifier: ^0.1.0
+        version: 0.1.0
       '@supabase/ssr':
         specifier: ^0.5.0
         version: 0.5.2(@supabase/supabase-js@2.103.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
@@ -5111,6 +5114,10 @@ packages:
       react:
         optional: true
 
+  '@profullstack/x402-gateway@0.1.0':
+    resolution: {integrity: sha512-B7tWvWk/bIEoqyec6UoyRF1pO7X/+b+wFRv2ZFIClqskmEpyxoA559ZgdTvnxqAIvuDeE9v56nVpYRQ+lmOZQQ==}
+    engines: {node: '>=20.11'}
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -5591,6 +5598,7 @@ packages:
 
   audio-decode@2.2.3:
     resolution: {integrity: sha512-Z0lHvMayR/Pad9+O9ddzaBJE0DrhZkQlStrC1RwcAHF3AhQAsdwKHeLGK8fYKyp2DDU6xHxzGb4CLMui12yVrg==}
+    deprecated: Renamed to @audio/decode — same API; this name remains a thin alias. npm i @audio/decode
 
   audio-type@2.4.1:
     resolution: {integrity: sha512-dK9Z/P83C/rBfTrXXgPD3jZ+aXxx2o/P4rq8+H1JqxbXklitEeJw4CrcwMC5CkON3CX3yy2gaWnIEVYejYh0zQ==}
@@ -5609,7 +5617,10 @@ packages:
 
   baileys@6.17.16:
     resolution: {integrity: sha512-5dLjZ6+yRR4K7u56xKGCOsLPu5o7PrfLpAW0wV3WELpQQ6m33xwFK+Jd6hu+xDSVfMr7SqP2Dn0jqj+zH8ymdw==}
-    deprecated: This package has been deprecated (wrong version)
+    deprecated: |-
+      This version is affected by a zero-day vulnerability that allows spoofing of messages, please update to
+        the latest versions (6.7.22^ or 7.0.0-rc12^)! For more information, check out the public advisory at
+        https://github.com/WhiskeySockets/Baileys/security/advisories/GHSA-qvv5-jq5g-4cgg
     peerDependencies:
       jimp: ^0.16.1
       link-preview-js: ^3.0.0
@@ -8582,6 +8593,8 @@ snapshots:
       '@supabase/ssr': 0.5.2(@supabase/supabase-js@2.103.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       next: 15.5.15(@opentelemetry/api@1.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
+
+  '@profullstack/x402-gateway@0.1.0': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 

--- a/sites/sh1pt.com/app/robots.txt/route.ts
+++ b/sites/sh1pt.com/app/robots.txt/route.ts
@@ -1,0 +1,9 @@
+import { robotsRoute } from "@profullstack/x402-gateway/next";
+import { gateway } from "@/lib/crawl-gateway";
+
+// Generated from the same crawler lists the gateway enforces: training
+// crawlers are refused everywhere but /crawl (where they can buy a pass),
+// retrieval crawlers are named as welcome, everyone else gets the rules below.
+export const GET = robotsRoute(gateway, {
+  disallow: ["/api/"],
+});

--- a/sites/sh1pt.com/lib/crawl-gateway.ts
+++ b/sites/sh1pt.com/lib/crawl-gateway.ts
@@ -1,0 +1,27 @@
+import { createGateway } from "@profullstack/x402-gateway";
+import { x402Proxy } from "@profullstack/x402-gateway/next";
+
+/**
+ * Sells crawl access to AI training crawlers (GPTBot, ClaudeBot, CCBot,
+ * meta-externalagent, Bytespider, Applebot-Extended, ...) by the day over
+ * x402, settled by CoinPay in USDC. People, Googlebot and the retrieval
+ * crawlers behind AI search pass through untouched.
+ *
+ * Runs inside the middleware, so nothing here may import Node-only modules.
+ * The env is read through a non-literal key on purpose: Next inlines
+ * `process.env.NAME` at build time, and these are runtime secrets. Without
+ * COINPAY_X402_KEY and CRAWL_PAY_TO the gateway still answers training
+ * crawlers with 402, just with an empty offer.
+ */
+const env = (name: string) => process.env[name];
+
+export const gateway = createGateway({
+  siteUrl: env("SITE_URL") || env("NEXT_PUBLIC_SITE_URL") || "https://sh1pt.com",
+  siteName: "sh1pt",
+  coinpay: { apiKey: env("COINPAY_X402_KEY") },
+  payTo: env("CRAWL_PAY_TO"),
+  contact: "mailto:support@sh1pt.com",
+});
+
+/** Resolves to a Response for a refused crawler, or undefined to carry on. */
+export const gate = x402Proxy(gateway);

--- a/sites/sh1pt.com/middleware.ts
+++ b/sites/sh1pt.com/middleware.ts
@@ -1,6 +1,13 @@
+import { gate } from "@/lib/crawl-gateway";
 import { NextResponse, type NextRequest } from 'next/server';
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
+  // Crawl gateway first: AI training crawlers get 402 Payment Required (or the
+  // sales page at /crawl) unless they present a paid pass. People, Googlebot
+  // and retrieval crawlers fall through to everything below.
+  const answer = await gate(request);
+  if (answer) return answer;
+
   const host = request.headers.get('host');
   if (host && host.startsWith('www.')) {
     const url = new URL(request.url);

--- a/sites/sh1pt.com/package.json
+++ b/sites/sh1pt.com/package.json
@@ -18,6 +18,7 @@
     "@profullstack/sh1pt-action-packs": "workspace:^",
     "@profullstack/sh1pt-actions-fleet-core": "workspace:^",
     "@profullstack/stack": "^0.1.3",
+    "@profullstack/x402-gateway": "^0.1.0",
     "@supabase/ssr": "^0.5.0",
     "@supabase/supabase-js": "^2.45.0",
     "next": "^15.0.0",


### PR DESCRIPTION
Wires @profullstack/x402-gateway in front of the middleware: training crawlers get 402 with an x402 offer or the sales page at /crawl; a paid pass opens the site for a day. robots.txt is generated from the same crawler lists. COINPAY_X402_KEY and CRAWL_PAY_TO are already set on the Railway service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YafYxayh7Gqe5MWNNQMev2