### PR TITLE
sh1pt browser: Playwright recipes for the consoles that have no API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # The cli depends on the six packages below it, and pnpm rewrites
+      # The cli depends on the seven packages below it, and pnpm rewrites
       # `workspace:` to a real range on publish — so every one of them has to
       # reach the registry or `npm i @profullstack/sh1pt` 404s on a dep.
       # Keep this list in step with PACKAGES in scripts/version.mjs.
@@ -36,6 +36,7 @@ jobs:
           --filter @profullstack/sh1pt-action-packs
           --filter @profullstack/sh1pt-secrets-env-updater
           --filter @profullstack/sh1pt-policy
+          --filter @profullstack/sh1pt-automation-browser
           --filter @profullstack/sh1pt
           build
 
@@ -66,6 +67,11 @@ jobs:
 
       - name: Publish @profullstack/sh1pt-policy
         run: pnpm --filter @profullstack/sh1pt-policy publish --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish @profullstack/sh1pt-automation-browser
+        run: pnpm --filter @profullstack/sh1pt-automation-browser publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/CLI_INTEGRATIONS.md
+++ b/CLI_INTEGRATIONS.md
@@ -56,6 +56,43 @@ These have real CLIs and map directly to existing or planned adapter surfaces.
 | Stagehand (Browserbase) | `npx @browserbasehq/stagehand` | `automation/stagehand` | Exists. AI browser automation — local Chromium or Browserbase cloud. |
 | OpenAPI → SDK/MCP/docs | `sh1pt openapi <sdk\|mcp\|docs\|all>` | built into the CLI (`packages/openapi`) | Stainless-style spec-driven generator. No external CLI needed. |
 
+## When there is no CLI and no API: browser recipes
+
+Some settings have no door but the console. Google's OAuth consent screen is
+the standard example: `gcloud` covers the rest of Google Cloud, but test
+users, publishing status and a client's redirect URIs exist only as pages. An
+app left in Testing with no test users answers every sign-in with
+`Error 403: access_denied`, and nothing on the command line can change that.
+
+`packages/automation/browser` holds those as typed, reusable recipes, driven
+with Playwright against a **persistent profile**: sign in once, and every
+later run is unattended. `sh1pt browser list` prints what is on the shelf.
+
+```bash
+sh1pt browser list
+sh1pt browser google-cloud-oauth status --project 1234567890
+sh1pt browser google-cloud-oauth add-test-users --project 1234567890 --email you@example.com
+sh1pt browser google-cloud-oauth publish --project 1234567890
+sh1pt browser google-cloud-oauth add-redirect-uri --project 1234567890 --client abc --uri https://example.com/api/v1/google/oauth/callback
+```
+
+| Surface | Why a browser | Recipe |
+|---|---|---|
+| Google Cloud OAuth consent screen | No API for test users, publishing status or client redirect URIs | `google-cloud-oauth` |
+
+Three things make the difference between a recipe that works and one that
+gets blocked, and they are all in `session.ts`:
+
+1. **A real Chrome, in *new* headless mode.** Playwright's `headless: true`
+   asks for the old headless binary, which sign-in pages recognise and refuse.
+2. **A desktop user agent.** New headless still says `HeadlessChrome`, and
+   Google downgrades that to a stripped flow that will not accept a password.
+3. **A virtual authenticator.** With no authenticator, a passkey prompt never
+   settles, the page sits on "Verifying it's you…", and even its own
+   "Try another way" button does nothing. Chrome's DevTools virtual
+   authenticator makes the request fail the way an empty security key would,
+   so the site offers the password fallback.
+
 ## Adapter rule
 
 When a vendor has a mature CLI, prefer a thin adapter over the CLI first:

--- a/packages/automation/browser/README.md
+++ b/packages/automation/browser/README.md
@@ -1,0 +1,75 @@
+# @profullstack/sh1pt-automation-browser
+
+Reusable Playwright recipes for the provider chores that have no CLI and no
+API.
+
+sh1pt prefers, in order: an official CLI, an official API, an unofficial API,
+an MCP server, and only then a browser. This package is that last rung. It
+exists because some settings genuinely have no other door — Google's OAuth
+consent screen being the standard example. `gcloud` covers the rest of Google
+Cloud, but test users, publishing status and a client's redirect URIs are
+console pages, and an app left in Testing with no test users answers every
+sign-in with `Error 403: access_denied`.
+
+```bash
+sh1pt browser list
+sh1pt browser google-cloud-oauth status --project 1234567890
+sh1pt browser google-cloud-oauth add-test-users --project 1234567890 --email you@example.com
+sh1pt browser google-cloud-oauth publish --project 1234567890
+```
+
+`playwright` is an optional peer dependency; install it where you run the
+recipes.
+
+## The profile is the point
+
+The clicking is easy. The sign-in is not: providers challenge a fresh browser
+with 2FA, device confirmation and "this browser may not be secure". So a
+session is a **persistent Chrome profile** under
+`~/.config/sh1pt/browser/profiles/<name>`. Sign in once, answer whatever is
+asked, and every later run of every recipe reuses it unattended.
+
+When something can only be answered by a person, a recipe calls
+`session.ask()`. That writes a screenshot and a question into the run's
+artifacts directory and waits for an answer file, so an unattended box parks
+instead of failing.
+
+## Three things that decide whether a sign-in works
+
+All in `session.ts`, all learned the hard way against Google:
+
+1. **A real Chrome in *new* headless mode.** Playwright's `headless: true`
+   asks for the old headless binary, which sign-in pages recognise and refuse.
+   The session finds a system Chrome and passes `--headless=new` itself.
+2. **A desktop user agent.** New headless still reports `HeadlessChrome`, and
+   Google answers that with a stripped-down flow that will not take a password
+   at all. `desktopUserAgent()` spells the binary's real version the way a
+   desktop Chrome would.
+3. **A virtual authenticator.** With no authenticator present, a passkey
+   prompt never settles: the page sits on "Verifying it's you…" and even its
+   own "Try another way" button does nothing, because the flow is still
+   waiting. Registering Chrome's DevTools virtual authenticator makes the
+   request fail the way an empty security key would, and the site offers its
+   password fallback.
+
+## Writing a recipe
+
+A recipe is a plain function over a `Session`, so it composes and tests like
+any other code.
+
+```ts
+import { openSession, clickFirst } from '@profullstack/sh1pt-automation-browser';
+
+const session = await openSession({ profile: 'acme' });
+await session.page.goto('https://console.example.com/settings');
+await clickFirst(session.page, ['button:has-text("Save")', 'button:has-text("SAVE")']);
+await session.close();
+```
+
+`clickFirst` takes every wording you have seen for the same button and tries
+them in order, then falls back from a normal click to a forced one to the
+element's own handler. Consoles rename and re-nest their buttons constantly;
+pinning one selector rots.
+
+Add the recipe to `RECIPES` in `index.ts` so `sh1pt browser list` shows it,
+and say there why a browser is needed rather than an API.

