### PR TITLE
meta: test the sign-in positively, and say where a run is stuck

### DIFF
--- a/packages/automation/browser/src/recipes/meta-app.ts
+++ b/packages/automation/browser/src/recipes/meta-app.ts
@@ -34,12 +34,22 @@ const bodyLines = async (session: Session): Promise<string[]> =>
     .map((line: string) => line.trim())
     .filter(Boolean);
 
-/** True when the profile already carries a signed-in Facebook session. */
+/**
+ * True when the profile already carries a signed-in Facebook session.
+ *
+ * Test for the positive. A signed-out browser asking for `/me` is bounced to
+ * `facebook.com/` — a URL with no "login" in it — so "not on a login page"
+ * reports a fresh profile as signed in, the sign-in is skipped, and every
+ * later step quietly runs as nobody. Require landing on a profile path with
+ * no login form on it.
+ */
 export async function isSignedIn(session: Session): Promise<boolean> {
   const { page } = session;
   await page.goto('https://www.facebook.com/me', { waitUntil: 'domcontentloaded' });
   await page.waitForLoadState('networkidle').catch(() => undefined);
-  return !/login|checkpoint|two_step/.test(page.url());
+  if (/login|checkpoint|two_step|recover/.test(page.url())) return false;
+  if (await page.locator('#email, input[name="email"]').first().isVisible().catch(() => false)) return false;
+  return /^https:\/\/(www\.)?facebook\.com\/[^/?#]+/.test(page.url());
 }
 
 export async function signIn(session: Session, options: MetaSignInOptions): Promise<void> {
@@ -63,6 +73,7 @@ export async function signIn(session: Session, options: MetaSignInOptions): Prom
   for (let i = 0; i < 10; i += 1) {
     await page.waitForLoadState('networkidle').catch(() => undefined);
     await page.waitForTimeout(4000);
+    if (process.env.SH1PT_BROWSER_DEBUG) process.stderr.write(`[meta] check ${i}: ${page.url().slice(0, 90)}\n`);
     if (/codesubmit|two_step|checkpoint/.test(page.url())) break;
   }
 
@@ -84,6 +95,11 @@ export async function signIn(session: Session, options: MetaSignInOptions): Prom
   while (Date.now() < deadline) {
     await page.waitForLoadState('networkidle').catch(() => undefined);
     const url = page.url();
+    // Without this a stuck run is completely silent for the whole timeout,
+    // and every wall Meta puts up looks identical from the outside.
+    if (process.env.SH1PT_BROWSER_DEBUG) {
+      process.stderr.write(`[meta] ${url.slice(0, 100)}\n[meta]   ${(await bodyLines(session)).slice(0, 6).join(' | ').slice(0, 220)}\n`);
+    }
     if (/facebook\.com\/?$/.test(url) && !/login|checkpoint|codesubmit|two_step/.test(url)) return;
 
     const codeBox = page


### PR DESCRIPTION
Two faults in the `meta-app` recipe from #1010, both found by driving a real account and both invisible without the second fix.

**`isSignedIn` false-positived.** It asked for `/me` and returned "the URL does not say login". A signed-out browser is bounced to `facebook.com/`, which does not say login either, so a brand-new profile reported as signed in, `signIn` was skipped, and `canAdminister` then returned `false` for an app the account owns. A wrong answer that looks exactly like a real one. It now requires landing on a profile path with no login form present.

This is the same trap the Google recipe already documents in a comment, repeated in the new one.

**The sign-in loop was silent.** No progress output at all, so a stuck run stayed quiet for its whole 55-minute timeout and every wall Meta raises looked identical from outside. `SH1PT_BROWSER_DEBUG` now prints the URL and the top of the page each pass, matching `google-cloud-oauth`.

Verified: `tsc --noEmit` clean, 27 tests pass across the package.

Not verified: a completed sign-in as an app-owning account. The dev box was starved at the time (63 Chrome processes, ~2 GB free, from a parallel test run), and the run made no progress in ten minutes. The recipe is unchanged in behaviour once signed in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYMJH7N4d2qRct5Q5q2YWQ