### PR TITLE
sh1pt browser: a Meta recipe, and a sign-in that does not need a phone

### DIFF
--- a/CLI_INTEGRATIONS.md
+++ b/CLI_INTEGRATIONS.md
@@ -77,13 +77,24 @@ sh1pt browser google-cloud-oauth add-redirect-uri --project 1234567890 --client 
 
 sh1pt browser pypi-trusted-publisher add-pending --package my-lib --owner me --repo my-repo --workflow release.yml
 sh1pt browser rubygems-trusted-publisher add-pending --package my-gem --owner me --repo my-repo --workflow release.yml
+
+sh1pt browser meta-app status --client 1234567890
+sh1pt browser meta-app add-redirect-uri --client 1234567890 --uri https://example.com/api/v1/facebook/oauth/callback
 ```
+
+Meta answers an account that does not own the app by redirecting every
+`/apps/<id>/…` URL to the developer home page, so `meta-app` checks it can
+administer the app before touching anything and fails loudly rather than
+reporting a success it did not achieve. Its second factor defaults to
+WhatsApp; the recipe switches to the emailed code, which an agent with
+mailbox access can fetch, so no phone is in the loop.
 
 | Surface | Why a browser | Recipe |
 |---|---|---|
 | Google Cloud OAuth consent screen | No API for test users, publishing status or client redirect URIs | `google-cloud-oauth` |
 | PyPI trusted publishers | The upload API publishes packages, not account settings; a pending publisher is the only way to ship a new project with no token | `pypi-trusted-publisher` |
 | RubyGems trusted publishers | Publishers live under the profile, with no API and no `gem` command | `rubygems-trusted-publisher` |
+| Meta app settings | The app-settings API answers `(#10)` until "Allow API Access to App Settings" is ticked, and that tick is console-only | `meta-app` |
 
 Both registries require two-factor on any account that can publish, so the
 recipes generate the code from a base32 seed (`PYPI_TOTP_SECRET`,

--- a/packages/automation/browser/src/index.ts
+++ b/packages/automation/browser/src/index.ts
@@ -23,6 +23,7 @@ export {
 export { base32Decode, secondsRemaining, totp, twoFactorCode, type TotpOptions } from './totp.js';
 
 export * as googleCloudOAuth from './recipes/google-cloud-oauth.js';
+export * as metaApp from './recipes/meta-app.js';
 export * as pypiTrustedPublisher from './recipes/pypi-trusted-publisher.js';
 export * as rubygemsTrustedPublisher from './recipes/rubygems-trusted-publisher.js';
 
@@ -59,5 +60,13 @@ export const RECIPES: RecipeInfo[] = [
       'trusted publishers live under the profile, with no API and no `gem` command; a pending one publishes a new gem with no key at all.',
     profile: 'rubygems',
     actions: ['list', 'add-pending'],
+  },
+  {
+    id: 'meta-app',
+    label: 'Meta — app settings',
+    because:
+      "Meta's app-settings API refuses with (#10) until 'Allow API Access to App Settings' is ticked, and that tick is console-only.",
+    profile: 'facebook',
+    actions: ['status', 'add-redirect-uri'],
   },
 ];

--- a/packages/automation/browser/src/main.ts
+++ b/packages/automation/browser/src/main.ts
@@ -1,0 +1,21 @@
+/**
+ * Standalone entry: `tsx src/main.ts <recipe> <action> [flags]`.
+ *
+ * Kept apart from `run.ts` because this is the only file that needs
+ * `import.meta`, and a module carrying it breaks Vite's SSR transform for
+ * any test that imports it.
+ */
+import { parse, runRecipe } from './run.js';
+
+const isMain = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const { recipe, action, options } = parse(process.argv.slice(2));
+  runRecipe(recipe, action, options)
+    .then((result) => {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    })
+    .catch((error: Error) => {
+      process.stderr.write(`${error.message}\n`);
+      process.exitCode = 1;
+    });
+}

--- a/packages/automation/browser/src/recipes/meta-app.ts
+++ b/packages/automation/browser/src/recipes/meta-app.ts
@@ -1,0 +1,165 @@
+/**
+ * Meta: signing in, and the app settings that have no API until the app says so.
+ *
+ * Meta *does* have an app-settings API, but it answers
+ * `(#10) Changing app settings through API calls has been disabled for this
+ * app` until someone ticks **Allow API Access to App Settings** under the
+ * app's Advanced settings. That tick is itself console-only, so a browser is
+ * the way in, and afterwards a rename needs no browser at all.
+ *
+ * Two things make the sign-in work where a naive script stalls:
+ *
+ *   - Facebook's Arkose "Running security checks" page clears itself, but the
+ *     login form's submit button selectors miss, so press Enter in the
+ *     password field instead of hunting for a button.
+ *   - The default second factor is WhatsApp. `Try another way` offers email,
+ *     which lands somewhere a mailbox-reading agent can fetch it from, so the
+ *     run never needs a phone. Buttons on those pages are `div[role=button]`.
+ */
+import { clickFirst, type Session } from '../session.js';
+
+export interface MetaSignInOptions {
+  email: string;
+  password: string;
+  /** Prefer the emailed code over the default WhatsApp one. Default true. */
+  preferEmail?: boolean;
+  challengeTimeoutMs?: number;
+}
+
+const DEVELOPERS = 'https://developers.facebook.com';
+
+const bodyLines = async (session: Session): Promise<string[]> =>
+  ((await session.page.locator('body').innerText().catch(() => '')) as string)
+    .split('\n')
+    .map((line: string) => line.trim())
+    .filter(Boolean);
+
+/** True when the profile already carries a signed-in Facebook session. */
+export async function isSignedIn(session: Session): Promise<boolean> {
+  const { page } = session;
+  await page.goto('https://www.facebook.com/me', { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  return !/login|checkpoint|two_step/.test(page.url());
+}
+
+export async function signIn(session: Session, options: MetaSignInOptions): Promise<void> {
+  const { page } = session;
+  if (await isSignedIn(session)) return;
+
+  await page.goto('https://www.facebook.com/login', { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+
+  const emailBox = page.locator('#email, input[name="email"]').first();
+  if (await emailBox.isVisible().catch(() => false)) {
+    await emailBox.fill(options.email);
+    const password = page.locator('#pass, input[name="pass"]').first();
+    await password.fill(options.password);
+    // The button selectors miss more often than they hit; Enter always submits.
+    await clickFirst(page, ['button[name="login"]', '#loginbutton', 'button[type="submit"]'], { timeoutMs: 4000 })
+      .catch(() => password.press('Enter'));
+  }
+
+  // Ride the Arkose security check through to whatever it asks next.
+  for (let i = 0; i < 10; i += 1) {
+    await page.waitForLoadState('networkidle').catch(() => undefined);
+    await page.waitForTimeout(4000);
+    if (/codesubmit|two_step|checkpoint/.test(page.url())) break;
+  }
+
+  if (options.preferEmail !== false) {
+    await clickFirst(page, [
+      'div[role="button"]:has-text("Try another way")',
+      'button:has-text("Try another way")',
+      'text=Try another way',
+    ], { timeoutMs: 10_000 }).catch(() => undefined);
+    await page.waitForTimeout(4000);
+    await clickFirst(page, ['div[role="button"]:has-text("Email")', 'label:has-text("Email")'], { timeoutMs: 8000 })
+      .catch(() => undefined);
+    await clickFirst(page, ['div[role="button"]:has-text("Continue")', 'button:has-text("Continue")'], { timeoutMs: 8000 })
+      .catch(() => undefined);
+    await page.waitForTimeout(6000);
+  }
+
+  const deadline = Date.now() + (options.challengeTimeoutMs ?? 55 * 60_000);
+  while (Date.now() < deadline) {
+    await page.waitForLoadState('networkidle').catch(() => undefined);
+    const url = page.url();
+    if (/facebook\.com\/?$/.test(url) && !/login|checkpoint|codesubmit|two_step/.test(url)) return;
+
+    const codeBox = page
+      .locator('input[name="code"]:visible, input[autocomplete="one-time-code"]:visible, input[type="text"]:visible')
+      .first();
+    if (await codeBox.isVisible().catch(() => false)) {
+      const code = await session.ask(
+        'meta-code',
+        `Facebook sent a login code${options.preferEmail === false ? '' : ` to ${options.email}`}. Paste the digits.`,
+      );
+      await codeBox.fill(code.trim());
+      await clickFirst(page, [
+        'div[role="button"]:has-text("Continue")',
+        'button:has-text("Continue")',
+        'button[type="submit"]',
+      ], { timeoutMs: 8000 }).catch(() => codeBox.press('Enter'));
+      await page.waitForTimeout(8000);
+      // Trusting the device keeps the profile signed in for later runs.
+      await clickFirst(page, ['div[role="button"]:has-text("Trust")', 'button:has-text("Trust")'], { timeoutMs: 6000 })
+        .catch(() => undefined);
+      continue;
+    }
+    await page.waitForTimeout(4000);
+  }
+  throw new Error(`Still on ${page.url()} after the sign-in timeout. Screenshot: ${await session.shot('meta-signin-stuck')}`);
+}
+
+/**
+ * True when this account can actually administer the app. Meta answers a
+ * stranger by redirecting every `/apps/<id>/…` URL to the developer home
+ * page, so a recipe that assumes it landed will edit nothing and report
+ * success.
+ */
+export async function canAdminister(session: Session, app: string): Promise<boolean> {
+  const { page } = session;
+  await page.goto(`${DEVELOPERS}/apps/${app}/settings/basic/`, { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  await page.waitForTimeout(5000);
+  return page.url().includes(`/apps/${app}`);
+}
+
+/** Add a redirect URI to the app's Facebook Login settings. */
+export async function addRedirectUri(session: Session, app: string, uri: string): Promise<boolean> {
+  const { page } = session;
+  if (!(await canAdminister(session, app))) {
+    throw new Error(
+      `This Facebook account cannot administer app ${app} — Meta redirected to ${page.url()}. ` +
+        'Sign in as an account that owns the app.',
+    );
+  }
+
+  await page.goto(`${DEVELOPERS}/apps/${app}/fb-login/settings/`, { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  await page.waitForTimeout(5000);
+
+  const box = page.locator('input[placeholder*="http" i]:visible, textarea:visible, input[type="text"]:visible').first();
+  if (!(await box.isVisible().catch(() => false))) {
+    throw new Error(`No redirect field on ${page.url()}. Is Facebook Login added as a product?`);
+  }
+
+  const existing = ((await box.inputValue().catch(() => '')) as string) || '';
+  if (existing.includes(uri)) return false;
+
+  await box.fill(existing ? `${existing}\n${uri}` : uri);
+  await clickFirst(page, [
+    'div[role="button"]:has-text("Save changes")',
+    'button:has-text("Save changes")',
+    'button:has-text("Save")',
+  ], { timeoutMs: 10_000 });
+  await page.waitForTimeout(6000);
+  await session.shot('meta-redirect-uri');
+  return true;
+}
+
+/** What the app's pages say right now, for debugging a refusal. */
+export async function status(session: Session, app: string): Promise<{ administers: boolean; page: string[] }> {
+  const administers = await canAdminister(session, app);
+  return { administers, page: (await bodyLines(session)).slice(0, 12) };
+}

--- a/packages/automation/browser/src/run.ts
+++ b/packages/automation/browser/src/run.ts
@@ -1,6 +1,11 @@
 /**
- * The runnable half: `sh1pt browser <recipe> <action>` dispatches here, and
- * it also runs directly with tsx during development.
+ * The runnable half: `sh1pt browser <recipe> <action>` dispatches here.
+ *
+ * No `import.meta` and no top-level side effect lives in this file: the
+ * standalone entry is `main.ts`. Vite's SSR transform chokes on
+ * "Cannot split a chunk that has already been edited" when a module a test
+ * imports carries `import.meta` past a certain size, and a test importing
+ * `parse`/`profileFor` from here is exactly that case.
  *
  *   tsx src/run.ts google-cloud-oauth status         --project 330436882816
  *   tsx src/run.ts google-cloud-oauth add-test-users --project 330436882816 --email a@b.com
@@ -230,17 +235,4 @@ export function parse(argv: string[]): { recipe: string; action: string; options
     else if (flag === '--headed') options.headed = true;
   }
   return { recipe, action, options };
-}
-
-const isMain = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
-if (isMain) {
-  const { recipe, action, options } = parse(process.argv.slice(2));
-  runRecipe(recipe, action, options)
-    .then((result) => {
-      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
-    })
-    .catch((error: Error) => {
-      process.stderr.write(`${error.message}\n`);
-      process.exitCode = 1;
-    });
 }

--- a/packages/automation/browser/src/run.ts
+++ b/packages/automation/browser/src/run.ts
@@ -23,6 +23,7 @@
  */
 import { openSession, type Session } from './session.js';
 import * as google from './recipes/google-cloud-oauth.js';
+import * as meta from './recipes/meta-app.js';
 import * as pypi from './recipes/pypi-trusted-publisher.js';
 import * as rubygems from './recipes/rubygems-trusted-publisher.js';
 import { RECIPES } from './index.js';
@@ -175,11 +176,36 @@ export async function runRecipe(recipe: string, action: string, options: RunOpti
         return await runPypi(session, action, options);
       case 'rubygems-trusted-publisher':
         return await runRubygems(session, action, options);
+      case 'meta-app':
+        return await runMeta(session, action, options);
       default:
         throw new Error(`Unknown recipe "${recipe}".`);
     }
   } finally {
     await session.close();
+  }
+}
+
+/**
+ * Meta's half. The app id rides in on `--client`, since that is what Meta
+ * calls it everywhere, and the account comes from FB_EMAIL / FB_PASSWORD.
+ */
+async function runMeta(session: Session, action: string, options: RunOptions): Promise<unknown> {
+  const email = process.env.FB_EMAIL;
+  const password = process.env.FB_PASSWORD;
+  if (!(await meta.isSignedIn(session))) {
+    if (!email || !password) throw new Error('This profile is not signed in. Set FB_EMAIL and FB_PASSWORD.');
+    await meta.signIn(session, { email, password });
+  }
+
+  const app = need(options.clientId, '--client (the Meta app id)');
+  switch (action) {
+    case 'status':
+      return await meta.status(session, app);
+    case 'add-redirect-uri':
+      return { added: await meta.addRedirectUri(session, app, need(options.redirectUri, '--uri')) };
+    default:
+      throw new Error(`Unknown action "${action}" for meta-app.`);
   }
 }
 


### PR DESCRIPTION
Adds `meta-app` to the browser recipes, alongside the PyPI and RubyGems publishers from #1009.

## Why Meta earns a browser recipe

Meta *does* have an app-settings API. It answers `(#10) Changing app settings through API calls has been disabled for this app` until someone ticks **Allow API Access to App Settings** under the app's Advanced settings, and that tick is console-only. Verified live against a real app token.

## What was learned signing in

- The stored Facebook password still works and the session clears Meta's **Arkose MatchKey** check unaided.
- The login form's submit-button selectors miss; press Enter in the password field.
- Buttons on the 2FA pages are `div[role="button"]`, not `<button>`.
- The default second factor is **WhatsApp**. `Try another way` offers **email**, which lands somewhere an agent with mailbox access can read, so the sign-in runs unattended with no phone. `preferEmail` is on by default.

## The part that matters

`canAdminister()` is checked before any edit. Meta answers an account that does not own the app by **redirecting every `/apps/<id>/…` URL to the developer home page**, so a recipe that assumes it landed edits nothing and reports success. This one throws with the URL it was bounced to.

That is not hypothetical: it is exactly what happened here. The account signed in is not a developer at all, so `status` correctly returns `administers: false` rather than a false positive. `add-redirect-uri` is written and typechecked but has **not** been exercised against an app this account owns.

## Verified

- `tsc --noEmit` clean; 42 tests pass across the package and the adapter registry.
- `sh1pt browser list` shows all four recipes; `meta-app status --client 994377213462196` returns `administers: false` live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYMJH7N4d2qRct5Q5q2YWQ