--- a/packages/automation/browser/package.json
+++ b/packages/automation/browser/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@profullstack/sh1pt-automation-browser",
+  "version": "0.1.15",
+  "description": "Reusable Playwright recipes for the console chores that have no API: OAuth consent screens, app review settings, redirect URIs.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./run": "./src/run.ts"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "prepublishOnly": "pnpm build"
+  },
+  "dependencies": {
+    "@profullstack/sh1pt-core": "workspace:*"
+  },
+  "peerDependencies": {
+    "playwright": "^1.47.0"
+  },
+  "peerDependenciesMeta": {
+    "playwright": {
+      "optional": true
+    }
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/profullstack/sh1pt.git",
+    "directory": "packages/automation/browser"
+  },
+  "homepage": "https://sh1pt.com",
+  "bugs": "https://github.com/profullstack/sh1pt/issues",
+  "keywords": [
+    "playwright",
+    "automation",
+    "oauth",
+    "google-cloud",
+    "recipes"
+  ],
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "./run": {
+        "types": "./dist/run.d.ts",
+        "import": "./dist/run.js",
+        "default": "./dist/run.js"
+      }
+    }
+  },
+  "devDependencies": {
+    "playwright": "^1.47.0"
+  }
+}

--- a/packages/automation/browser/src/index.ts
+++ b/packages/automation/browser/src/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Browser recipes for the chores that have no API.
+ *
+ * Every provider surface sh1pt talks to is, in order of preference: an
+ * official CLI, an official API, an unofficial API, an MCP server, and only
+ * then a browser. This package is that last rung, and it exists because some
+ * settings genuinely have no other door: Google's OAuth consent screen, Meta's
+ * redirect URI list, App Store review answers.
+ *
+ * A recipe is a plain function over a `Session`, so it composes and tests like
+ * any other code. The registry below is what `sh1pt browser` lists.
+ */
+export {
+  openSession,
+  clickFirst,
+  anyVisible,
+  DEFAULT_ROOT,
+  type Session,
+  type SessionOptions,
+} from './session.js';
+
+export * as googleCloudOAuth from './recipes/google-cloud-oauth.js';
+
+export interface RecipeInfo {
+  id: string;
+  label: string;
+  /** Why a browser and not an API. */
+  because: string;
+  profile: string;
+  actions: string[];
+}
+
+/** What `sh1pt browser list` prints. Keep it in step with the exports above. */
+export const RECIPES: RecipeInfo[] = [
+  {
+    id: 'google-cloud-oauth',
+    label: 'Google Cloud — OAuth consent screen',
+    because: 'gcloud covers the rest of Google Cloud; test users, publishing status and client redirect URIs are console-only.',
+    profile: 'google',
+    actions: ['status', 'add-test-users', 'publish', 'add-redirect-uri'],
+  },
+];

--- a/packages/automation/browser/src/recipes/google-cloud-oauth.ts
+++ b/packages/automation/browser/src/recipes/google-cloud-oauth.ts
@@ -1,0 +1,283 @@
+/**
+ * Google Cloud: the OAuth consent screen chores that have no API.
+ *
+ * `gcloud` covers most of Google Cloud, but not this. Test users, publishing
+ * status and the client's redirect URIs live only in the Auth Platform pages
+ * of the console, and an app stuck in Testing with no test users answers
+ * every sign-in with `Error 403: access_denied` — "has not completed the
+ * Google verification process". That is what these recipes fix.
+ *
+ * Two ways out of that 403, and they are not equivalent:
+ *
+ *   addTestUsers  keeps the app in Testing. Fastest, but Google expires the
+ *                 refresh token after **seven days**, so anything scheduled
+ *                 breaks a week later.
+ *   publishApp    moves it to In production. Sensitive scopes then show an
+ *                 "unverified app" warning the user clicks through once, and
+ *                 the refresh token stops expiring. For a personal app this
+ *                 is usually what you actually want.
+ *
+ * The project may be named by id or number; the console accepts either in
+ * `?project=`, and the number is the prefix of every client id it issues.
+ */
+import { anyVisible, clickFirst, type Session } from '../session.js';
+
+export interface GoogleAuthTarget {
+  /** Project id or project number. The number is the digits before the dash in a client id. */
+  project: string;
+}
+
+export interface GoogleSignInOptions {
+  email: string;
+  password: string;
+  /** Seconds to wait for a human to answer a 2FA challenge. */
+  challengeTimeoutMs?: number;
+}
+
+const CONSOLE = 'https://console.cloud.google.com';
+
+const audienceUrl = (project: string) => `${CONSOLE}/auth/audience?project=${encodeURIComponent(project)}`;
+const clientsUrl = (project: string) => `${CONSOLE}/auth/clients?project=${encodeURIComponent(project)}`;
+
+/**
+ * True when the profile already carries a signed-in Google session.
+ *
+ * Test for the positive, never for the absence of a sign-in URL: a signed-out
+ * browser asking for myaccount.google.com is bounced to
+ * `www.google.com/account/about`, a marketing page that looks nothing like a
+ * login. Checking "not on accounts.google.com" reports that as signed in, the
+ * sign-in step is skipped, and the recipe fails much later on a page that
+ * silently redirected to a login form.
+ */
+export async function isSignedIn(session: Session): Promise<boolean> {
+  const { page } = session;
+  await page.goto('https://myaccount.google.com/', { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  return /^https:\/\/myaccount\.google\.com\//.test(page.url());
+}
+
+/**
+ * Sign in, if the profile is not signed in already. Anything Google asks that
+ * a script cannot answer (a code, a tap on a phone, a captcha) is handed to
+ * the caller through `session.ask`, so the run parks rather than failing.
+ */
+export async function signIn(session: Session, options: GoogleSignInOptions): Promise<void> {
+  const { page } = session;
+  if (await isSignedIn(session)) return;
+
+  await page.goto('https://accounts.google.com/signin/v2/identifier?hl=en', { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+
+  // The email box is `input[name="identifier"]`, typed `text`, not `email`.
+  const email = page.locator('#identifierId, input[name="identifier"], input[type="email"]').first();
+  await email.waitFor({ state: 'visible', timeout: 30_000 });
+  await email.fill(options.email);
+  await clickFirst(page, ['#identifierNext button', '#identifierNext', 'button:has-text("Next")']);
+
+  // What comes after the email is not a fixed sequence. Google may offer a
+  // passkey first, ask for the password, ask for a code, or offer to skip
+  // something. So: loop, look at what is on screen, answer that, repeat.
+  const deadline = Date.now() + (options.challengeTimeoutMs ?? 30 * 60_000);
+  let passwordAttempts = 0;
+
+  while (Date.now() < deadline) {
+    await page.waitForLoadState('networkidle').catch(() => undefined);
+    if (process.env.SH1PT_BROWSER_DEBUG) {
+      const seen = ((await page.locator('body').innerText().catch(() => '')) as string)
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .slice(0, 6)
+        .join(' | ');
+      process.stderr.write(`[signin] ${page.url().slice(0, 100)}\n[signin]   ${seen}\n`);
+    }
+    if (!/accounts\.google\.com/.test(page.url())) return;
+
+    const body = (await page.locator('body').innerText().catch(() => '')) as string;
+    // Say "that password is wrong" rather than spinning. Google's current
+    // flow rarely prints "Wrong password": it drops you back on the method
+    // chooser, which looks exactly like ordinary progress and will loop
+    // forever if you let it.
+    const rejected =
+      /Wrong password|password you entered/i.test(body) ||
+      (passwordAttempts > 0 && /\/challenge\/selection/.test(page.url()));
+    if (rejected) {
+      throw new Error(
+        `Google rejected the password for ${options.email} (it returned to the sign-in method chooser). ` +
+          `Update the stored credential and run again. Screenshot: ${await session.shot('google-wrong-password')}`,
+      );
+    }
+
+    // The identifier page ships a hidden `input[name="hiddenPassword"]`, so
+    // never take "the first password input" — only a visible one counts.
+    const password = page.locator('input[name="Passwd"]:visible, input[type="password"]:visible').first();
+    if (await password.isVisible().catch(() => false)) {
+      if (passwordAttempts >= 2) {
+        throw new Error(
+          `Google keeps asking for the password for ${options.email}; it is probably out of date. ` +
+            `Screenshot: ${await session.shot('google-password-loop')}`,
+        );
+      }
+      passwordAttempts += 1;
+      await password.fill(options.password);
+      // Submit with the keyboard. The Next button is a generated element that
+      // moves between releases, and pressing Enter in the field is what the
+      // form listens for anyway.
+      await password.press('Enter');
+      await page.waitForTimeout(3_000);
+      continue;
+    }
+
+    // A passkey cannot be produced by a script. "Try another way" opens the
+    // list of methods, where the password is one of the options.
+    if (passwordAttempts < 2) {
+      const other = await clickFirst(page, [
+        'button:has-text("Enter your password")',
+        'li:has-text("Enter your password")',
+        'div[role="link"]:has-text("Enter your password")',
+        'button:has-text("Try another way")',
+        'text=Try another way',
+      ], { timeoutMs: 4_000 }).catch(() => undefined);
+      if (other) continue;
+    }
+
+    const codeBox = page.locator('input[type="tel"]:visible, input[name="totpPin"]:visible, input[aria-label*="code" i]:visible').first();
+    if (await codeBox.isVisible().catch(() => false)) {
+      const code = await session.ask('google-2fa', 'Google is asking for a verification code. Paste it.');
+      await codeBox.fill(code);
+      await clickFirst(page, ['button:has-text("Next")', 'button:has-text("Verify")', '#totpNext button']);
+      continue;
+    }
+
+    // Offers that are safe to decline and would otherwise block the flow.
+    const dismissed = await clickFirst(page, [
+      'button:has-text("Not now")',
+      'button:has-text("Skip")',
+      'button:has-text("Cancel")',
+    ], { timeoutMs: 3_000 }).catch(() => undefined);
+    if (dismissed) continue;
+
+    // A phone prompt or an unrecognised wall: show it and wait to be told to carry on.
+    if (await anyVisible(page, ['text=Verify it', 'text=2-Step Verification', 'text=Check your'], 3_000)) {
+      await session.ask('google-challenge', 'Approve the Google sign-in prompt on your phone, then write "ok" here.');
+      continue;
+    }
+
+    await page.waitForTimeout(2_000);
+  }
+  throw new Error(`Still on ${page.url()} after the sign-in timeout. Screenshot: ${await session.shot('google-signin-stuck')}`);
+}
+
+export interface AudienceStatus {
+  publishing: 'testing' | 'production' | 'unknown';
+  testUsers: string[];
+}
+
+/** What the Audience page currently says: publishing status and the test-user list. */
+export async function readAudience(session: Session, target: GoogleAuthTarget): Promise<AudienceStatus> {
+  const { page } = session;
+  await page.goto(audienceUrl(target.project), { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+
+  const body = (await page.locator('body').innerText().catch(() => '')) as string;
+  const publishing: AudienceStatus['publishing'] = /In production/i.test(body)
+    ? 'production'
+    : /Testing/i.test(body)
+      ? 'testing'
+      : 'unknown';
+
+  // Test users render as plain rows of email text; scrape by shape, since the
+  // table markup is generated and renamed often.
+  const testUsers = [...new Set((body.match(/[\w.+-]+@[\w-]+\.[\w.]+/g) ?? []))];
+  return { publishing, testUsers };
+}
+
+/**
+ * Add test users to an app that is still in Testing. Returns the addresses
+ * that were actually submitted (already-present ones are skipped).
+ */
+export async function addTestUsers(session: Session, target: GoogleAuthTarget, emails: string[]): Promise<string[]> {
+  const { page } = session;
+  const before = await readAudience(session, target);
+  const missing = emails.filter((email) => !before.testUsers.includes(email));
+  if (!missing.length) return [];
+
+  await clickFirst(page, [
+    'button:has-text("Add users")',
+    'button:has-text("ADD USERS")',
+    'button[aria-label*="Add users" i]',
+    'a:has-text("Add users")',
+  ]);
+
+  const box = page.locator('textarea, input[type="text"]').last();
+  await box.waitFor({ state: 'visible' });
+  await box.fill(missing.join('\n'));
+
+  await clickFirst(page, [
+    'button:has-text("Save")',
+    'button:has-text("SAVE")',
+    'button:has-text("Add")',
+  ]);
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  await session.shot('google-test-users');
+  return missing;
+}
+
+/**
+ * Move the app from Testing to In production. Sensitive scopes stay
+ * unverified (users click through a warning once) but refresh tokens stop
+ * expiring after seven days.
+ */
+export async function publishApp(session: Session, target: GoogleAuthTarget): Promise<boolean> {
+  const { page } = session;
+  const before = await readAudience(session, target);
+  if (before.publishing === 'production') return false;
+
+  await clickFirst(page, [
+    'button:has-text("Publish app")',
+    'button:has-text("PUBLISH APP")',
+    'button[aria-label*="Publish" i]',
+  ]);
+  await clickFirst(page, [
+    'button:has-text("Confirm")',
+    'button:has-text("CONFIRM")',
+    'button:has-text("Publish")',
+  ]);
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  await session.shot('google-publish');
+  return true;
+}
+
+/**
+ * Add a redirect URI to an existing OAuth client. `clientId` may be the full
+ * `…apps.googleusercontent.com` value or just the part before the dot.
+ */
+export async function addRedirectUri(
+  session: Session,
+  target: GoogleAuthTarget,
+  clientId: string,
+  redirectUri: string,
+): Promise<boolean> {
+  const { page } = session;
+  await page.goto(clientsUrl(target.project), { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+
+  const short = clientId.split('.')[0] ?? clientId;
+  await clickFirst(page, [`a:has-text("${short}")`, `td:has-text("${short}")`, `text=${short}`]);
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+
+  const body = (await page.locator('body').innerText().catch(() => '')) as string;
+  if (body.includes(redirectUri)) return false;
+
+  await clickFirst(page, [
+    'button:has-text("Add URI")',
+    'button:has-text("ADD URI")',
+    'button:has-text("Add redirect URI")',
+  ]);
+  const box = page.locator('input[type="text"]:visible, input[type="url"]:visible').last();
+  await box.fill(redirectUri);
+  await clickFirst(page, ['button:has-text("Save")', 'button:has-text("SAVE")']);
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  await session.shot('google-redirect-uri');
+  return true;
+}

--- a/packages/automation/browser/src/run.ts
+++ b/packages/automation/browser/src/run.ts
@@ -1,0 +1,115 @@
+/**
+ * The runnable half: `sh1pt browser <recipe> <action>` dispatches here, and
+ * it also runs directly with tsx during development.
+ *
+ *   tsx src/run.ts google-cloud-oauth status        --project 330436882816
+ *   tsx src/run.ts google-cloud-oauth add-test-users --project 330436882816 --email a@b.com
+ *   tsx src/run.ts google-cloud-oauth publish        --project 330436882816
+ *   tsx src/run.ts google-cloud-oauth add-redirect-uri --project N --client ID --uri https://…
+ *
+ * Credentials come from the environment so nothing lands in a shell history:
+ * GOOGLE_ACCOUNT_EMAIL and GOOGLE_ACCOUNT_PASSWORD, or an already signed-in
+ * profile, in which case neither is read.
+ */
+import { openSession } from './session.js';
+import * as google from './recipes/google-cloud-oauth.js';
+import { RECIPES } from './index.js';
+
+export interface RunOptions {
+  project?: string;
+  emails?: string[];
+  clientId?: string;
+  redirectUri?: string;
+  headed?: boolean;
+  profile?: string;
+  channel?: 'chrome' | 'chromium' | 'msedge';
+}
+
+const need = <T>(value: T | undefined, what: string): T => {
+  if (value === undefined || value === null || value === '') throw new Error(`Missing ${what}.`);
+  return value;
+};
+
+export async function runRecipe(recipe: string, action: string, options: RunOptions = {}): Promise<unknown> {
+  if (recipe !== 'google-cloud-oauth') {
+    throw new Error(`Unknown recipe "${recipe}". Known: ${RECIPES.map((r) => r.id).join(', ')}`);
+  }
+
+  const session = await openSession({
+    profile: options.profile ?? 'google',
+    headed: options.headed,
+    channel: options.channel,
+  });
+
+  try {
+    const email = process.env.GOOGLE_ACCOUNT_EMAIL;
+    const password = process.env.GOOGLE_ACCOUNT_PASSWORD;
+    if (!(await google.isSignedIn(session))) {
+      if (!email || !password) {
+        throw new Error(
+          'This profile is not signed in to Google. Set GOOGLE_ACCOUNT_EMAIL and GOOGLE_ACCOUNT_PASSWORD, ' +
+            'or sign in once with --headed on a machine with a display.',
+        );
+      }
+      await google.signIn(session, { email, password });
+    }
+
+    const target = { project: need(options.project, '--project (project id or number)') };
+
+    switch (action) {
+      case 'status':
+        return await google.readAudience(session, target);
+      case 'add-test-users': {
+        const emails = need(options.emails?.length ? options.emails : undefined, '--email (repeatable)');
+        const added = await google.addTestUsers(session, target, emails);
+        return { added, alreadyPresent: emails.filter((e) => !added.includes(e)) };
+      }
+      case 'publish':
+        return { published: await google.publishApp(session, target) };
+      case 'add-redirect-uri':
+        return {
+          added: await google.addRedirectUri(
+            session,
+            target,
+            need(options.clientId, '--client'),
+            need(options.redirectUri, '--uri'),
+          ),
+        };
+      default:
+        throw new Error(`Unknown action "${action}" for ${recipe}.`);
+    }
+  } finally {
+    await session.close();
+  }
+}
+
+/** Minimal flag parsing so this file runs standalone under tsx. */
+function parse(argv: string[]): { recipe: string; action: string; options: RunOptions } {
+  const [recipe = '', action = ''] = argv;
+  const options: RunOptions = { emails: [] };
+  for (let i = 2; i < argv.length; i += 1) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    if (flag === '--project') (options.project = value), (i += 1);
+    else if (flag === '--email') (options.emails!.push(value ?? ''), (i += 1));
+    else if (flag === '--client') (options.clientId = value), (i += 1);
+    else if (flag === '--uri') (options.redirectUri = value), (i += 1);
+    else if (flag === '--profile') (options.profile = value), (i += 1);
+    else if (flag === '--channel') (options.channel = value as RunOptions['channel']), (i += 1);
+    else if (flag === '--headed') options.headed = true;
+  }
+  return { recipe, action, options };
+}
+
+const isMain = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const { recipe, action, options } = parse(process.argv.slice(2));
+  runRecipe(recipe, action, options)
+    .then((result) => {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    })
+    .catch((error: Error) => {
+      process.stderr.write(`${error.message}\n`);
+      process.exitCode = 1;
+    });
+}

--- a/packages/automation/browser/src/session.test.ts
+++ b/packages/automation/browser/src/session.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { desktopUserAgent, findSystemChrome, DEFAULT_ROOT } from './session.js';
+import { RECIPES } from './index.js';
+
+describe('desktopUserAgent', () => {
+  it('never announces a headless browser', () => {
+    const ua = desktopUserAgent();
+    expect(ua).not.toMatch(/headless/i);
+    expect(ua).toMatch(/^Mozilla\/5\.0 /);
+    expect(ua).toMatch(/Chrome\/\d+\.\d+\.\d+\.\d+ Safari\/537\.36$/);
+  });
+
+  it('falls back to a plausible version when the binary cannot be asked', () => {
+    expect(desktopUserAgent('/nope/not/a/browser')).toMatch(/Chrome\/\d+/);
+  });
+});
+
+describe('findSystemChrome', () => {
+  it('returns an absolute path or nothing at all', () => {
+    const found = findSystemChrome();
+    if (found !== undefined) expect(found.startsWith('/')).toBe(true);
+  });
+});
+
+describe('recipe registry', () => {
+  it('gives every recipe an id, a profile and a reason it needs a browser', () => {
+    expect(RECIPES.length).toBeGreaterThan(0);
+    for (const recipe of RECIPES) {
+      expect(recipe.id).toMatch(/^[a-z0-9-]+$/);
+      expect(recipe.profile).toMatch(/^[a-z0-9-]+$/);
+      expect(recipe.because.length).toBeGreaterThan(20);
+      expect(recipe.actions.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('keeps profiles under one root so a sign-in is reusable', () => {
+    expect(DEFAULT_ROOT).toMatch(/sh1pt\/browser$/);
+  });
+});

--- a/packages/automation/browser/src/session.ts
+++ b/packages/automation/browser/src/session.ts
@@ -1,0 +1,314 @@
+/**
+ * A browser that stays logged in between runs.
+ *
+ * Console chores (OAuth consent screens, app review settings, redirect URIs)
+ * have no API, so the only way to script them is to drive the console. The
+ * expensive part is not the clicking, it is the sign-in: providers challenge
+ * a fresh browser with 2FA, device confirmation and "this browser may not be
+ * secure". So the session is a **persistent profile** on disk. Sign in once,
+ * answering whatever is asked, and every later run of every recipe reuses it
+ * unattended.
+ *
+ * Playwright is an optional peer dependency: importing this module costs
+ * nothing until you actually open a session.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/** Where profiles and run artifacts live, unless overridden. */
+export const DEFAULT_ROOT = join(homedir(), '.config', 'sh1pt', 'browser');
+
+export interface SessionOptions {
+  /** Profile name. The sign-in survives between runs under this name. */
+  profile: string;
+  /** Show a window. Needs a display; on a headless box leave it off. */
+  headed?: boolean;
+  /** Root directory for profiles and artifacts. */
+  root?: string;
+  /** Milliseconds between actions, for watching a run or calming a flaky console. */
+  slowMo?: number;
+  /** Use a named browser channel rather than Playwright's build. */
+  channel?: 'chrome' | 'chromium' | 'msedge';
+  /**
+   * Browser binary to drive. Defaults to a system Chrome when one is found:
+   * sign-in flows treat Playwright's headless shell with much more suspicion
+   * than a real Chrome, and on a box whose distro is newer than the installed
+   * Playwright, the bundled download may not exist at all.
+   */
+  executablePath?: string;
+  /** Default timeout for every action, in ms. Consoles are slow; 45s is not paranoid. */
+  timeoutMs?: number;
+  locale?: string;
+  timezoneId?: string;
+  /** Override the user agent. Defaults to a desktop Chrome string in headless runs. */
+  userAgent?: string;
+  /**
+   * Make WebAuthn decline instead of hanging. On by default: a headless
+   * browser has no authenticator, so a passkey prompt never resolves and the
+   * page freezes mid-sign-in. Turn it off only when testing passkeys.
+   */
+  stubWebAuthn?: boolean;
+}
+
+export interface Session {
+  /** Playwright BrowserContext. Typed loosely so playwright stays optional. */
+  context: any;
+  /** The first page, ready to navigate. */
+  page: any;
+  /** Directory this run writes screenshots and prompts into. */
+  artifacts: string;
+  /** Save a PNG under the artifacts directory and return its path. */
+  shot(name: string): Promise<string>;
+  /**
+   * Ask a human for a value the browser cannot supply (a 2FA code, a captcha
+   * answer). Writes `<name>.txt` describing what is needed plus a screenshot,
+   * then waits for `<name>.answer.txt` to appear. This is the same
+   * file-handoff the myna logins use, and it is what makes an unattended box
+   * workable: the run parks instead of failing.
+   */
+  ask(name: string, question: string, opts?: { timeoutMs?: number }): Promise<string>;
+  close(): Promise<void>;
+}
+
+async function loadPlaywright(): Promise<any> {
+  try {
+    return await import('playwright');
+  } catch {
+    throw new Error(
+      'sh1pt browser: playwright is not installed. Run `pnpm add -D playwright && pnpm exec playwright install chromium`.',
+    );
+  }
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Chromium flags that stop the obvious "you are a robot" tells. This is not
+ * an arms race we win, and it is not meant to be: it is enough that a real
+ * signed-in profile driving its owner's own console is not tripped up by
+ * automation heuristics.
+ */
+const STEALTH_ARGS = [
+  '--disable-blink-features=AutomationControlled',
+  '--no-first-run',
+  '--no-default-browser-check',
+  '--disable-features=Translate,OptimizationHints',
+];
+
+/** Where a real Chrome usually is, most preferred first. */
+const CHROME_PATHS = [
+  '/opt/google/chrome/chrome',
+  '/usr/bin/google-chrome',
+  '/usr/bin/google-chrome-stable',
+  '/usr/bin/chromium',
+  '/usr/bin/chromium-browser',
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+];
+
+/** The system Chrome to prefer over Playwright's own download, if there is one. */
+export function findSystemChrome(): string | undefined {
+  return CHROME_PATHS.find((path) => existsSync(path));
+}
+
+/**
+ * A user agent that does not announce a robot.
+ *
+ * New headless Chrome still ships `HeadlessChrome/1.2.3` in its UA, and
+ * "Chrome for Testing" builds say so too. Sign-in pages read that and hand
+ * back a stripped-down flow that refuses to take a password at all. Take the
+ * binary's real version and spell it the way a desktop Chrome would.
+ */
+export function desktopUserAgent(executablePath?: string): string {
+  let version = '141.0.0.0';
+  if (executablePath) {
+    try {
+      const raw = execFileSync(executablePath, ['--version'], { encoding: 'utf8', timeout: 10_000 });
+      const found = /(\d+\.\d+\.\d+\.\d+)/.exec(raw)?.[1];
+      if (found) version = found;
+    } catch {
+      /* fall back to the default */
+    }
+  }
+  return (
+    `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) ` +
+    `Chrome/${version} Safari/537.36`
+  );
+}
+
+export async function openSession(options: SessionOptions): Promise<Session> {
+  const root = options.root ?? DEFAULT_ROOT;
+  const profileDir = join(root, 'profiles', options.profile);
+  const artifacts = join(root, 'runs', `${options.profile}-${new Date().toISOString().replace(/[:.]/g, '-')}`);
+  mkdirSync(profileDir, { recursive: true });
+  mkdirSync(artifacts, { recursive: true });
+
+  const { chromium } = await loadPlaywright();
+  const executablePath = options.executablePath ?? (options.channel ? undefined : findSystemChrome());
+
+  // Chrome's *new* headless mode is the same browser as headed, only without
+  // a window; the old one is a separate binary that sign-in pages recognise
+  // and refuse ("This browser or app may not be secure"). Playwright still
+  // asks for the old mode when you pass `headless: true`, so ask for headed
+  // and add the flag ourselves. No display is needed either way.
+  const newHeadless = !options.headed;
+  const args = [...STEALTH_ARGS, ...(newHeadless ? ['--headless=new'] : [])];
+
+  const context = await chromium.launchPersistentContext(profileDir, {
+    headless: false,
+    channel: options.channel,
+    executablePath,
+    slowMo: options.slowMo,
+    args,
+    userAgent: options.userAgent ?? (newHeadless ? desktopUserAgent(executablePath) : undefined),
+    locale: options.locale ?? 'en-US',
+    timezoneId: options.timezoneId,
+    viewport: { width: 1440, height: 900 },
+  });
+  context.setDefaultTimeout(options.timeoutMs ?? 45_000);
+
+  // `navigator.webdriver` is the one signal that is both universally checked
+  // and trivially removed. Do it before any page script runs.
+  await context.addInitScript(() => {
+    Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+  });
+
+  // Passkeys are the quiet killer of headless sign-ins. There is no
+  // authenticator, so `navigator.credentials.get()` never settles: the page
+  // sits on "Verifying it's you…" forever, and because its state machine is
+  // still waiting, even the "Try another way" button does nothing when
+  // clicked. Rejecting the way a real declined prompt does makes the site
+  // fall through to its password fallback immediately.
+  // Written against `globalThis` rather than `navigator`/`window` because
+  // this package compiles without the DOM lib: the body is serialised and
+  // runs in the page, not here.
+  if (options.stubWebAuthn !== false) {
+    await context.addInitScript(() => {
+      const scope = globalThis as unknown as {
+        navigator?: { credentials?: Record<string, unknown> };
+        PublicKeyCredential?: Record<string, unknown>;
+        DOMException?: new (message: string, name: string) => Error;
+      };
+      const credentials = scope.navigator?.credentials;
+      if (!credentials) return;
+      const decline = () =>
+        Promise.reject(
+          scope.DOMException
+            ? new scope.DOMException('The operation was aborted.', 'NotAllowedError')
+            : new Error('NotAllowedError'),
+        );
+      credentials.get = decline;
+      credentials.create = decline;
+      if (scope.PublicKeyCredential) {
+        scope.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable = () => Promise.resolve(false);
+      }
+    });
+  }
+
+  const page = context.pages()[0] ?? (await context.newPage());
+
+  // Chrome's own virtual authenticator, registered over DevTools. It holds no
+  // credentials, so a passkey request fails at the browser layer the way an
+  // empty security key would, rather than in page JavaScript a site can see
+  // has been patched. Best effort: older builds may not have the domain.
+  if (options.stubWebAuthn !== false) {
+    try {
+      const cdp = await context.newCDPSession(page);
+      await cdp.send('WebAuthn.enable');
+      await cdp.send('WebAuthn.addVirtualAuthenticator', {
+        options: { protocol: 'ctap2', transport: 'usb', hasResidentKey: false, hasUserVerification: false, isUserVerified: false },
+      });
+    } catch {
+      /* the init-script stub above still applies */
+    }
+  }
+
+  const shot = async (name: string): Promise<string> => {
+    const path = join(artifacts, `${name}.png`);
+    await page.screenshot({ path, fullPage: true }).catch(() => undefined);
+    return path;
+  };
+
+  const ask = async (name: string, question: string, opts: { timeoutMs?: number } = {}): Promise<string> => {
+    const image = await shot(name);
+    const askFile = join(artifacts, `${name}.txt`);
+    const answerFile = join(artifacts, `${name}.answer.txt`);
+    writeFileSync(askFile, `${question}\n\nScreenshot: ${image}\nAnswer by writing the value into: ${answerFile}\n`);
+    process.stderr.write(`[browser] needs input: ${question}\n[browser] screenshot ${image}\n[browser] answer file ${answerFile}\n`);
+
+    const deadline = Date.now() + (opts.timeoutMs ?? 30 * 60_000);
+    while (Date.now() < deadline) {
+      if (existsSync(answerFile)) {
+        const value = readFileSync(answerFile, 'utf8').trim();
+        if (value) {
+          unlinkSync(answerFile);
+          return value;
+        }
+      }
+      await sleep(2000);
+    }
+    throw new Error(`No answer for "${name}" arrived in time. Screenshot: ${image}`);
+  };
+
+  return {
+    context,
+    page,
+    artifacts,
+    shot,
+    ask,
+    close: () => context.close(),
+  };
+}
+
+/**
+ * Click the first thing that matches any of these, in order. Consoles rename
+ * and re-nest their buttons constantly, so a recipe lists every wording it
+ * has seen rather than pinning one selector and rotting.
+ */
+export async function clickFirst(page: any, candidates: string[], opts: { timeoutMs?: number } = {}): Promise<string> {
+  const timeout = opts.timeoutMs ?? 8_000;
+  for (const selector of candidates) {
+    const locator = page.locator(selector).first();
+    try {
+      await locator.waitFor({ state: 'visible', timeout });
+    } catch {
+      continue; // not this wording
+    }
+    // Visible is not the same as clickable. Consoles overlay spinners and
+    // animate panels in, so fall back to a forced click and finally to the
+    // element's own handler rather than giving up on a button that is there.
+    try {
+      await locator.click({ timeout });
+      return selector;
+    } catch {
+      /* covered or moving */
+    }
+    try {
+      await locator.click({ timeout, force: true });
+      return selector;
+    } catch {
+      /* still no */
+    }
+    try {
+      await locator.evaluate((element: { click?: () => void }) => element.click?.());
+      return selector;
+    } catch {
+      /* try the next wording */
+    }
+  }
+  throw new Error(`None of these were clickable: ${candidates.join(' | ')}`);
+}
+
+/** True when any of the selectors is visible right now. */
+export async function anyVisible(page: any, candidates: string[], timeoutMs = 5_000): Promise<boolean> {
+  for (const selector of candidates) {
+    try {
+      await page.locator(selector).first().waitFor({ state: 'visible', timeout: timeoutMs });
+      return true;
+    } catch {
+      /* keep looking */
+    }
+  }
+  return false;
+}

--- a/packages/automation/browser/tsconfig.json
+++ b/packages/automation/browser/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist", "rootDir": "src" },
+  "include": ["src/**/*"]
+}

--- a/packages/automation/browser/tsconfig.json
+++ b/packages/automation/browser/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": { "outDir": "dist", "rootDir": "src" },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@profullstack/sh1pt-action-packs": "workspace:^",
     "@profullstack/sh1pt-actions-fleet-core": "workspace:^",
+    "@profullstack/sh1pt-automation-browser": "workspace:^",
     "@profullstack/sh1pt-core": "workspace:^",
     "@profullstack/sh1pt-openapi": "workspace:^",
     "@profullstack/sh1pt-policy": "workspace:^",

--- a/packages/cli/src/adapter-registry.ts
+++ b/packages/cli/src/adapter-registry.ts
@@ -53,8 +53,8 @@ export const CATEGORIES: readonly AdapterCategory[] = [
   {
     id: 'automation',
     pkgPrefix: '@profullstack/sh1pt-automation',
-    description: 'AI browser automation — Stagehand (Browserbase) and friends',
-    adapters: ['stagehand'],
+    description: 'Browser automation — Playwright recipes for console-only settings, and Stagehand',
+    adapters: ['browser', 'stagehand'],
   },
   {
     id: 'bots',

--- a/packages/cli/src/commands/browser.ts
+++ b/packages/cli/src/commands/browser.ts
@@ -1,0 +1,53 @@
+import { Command } from 'commander';
+import kleur from 'kleur';
+
+/**
+ * `sh1pt browser` — the recipes for provider settings that have no API.
+ *
+ * The package is loaded lazily so the CLI starts fast and so a machine
+ * without playwright still runs every other command.
+ */
+export const browserCmd = new Command('browser')
+  .description('Automate provider consoles that have no CLI or API (OAuth consent screens, redirect URIs).')
+  .argument('[recipe]', 'recipe id, or "list"')
+  .argument('[action]', 'action within the recipe')
+  .option('--project <id>', 'project id or number')
+  .option('--email <address...>', 'email address (repeatable)')
+  .option('--client <id>', 'OAuth client id')
+  .option('--uri <url>', 'redirect URI')
+  .option('--profile <name>', 'browser profile to sign in as')
+  .option('--headed', 'show the browser window (needs a display)')
+  .option('--json', 'machine-readable output')
+  .action(async (recipe: string | undefined, action: string | undefined, opts: Record<string, unknown>) => {
+    const { RECIPES } = await import('@profullstack/sh1pt-automation-browser');
+
+    if (!recipe || recipe === 'list') {
+      console.log(kleur.bold('Browser recipes'));
+      console.log(kleur.dim('Last resort, on purpose: an official CLI or API comes first.'));
+      console.log();
+      for (const entry of RECIPES) {
+        console.log(`${kleur.cyan(entry.id)}  ${entry.label}`);
+        console.log(`  ${kleur.dim(entry.because)}`);
+        console.log(`  actions: ${entry.actions.join(', ')}`);
+        console.log(`  profile: ${entry.profile}`);
+      }
+      console.log();
+      console.log('Example:');
+      console.log('  sh1pt browser google-cloud-oauth add-test-users --project 1234567 --email you@example.com');
+      return;
+    }
+
+    if (!action) throw new Error(`Which action? Try: sh1pt browser ${recipe} <action>`);
+
+    const { runRecipe } = await import('@profullstack/sh1pt-automation-browser/run');
+    const result = await runRecipe(recipe, action, {
+      project: opts.project as string | undefined,
+      emails: opts.email as string[] | undefined,
+      clientId: opts.client as string | undefined,
+      redirectUri: opts.uri as string | undefined,
+      profile: opts.profile as string | undefined,
+      headed: Boolean(opts.headed),
+    });
+
+    console.log(JSON.stringify(result, null, 2));
+  });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,6 +20,7 @@ import { deployCmd } from './commands/deploy.js';
 import { openapiCmd } from './commands/openapi.js';
 import { runsCmd } from './commands/runs.js';
 import { logicsrcCmd } from './commands/logicsrc.js';
+import { browserCmd } from './commands/browser.js';
 
 const program = new Command();
 
@@ -58,6 +59,7 @@ program.addCommand(agentsCmd);      // agents   · generate/run/talk with AI cod
 program.addCommand(deployCmd);      // deploy   · provision cloud infrastructure
 program.addCommand(openapiCmd);     // openapi  · spec → SDK + MCP server + docs site (Stainless-style)
 program.addCommand(logicsrcCmd);    // logicsrc · LogicSRC OpenSpec-only workflows
+program.addCommand(browserCmd);     // browser  · console chores with no CLI or API, driven in a real browser
 
 // Self-management — sh1pt update / upgrade / remove / uninstall.
 program.addCommand(updateCmd);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -606,6 +606,16 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
 
+  packages/automation/browser:
+    dependencies:
+      '@profullstack/sh1pt-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      playwright:
+        specifier: ^1.47.0
+        version: 1.60.0
+
   packages/automation/stagehand:
     dependencies:
       '@browserbasehq/stagehand':
@@ -803,6 +813,9 @@ importers:
       '@profullstack/sh1pt-actions-fleet-core':
         specifier: workspace:^
         version: link:../actions-fleet-core
+      '@profullstack/sh1pt-automation-browser':
+        specifier: workspace:^
+        version: link:../automation/browser
       '@profullstack/sh1pt-core':
         specifier: workspace:^
         version: link:../core

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -2,7 +2,7 @@
 // Lockstep-bump every published sh1pt package:
 //   @profullstack/sh1pt-core, sh1pt-openapi, sh1pt-actions-fleet-core,
 //   sh1pt-action-packs, sh1pt-secrets-env-updater, sh1pt-policy,
-//   sh1pt (the cli)
+//   sh1pt-automation-browser, sh1pt (the cli)
 //
 // The cli depends on all of the others, and pnpm rewrites `workspace:` to a
 // real range at publish time. Anything the cli depends on therefore has to be
@@ -32,6 +32,7 @@ const PACKAGES = [
   'packages/actions',
   'packages/secrets/env-updater',
   'packages/policy',
+  'packages/automation/browser',
   'packages/cli',
 ];
 const arg = process.argv[2] ?? 'patch';


### PR DESCRIPTION
## Why

Some provider settings have no CLI and no API. Google's OAuth consent screen is the standard case: `gcloud` covers the rest of Google Cloud, but test users, publishing status and a client's redirect URIs are console pages. An app left in Testing with no test users answers every sign-in with `Error 403: access_denied`, and nothing on the command line can change that.

## What

- **`packages/automation/browser`** (`@profullstack/sh1pt-automation-browser`): typed, reusable Playwright recipes on a **persistent Chrome profile**, so a sign-in is answered once and every later run is unattended. When only a person can answer (a 2FA code, a captcha), `session.ask()` writes a screenshot and question into the run's artifacts and waits for an answer file, so an unattended box parks instead of failing.
- **First recipe `google-cloud-oauth`**: `status`, `add-test-users`, `publish`, `add-redirect-uri`.
- **`sh1pt browser`** command: `list` plus `<recipe> <action>`. Playwright is an optional peer dependency, loaded lazily, so machines without it run every other command fine.
- Docs: a "When there is no CLI and no API" section in `CLI_INTEGRATIONS.md` and a package README.

## Three things that decide whether a sign-in works

Learned the hard way against Google, all in `session.ts`:

1. Playwright's `headless: true` asks for the **old** headless binary, which sign-in pages recognise and refuse. Drive a real Chrome and pass `--headless=new`.
2. New headless still reports `HeadlessChrome`; Google answers that with a stripped flow (`flowName=WebLiteSignIn`) that will not take a password at all. Send a desktop user agent built from the binary's own version.
3. With no authenticator a **passkey** prompt never settles: the page sits on "Verifying it's you…" and even its own "Try another way" button does nothing, because the flow is still waiting. Registering Chrome's DevTools **virtual authenticator** makes the request fail like an empty security key, and the password fallback appears.

## Verified

- Full suite the way CI runs it (build the library packages, then `pnpm test`): **719 files, 3,642 tests, 0 failures**. Without that build step 670 files fail to collect on `@profullstack/sh1pt-core/testing`; that is the known unbuilt-worktree behaviour, not this change.
- `tsc --noEmit` clean for the new package and the CLI.
- Live against Google: the recipe now walks identifier → passkey → method chooser → password reliably. It stops at the password itself, which the stored credential no longer satisfies; the recipe reports that instead of looping.
- `add-test-users` / `publish` are therefore **not yet exercised end to end**; the page objects are written from the live DOM but wait on a working credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYMJH7N4d2qRct5Q5q2YWQ